### PR TITLE
Inline help feature

### DIFF
--- a/src/MyEditor.jsx
+++ b/src/MyEditor.jsx
@@ -1,6 +1,6 @@
 // Import React!
 import React from 'react'
-import { Editor, Block, Inline, Raw, Text, Html } from 'slate'
+import { Editor, Block, Inline, Transform , Raw, Text, Html } from 'slate'
 import AutoReplace from 'slate-auto-replace'
 import { List } from 'immutable'
 
@@ -8,52 +8,48 @@ import { List } from 'immutable'
 import './MyEditor.css';
 
 
-const initialState = Raw.deserialize({
-  nodes: [
-    {
-      kind: 'block',
-      type: 'paragraph',
-      nodes: [
-        {
-          kind: 'text',
-          text: 'A line of text in a paragraph.'
-        }
-      ]
-    }
-  ]
-}, { terse: true })
-
-// Custom staging styling block
-function StageNode(props) {
-  return <div id="staging" {...props.attributes}><p>{props.children}</p></div>
+function textFromStringAndKey(str, key) { 
+  return Text.create({
+    key: key,
+    characters: charListFromString(str)
+  });
 }
-
-const stagingText = Text.createFromString('Staging information ');
-const tText = Text.createFromString('T:_');
+function charListFromString(str) { 
+  let arr = [];
+  for (const c of str) {
+    arr.push({
+      marks: List([]),
+      text: c
+    });
+  }
+  return List(arr);
+}
+const stagingText = Text.createFromString('Staging ');
+const tText = Text.createFromString('T:_ ');
 const tBlock = Inline.create({
   isVoid: false,  
   key: 'T-staging',
-  type: 'div',
+  type: 'span',
   nodes: List([tText])
 });
-const nText = Text.createFromString('N:_')
+const nText = Text.createFromString('N:_ ')
 const nBlock = Inline.create({
   isVoid: false,  
   key: 'N-staging',
-  type: 'div',
+  type: 'span',
   nodes: List([nText])
 });
-const mText = Text.createFromString('M:_')
+const mText = Text.createFromString('M:_ ')
 const mBlock = Inline.create({
   isVoid: false,  
   key: 'M-staging',
-  type: 'div',
+  type: 'span',
   nodes: List([mText])
 });
-const bl = Block.create({
+const bl = Inline.create({
   key:"staging",
   isVoid: false,
-  type: "paragraph",
+  type: "span",
   nodes:  List([stagingText, tBlock, nBlock, mBlock])
 });
 
@@ -63,14 +59,17 @@ const plugins = [
     trigger: 'space',
     before: /(\.staging)/,
     transform: (transform, e, data, matches) => {
-      const newTrans = transform.insertBlock(bl).extendToStartOf(tBlock);
+      const newTrans = transform.insertInline(bl).moveToRangeOf(tBlock).moveStart(2).moveEnd(-1);
       return newTrans;
     }
   })
 ]
 
+
 const BLOCK_TAGS = {
   p: 'paragraph',
+  span: 'span',
+  div: 'div',
   li: 'list-item',
   ul: 'bulleted-list',
   ol: 'numbered-list',
@@ -87,31 +86,54 @@ const MARK_TAGS = {
   code: 'code'
 }
 
-// const RULES = [
-//   {
-//     deserialize(el, next) {
-//       const block = BLOCK_TAGS[el.tagName]
-//       if (!block) return
-//       return {
-//         kind: 'block',
-//         type: block,
-//         nodes: next(el.children)
-//       }
-//     }
-//   },
-//   {
-//     deserialize(el, next) {
-//       const mark = MARK_TAGS[el.tagName]
-//       if (!mark) return
-//       return {
-//         kind: 'mark',
-//         type: mark,
-//         nodes: next(el.children)
-//       }
-//     }
-//   }
-// ]
-// const serializer = new Html({ rules: RULES })
+const RULES = [
+  {
+    deserialize(el, next) {
+      const block = BLOCK_TAGS[el.tagName]
+      if (!block) return
+      return {
+        kind: 'block',
+        type: block,
+        nodes: next(el.children)
+      }
+    }, 
+    serialize(el, next) { 
+
+    }
+  },
+  {
+    deserialize(el, next) {
+      const mark = MARK_TAGS[el.tagName]
+      if (!mark) return
+      return {
+        kind: 'mark',
+        type: mark,
+        nodes: next(el.children)
+      }
+    }
+  }
+]
+const serializer = new Html({ rules: RULES });
+
+
+const initialState = Raw.deserialize({
+  nodes: [
+    {
+      kind: 'block',
+      type: 'paragraph',
+      nodes: [
+        {
+          kind: 'text',
+          text: 'A line of text in a paragraph.'
+        }
+      ]
+    }
+  ]
+}, { terse: true })
+function e(event, data, state) { 
+  // const newTrans = state.transform().moveToRangeOf(nBlock).moveStart(2).moveEnd(-1);
+  // console.log(newTrans)
+}
 
 // Define our app...
 class MyEditor extends React.Component {
@@ -121,62 +143,78 @@ class MyEditor extends React.Component {
     state: initialState,
     schema: {
       nodes: {
-        'paragraph': props => <p {...props.attributes}>{props.children}</p>,
-        'list-item': props => <li {...props.attributes}> {props.children} </li>,
-        'bulleted-list': props => <ul {...props.attributes}> {props.children} </ul>,
-        'numbered-list': props => <ol {...props.attributes}> {props.children} </ol>,
-        'block-quote': props => <blockquote {...props.attributes}> {props.children} </blockquote>,
-        'heading-one': props => <h1 {...props.attributes}> {props.children} </h1>,
-        'heading-two': props => <h2 {...props.attributes}> {props.children} </h2>,
-        'stage': StageNode
+        'paragraph':     props => <p {...props.attributes}>{props.children}</p>,
+        'span':          props => <span {...props.attributes}>{props.children}</span>,
+        'div':           props => <div {...props.attributes}>{props.children}</div>,
+        'list-item':     props => <li {...props.attributes}>{props.children}</li>,
+        'bulleted-list': props => <ul {...props.attributes}>{props.children}</ul>,
+        'numbered-list': props => <ol {...props.attributes}>{props.children}</ol>,
+        'block-quote':   props => <blockquote {...props.attributes}>{props.children}</blockquote>,
+        'heading-one':   props => <h1 {...props.attributes}>{props.children}</h1>,
+        'heading-two':   props => <h2 {...props.attributes}>{props.children}</h2>,
       },
       marks: { 
-        'bold': props => <strong>{props.children}</strong>,
-        'italic': props => <em>{props.children}</em>,
-        'underline': props => <u>{props.children}</u>,
+        'bold':          props => <strong>{props.children}</strong>,
+        'italic':        props => <em>{props.children}</em>,
+        'underline':     props => <u>{props.children}</u>,
         'strikethrough': props => <del>{props.children}</del>,
-        'code': props => <code>{props.children}</code>,
+        'code':          props => <code>{props.children}</code>,
       }
     }
   }
 
   // On change, update the app's React state with the new editor state.
   onChange = (state) => {
+    // console.log('in change')
+    // console.log(state.document.nodes)
+    // console.log(Raw.serialize(state))    
+    // if (state.document.nodes.find(function(val, k, iter) { console.log(val); console.log(k); return val===bl; })) {
+    //   console.log('abile to find');
+    // }
+    // state = state.transform().moveToRangeOf(nBlock).moveStart(2).moveEnd(-1).apply()
+    console.log(state)
     this.setState({ state })
   }
 
   onKeyDown = (event, data, state) => {
-    if (!event.ctrlKey) return
-
-    // Return with no changes if it's not the "," key with cmd/ctrl pressed.
-    switch (event.which) {
-      // When "B" is pressed, add a "bold" mark to the text.
-      case 66: {
-        event.preventDefault()
-        return state
-          .transform()
-          .toggleMark('bold')
-          .apply()
+    if (!event.ctrlKey) {
+      switch (event.which) {
+        case 48: {
+          return e(event, data, state);
+        }  
+        case 49: {
+          return e(event, data, state);
+        } 
+        case 50: {
+          return e(event, data, state);
+        } 
+        case 51: {
+          return e(event, data, state);
+        } 
+        case 52: {
+          return e(event, data, state);
+        } 
+        case 53: {
+          return e(event, data, state);
+        } 
+        case 54: {
+          return e(event, data, state);
+        } 
+        case 55: {
+          return e(event, data, state);
+        } 
+        case 56: {
+          return e(event, data, state);
+        } 
+        case 57: {
+          return e(event, data, state);
+        } 
+        default: {  
+          break;
+        }
       }
-      case 65: {  
-        // event.preventDefault()
-        // const alternativeState =  serializer.deserialize(`<p>The Slate editor gives you <em>complete</em> control over the logic you can add.</p>
-        // <p>In its simplest form, when representing plain text, Slate is a glorified <code>&laquo;textarea&raquo;</code>. But you can augment it to be much more than that.</p>
-        // <p>Check out <a href="http://slatejs.org">http://slatejs.org</a> for examples!</p>`);
-
-        // // Otherwise, set the currently selected blocks type to "code".
-        // return alternativeState
-        //   .transform()
-        //   .insertTextByKey('3', 2,'there is something here')
-        //   .apply();
-        break;
-      }
-      default: { 
-
-      }
-    }
+    } 
   }
-
   // Render the editor.
   render = () => {
     return (
@@ -191,7 +229,6 @@ class MyEditor extends React.Component {
       </div>
     )
   }
-
 }
 
 export default MyEditor;

--- a/src/MyEditor.jsx
+++ b/src/MyEditor.jsx
@@ -36,7 +36,7 @@ const initialState = Raw.deserialize({
       nodes: [
         {
           kind: 'text',
-          text: 'This is wher clinical notes go...'
+          text: 'Begin typing your clinical notes below.'
         }
       ]
     }, 
@@ -46,7 +46,7 @@ const initialState = Raw.deserialize({
       nodes: [
         {
           kind: 'text',
-          text: '.staging'
+          text: 'Add a space at the end of this line to trigger a inline template: .staging'
         }
       ]
     }

--- a/src/MyEditor.jsx
+++ b/src/MyEditor.jsx
@@ -267,7 +267,30 @@ class MyEditor extends React.Component {
               .moveEnd(-1)
               .apply();
           } else if (stagingKeys.includes(String.fromCharCode(event.keyCode))) {
-            console.log('this is a character that we care about') 
+            event.preventDefault();
+            switch(String.fromCharCode(event.keyCode)) { 
+              case "T": 
+                return state
+                 .transform()
+                 .moveToRangeOf(tNode)
+                 .moveStart(1)
+                 .moveEnd(-1)
+                 .apply();
+              case "N":
+                return state
+                  .transform()
+                  .moveToRangeOf(nNode)
+                  .moveStart(1)
+                  .moveEnd(-1)
+                  .apply();
+              case "M":
+                return state
+                  .transform()
+                  .moveToRangeOf(mNode)
+                  .moveStart(1)
+                  .moveEnd(-1)
+                  .apply();
+            } 
           }
         } else if (nKeys.includes(state.selection.startKey)) { 
           if(event.keyCode >= 48 && event.keyCode <=57) {
@@ -284,7 +307,30 @@ class MyEditor extends React.Component {
               .moveEnd(-1)
               .apply();
           } else if (stagingKeys.includes(String.fromCharCode(event.keyCode))) {
-            console.log('this is a character that we care about') 
+            event.preventDefault();
+            switch(String.fromCharCode(event.keyCode)) { 
+              case "T": 
+                return state
+                 .transform()
+                 .moveToRangeOf(tNode)
+                 .moveStart(1)
+                 .moveEnd(-1)
+                 .apply();
+              case "N":
+                return state
+                  .transform()
+                  .moveToRangeOf(nNode)
+                  .moveStart(1)
+                  .moveEnd(-1)
+                  .apply();
+              case "M":
+                return state
+                  .transform()
+                  .moveToRangeOf(mNode)
+                  .moveStart(1)
+                  .moveEnd(-1)
+                  .apply();
+            } 
           }
         } else if (mKeys.includes(state.selection.startKey))  { 
           if(event.keyCode >= 48 && event.keyCode <=57) {
@@ -299,7 +345,30 @@ class MyEditor extends React.Component {
               .collapseToEndOf(mNode)
               .apply();
           } else if (stagingKeys.includes(String.fromCharCode(event.keyCode))) {
-            console.log('this is a character that we care about') 
+            event.preventDefault();
+            switch(String.fromCharCode(event.keyCode)) { 
+              case "T": 
+                return state
+                 .transform()
+                 .moveToRangeOf(tNode)
+                 .moveStart(1)
+                 .moveEnd(-1)
+                 .apply();
+              case "N":
+                return state
+                  .transform()
+                  .moveToRangeOf(nNode)
+                  .moveStart(1)
+                  .moveEnd(-1)
+                  .apply();
+              case "M":
+                return state
+                  .transform()
+                  .moveToRangeOf(mNode)
+                  .moveStart(1)
+                  .moveEnd(-1)
+                  .apply();
+            } 
           }
         } 
       } 

--- a/src/MyEditor.jsx
+++ b/src/MyEditor.jsx
@@ -2,7 +2,7 @@
 import React from 'react'
 import { Editor, Block, Inline, Transform , Raw, Text, Html } from 'slate'
 import AutoReplace from 'slate-auto-replace'
-import { List } from 'immutable'
+import { List , Map } from 'immutable'
 
 // Styling
 import './MyEditor.css';
@@ -24,34 +24,77 @@ function charListFromString(str) {
   }
   return List(arr);
 }
-const stagingText = Text.createFromString('Staging ');
-const tText = Text.createFromString('T:_ ');
-const tBlock = Inline.create({
-  isVoid: false,  
-  key: 'T-staging',
-  type: 'span',
-  nodes: List([tText])
-});
-const nText = Text.createFromString('N:_ ')
-const nBlock = Inline.create({
-  isVoid: false,  
-  key: 'N-staging',
-  type: 'span',
-  nodes: List([nText])
-});
-const mText = Text.createFromString('M:_ ')
-const mBlock = Inline.create({
-  isVoid: false,  
-  key: 'M-staging',
-  type: 'span',
-  nodes: List([mText])
-});
-const bl = Inline.create({
-  key:"staging",
-  isVoid: false,
-  type: "span",
-  nodes:  List([stagingText, tBlock, nBlock, mBlock])
-});
+const test = Raw.deserialize({
+  "nodes": [
+    {
+      "kind": "block",
+      "type": "paragraph",
+      "isVoid": false,
+      "nodes": [
+        {
+          "kind": "text",
+          "ranges": [
+            {
+              "text": "Staging "
+            }
+          ]
+        },
+        {
+          "kind": "inline",
+          "type": "structured-span",
+          "data": {
+            "id": "t-staging",
+          },
+          "nodes": [
+            {
+              "kind": "text",
+              "ranges": [
+                {
+                  "text": "T_ "
+                }
+              ]
+            }
+          ]
+        }, 
+        {
+          "kind": "inline",
+          "type": "structured-span",
+          "data": {
+            "id": "n-staging",
+          },
+          "nodes": [
+            {
+              "kind": "text",
+              "ranges": [
+                {
+                  "text": "N_ "
+                }
+              ]
+            }
+          ]
+        }, 
+        {
+          "kind": "inline",
+          "type": "structured-span",
+          "data": {
+            "id": "m-staging",
+          },
+          "nodes": [
+            {
+              "kind": "text",
+              "ranges": [
+                {
+                  "text": "M_ "
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}, { terse: true });
+
 
 // Add the plugin to your set of plugins...
 const plugins = [
@@ -59,63 +102,32 @@ const plugins = [
     trigger: 'space',
     before: /(\.staging)/,
     transform: (transform, e, data, matches) => {
-      const newTrans = transform.insertInline(bl).moveToRangeOf(tBlock).moveStart(2).moveEnd(-1);
+      const stagingBlock = test.document.nodes.get(0);
+      const newTrans = transform.insertBlock(stagingBlock);
       return newTrans;
     }
   })
 ]
 
+// const BLOCK_TAGS = {
+//   p: 'paragraph',
+//   span: 'span',
+//   div: 'div',
+//   li: 'list-item',
+//   ul: 'bulleted-list',
+//   ol: 'numbered-list',
+//   blockquote: 'quote',
+//   h1: 'heading-one',
+//   h2: 'heading-two',
+// }
 
-const BLOCK_TAGS = {
-  p: 'paragraph',
-  span: 'span',
-  div: 'div',
-  li: 'list-item',
-  ul: 'bulleted-list',
-  ol: 'numbered-list',
-  blockquote: 'quote',
-  h1: 'heading-one',
-  h2: 'heading-two',
-}
-
-const MARK_TAGS = {
-  strong: 'bold',
-  em: 'italic',
-  u: 'underline',
-  s: 'strikethrough',
-  code: 'code'
-}
-
-const RULES = [
-  {
-    deserialize(el, next) {
-      const block = BLOCK_TAGS[el.tagName]
-      if (!block) return
-      return {
-        kind: 'block',
-        type: block,
-        nodes: next(el.children)
-      }
-    }, 
-    serialize(el, next) { 
-
-    }
-  },
-  {
-    deserialize(el, next) {
-      const mark = MARK_TAGS[el.tagName]
-      if (!mark) return
-      return {
-        kind: 'mark',
-        type: mark,
-        nodes: next(el.children)
-      }
-    }
-  }
-]
-const serializer = new Html({ rules: RULES });
-
-
+// const MARK_TAGS = {
+//   strong: 'bold',
+//   em: 'italic',
+//   u: 'underline',
+//   s: 'strikethrough',
+//   code: 'code'
+// }
 const initialState = Raw.deserialize({
   nodes: [
     {
@@ -124,15 +136,37 @@ const initialState = Raw.deserialize({
       nodes: [
         {
           kind: 'text',
-          text: 'A line of text in a paragraph.'
+          text: '.staging'
         }
       ]
     }
   ]
 }, { terse: true })
-function e(event, data, state) { 
-  // const newTrans = state.transform().moveToRangeOf(nBlock).moveStart(2).moveEnd(-1);
-  // console.log(newTrans)
+
+
+function getNodeById(nodes, id) { 
+  return nodes.find(function(v, k, iter) {
+    if (v.data) {
+      return v.data.get('id') === id;
+    } else { 
+      return false;
+    }
+  });
+}
+
+function getKeysForNode(curNode, keys) { 
+  console.log(curNode);
+  if(curNode.key) { 
+    console.log(`new key: ${curNode.key}`)
+    keys.push(curNode.key)
+  }
+  if (curNode.nodes) { 
+    for(const child of curNode.nodes) { 
+      console.log(`Checking child node: ${child}`);
+      keys = getKeysForNode(child, keys);
+    }
+  }
+  return keys;
 }
 
 // Define our app...
@@ -144,14 +178,16 @@ class MyEditor extends React.Component {
     schema: {
       nodes: {
         'paragraph':     props => <p {...props.attributes}>{props.children}</p>,
-        'span':          props => <span {...props.attributes}>{props.children}</span>,
+        'structured-span':          (props) => {
+          const id = (props.node) ? props.node.data.get('id') : '';
+          return <span id={id} {...props.attributes}>{props.children}</span>;
+        },
+        'span':           props => <span {...props.attributes}>{props.children}</span>,
         'div':           props => <div {...props.attributes}>{props.children}</div>,
         'list-item':     props => <li {...props.attributes}>{props.children}</li>,
         'bulleted-list': props => <ul {...props.attributes}>{props.children}</ul>,
         'numbered-list': props => <ol {...props.attributes}>{props.children}</ol>,
-        'block-quote':   props => <blockquote {...props.attributes}>{props.children}</blockquote>,
-        'heading-one':   props => <h1 {...props.attributes}>{props.children}</h1>,
-        'heading-two':   props => <h2 {...props.attributes}>{props.children}</h2>,
+        'block-quote':   props => <blockquote {...props.attributes}>{props.children}</blockquote>
       },
       marks: { 
         'bold':          props => <strong>{props.children}</strong>,
@@ -172,48 +208,41 @@ class MyEditor extends React.Component {
     //   console.log('abile to find');
     // }
     // state = state.transform().moveToRangeOf(nBlock).moveStart(2).moveEnd(-1).apply()
-    console.log(state)
+    // console.log(state)
+    // console.log(state.selection)
+    // console.log(state.selection.startKey)
+    // console.log(state.selection.startOffset)
+
+    // const docBlock = state.document.nodes.get(1);
+    // if(tNode) { 
+    //   console.log('in this transform')
+    // const nNode = getNodeById(docBlock.nodes, 'n-staging');
+    // const mNode = getNodeById(docBlock.nodes, 'm-staging');
+
+    //   state = state.transform().moveToRangeOf(tNode).moveStart(1).moveEnd(-1).apply();
+    // }
+
     this.setState({ state })
   }
 
   onKeyDown = (event, data, state) => {
-    if (!event.ctrlKey) {
-      switch (event.which) {
-        case 48: {
-          return e(event, data, state);
-        }  
-        case 49: {
-          return e(event, data, state);
-        } 
-        case 50: {
-          return e(event, data, state);
-        } 
-        case 51: {
-          return e(event, data, state);
-        } 
-        case 52: {
-          return e(event, data, state);
-        } 
-        case 53: {
-          return e(event, data, state);
-        } 
-        case 54: {
-          return e(event, data, state);
-        } 
-        case 55: {
-          return e(event, data, state);
-        } 
-        case 56: {
-          return e(event, data, state);
-        } 
-        case 57: {
-          return e(event, data, state);
-        } 
-        default: {  
-          break;
+    console.log('\n\nlooping...')
+    for(const parentNode of state.document.nodes) { 
+      const tNode = getNodeById(parentNode.nodes, 't-staging');
+      const nNode = getNodeById(parentNode.nodes, 'n-staging');
+      const mNode = getNodeById(parentNode.nodes, 'm-staging');
+
+      if(tNode) { 
+        const tKeys = getKeysForNode(tNode, []);
+        console.log(tKeys)
+        // console.log(tNode.key)
+        // console.log(state.selection.startKey)
+        if (state.selection.startKey in tKeys) { 
+          console.log('success')
         }
       }
-    } 
+    }
+    
   }
   // Render the editor.
   render = () => {

--- a/src/structuredDataRaw.js
+++ b/src/structuredDataRaw.js
@@ -1,0 +1,74 @@
+const structuredDataRaw = { 
+  "staging": {
+    "nodes": [
+      {
+        "kind": "block",
+        "type": "span",
+        "isVoid": false,
+        "nodes": [
+          {
+            "kind": "text",
+            "ranges": [
+              {
+                "text": "Staging "
+              }
+            ]
+          },
+          {
+            "kind": "inline",
+            "type": "structured-span",
+            "data": {
+              "id": "t-staging",
+            },
+            "nodes": [
+              {
+                "kind": "text",
+                "ranges": [
+                  {
+                    "text": "T_ "
+                  }
+                ]
+              }
+            ]
+          }, 
+          {
+            "kind": "inline",
+            "type": "structured-span",
+            "data": {
+              "id": "n-staging",
+            },
+            "nodes": [
+              {
+                "kind": "text",
+                "ranges": [
+                  {
+                    "text": "N_ "
+                  }
+                ]
+              }
+            ]
+          }, 
+          {
+            "kind": "inline",
+            "type": "structured-span",
+            "data": {
+              "id": "m-staging",
+            },
+            "nodes": [
+              {
+                "kind": "text",
+                "ranges": [
+                  {
+                    "text": "M_ "
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}
+
+export default structuredDataRaw;


### PR DESCRIPTION
From task 69 on our board: Allow user to enter shorthand notation resulting in in-line help for sub-field specification to represent structured data concepts defined in SHR.

If user types a number when in one of the appropriate fields: fill in the current field, and move to the next one in sequence.

If user types in 't', 'n', or 'm' when in one of the appropriate fields: switch over to the letter's corresponding  field. 
