### PR TITLE
Moved stage calculation into App; split stage update from TMN updates into sep. function

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -34,6 +34,7 @@ class App extends Component {
         this.handleStagingTUpdate = this.handleStagingTUpdate.bind(this);
         this.handleStagingNUpdate = this.handleStagingNUpdate.bind(this);
         this.handleStagingMUpdate = this.handleStagingMUpdate.bind(this);
+        this.handleStageUpdate = this.handleStageUpdate.bind(this);
         this.handleSummaryUpdate = this.handleSummaryUpdate.bind(this);
         this.handleStructuredFieldEntered = this.handleStructuredFieldEntered.bind(this);
         this.handleStructuredFieldExited = this.handleStructuredFieldExited.bind(this);
@@ -110,6 +111,43 @@ class App extends Component {
         })
 	}
 
+    calculateStage(t, n, m) { 
+        let stage;
+        // Metastisized cancer is always Stage IV
+        if (m === 1) {
+            stage = 'IV';
+        } else { 
+            // Lookup the rest based on T and N:
+            const lookup = [
+              ['0', 'IIA', 'IIIA', 'IIIC'], // T0
+              ['IA', 'IIA', 'IIIA', 'IIIC'], // T1
+              ['IIA', 'IIB', 'IIIA', 'IIIC'], // T2
+              ['IIB', 'IIIA', 'IIIA', 'IIIC'], // T3
+              ['IIIB', 'IIIB', 'IIIB', 'IIIC'] // T4
+            ];
+
+            // With N1M1 Values
+            // const lookup = [
+            //   ['0', 'IB', 'IIA', 'IIIA', 'IIIC'], // T0
+            //   ['IA', 'IB', 'IIA', 'IIIA', 'IIIC'], // T1
+            //   ['IIA', 'IIB', 'IIB', 'IIIA', 'IIIC'], // T2
+            //   ['IIB', 'IIIA', 'IIIA', 'IIIA', 'IIIC'], // T3
+            //   ['IIIB', 'IIIB', 'IIIB', 'IIIB', 'IIIC'] // T4
+            // ];
+
+            stage = lookup[t][n];
+        }
+        return stage;
+    }
+
+    handleStageUpdate(stage) {
+        console.log("App.handleStageUpdate. stage=" + stage);
+        (stage !== "") && this.setState({
+            hasStagingData: true,
+            prognosticState: stage,
+        })
+    }
+
     render() {
         return (
             <MuiThemeProvider muiTheme={getMuiTheme(lightBaseTheme)}>
@@ -123,13 +161,14 @@ class App extends Component {
                             <Col sm={3}>
                                 <DataSummary
                                     className="dashboard-panel"
-                                    
+                                    // Update functions
                                     onHER2StatusChange={this.changeHER2Status}
                                     onERStatusChange={this.changeERStatus}
                                     onPRStatusChange={this.changePRStatus}
                                     onSummaryItemSelected={this.handleSummaryUpdate}
+                                    // Helper functions
                                     hasStagingData={this.state.hasStagingData}
-
+                                    // Properties
                                     stage={this.state.prognosticState}
                                     tumorSize={this.state.tumorSize}
                                     nodeSize={this.state.nodeSize}
@@ -142,16 +181,19 @@ class App extends Component {
                             <Col sm={5}>
                                 <ClinicalNotes
                                     className="dashboard-panel"
-
+                                    // Update functions
                                     onStagingTUpdate={this.handleStagingTUpdate}
                                     onStagingNUpdate={this.handleStagingNUpdate}
                                     onStagingMUpdate={this.handleStagingMUpdate}
+                                    onStageUpdate={this.handleStageUpdate}
                                     onHER2StatusChange={this.changeHER2Status}
                                     onERStatusChange={this.changeERStatus}
                                     onPRStatusChange={this.changePRStatus}
                                     onStructuredFieldEntered={this.handleStructuredFieldEntered}
                                     onStructuredFieldExited={this.handleStructuredFieldExited}
-
+                                    // Helper functions
+                                    calculateStage={this.calculateStage}
+                                    // Properties
                                     stage={this.state.prognosticState}
                                     tumorSize={this.state.tumorSize}
                                     nodeSize={this.state.nodeSize}
@@ -164,16 +206,20 @@ class App extends Component {
                             </Col>
                             <Col sm={3}>
                                 <RightPanel
-                                    className="dashboard-panel"
-
+                                    className="dashboard-panel" 
+                                    // Update functions
+                                    onStagingTUpdate={this.handleStagingTUpdate}
+                                    onStagingNUpdate={this.handleStagingNUpdate}
+                                    onStagingMUpdate={this.handleStagingMUpdate}
+                                    onStageUpdate={this.handleStageUpdate}
+                                    // Helper functions
+                                    calculateStage={this.calculateStage}
+                                    // Properties
                                     stage={this.state.prognosticState}
                                     tumorSize={this.state.tumorSize}
                                     nodeSize={this.state.nodeSize}
                                     metastasis={this.state.metastasis}
                                     withinStructuredField={this.state.withinStructuredField}
-                                    onStagingTUpdate={this.handleStagingTUpdate}
-                                    onStagingNUpdate={this.handleStagingNUpdate}
-                                    onStagingMUpdate={this.handleStagingMUpdate}
                                 />
                             </Col>
                         </Row>

--- a/src/ClinicalNotes.jsx
+++ b/src/ClinicalNotes.jsx
@@ -15,49 +15,44 @@ import './ClinicalNotes.css';
 
 class ClinicalNotes extends Component {
 
-  constructor(props) {
-    super(props);
+  // constructor(props) {
+  //   super(props);
+  // }
 
-    this.handleHER2StatusChange = this.handleHER2StatusChange.bind(this);
-    this.handleERStatusChange = this.handleERStatusChange.bind(this);
-    this.handlePRStatusChange = this.handlePRStatusChange.bind(this);
-    this.handleStructuredFieldEntered = this.handleStructuredFieldEntered.bind(this);
-    this.handleStructuredFieldExited = this.handleStructuredFieldExited.bind(this);
-    this.handleStagingTUpdate = this.handleStagingTUpdate.bind(this);
-    this.handleStagingNUpdate = this.handleStagingNUpdate.bind(this);
-    this.handleStagingMUpdate = this.handleStagingMUpdate.bind(this);
-  }
-
-  handleHER2StatusChange (newStatus) {
+  handleHER2StatusChange = (newStatus) => {
     this.props.onHER2StatusChange(newStatus);
   }
 
-  handleERStatusChange (newStatus) {
+  handleERStatusChange = (newStatus) => {
     this.props.onERStatusChange(newStatus);
   }
 
-  handlePRStatusChange (newStatus) {
+  handlePRStatusChange = (newStatus) => {
     this.props.onPRStatusChange(newStatus);
   }
 
-  handleStagingTUpdate (newVal) {
-    this.props.onStagingTUpdate(newVal, this.props.stage);
+  handleStagingTUpdate = (newVal) => {
+    this.props.onStagingTUpdate(newVal);
   }
 
-  handleStagingNUpdate (newVal) {
-    this.props.onStagingNUpdate(newVal, this.props.stage);
+  handleStagingNUpdate = (newVal) => {
+    this.props.onStagingNUpdate(newVal);
   }
 
-  handleStagingMUpdate (newVal) {
-    this.props.onStagingMUpdate(newVal, this.props.stage);
+  handleStagingMUpdate = (newVal) => {
+    this.props.onStagingMUpdate(newVal);
   }
 
-  handleStructuredFieldEntered (currentFocus) { 
-    this.props.onStructuredFieldEntered("staging");
+  handleStageUpdate = (newVal) => { 
+    this.props.onStageUpdate(newVal)
   }
 
-  handleStructuredFieldExited (currentFocus) { 
-    this.props.onStructuredFieldExited("staging");
+  handleStructuredFieldEntered = (currentFocus) => { 
+    this.props.onStructuredFieldEntered(currentFocus);
+  }
+
+  handleStructuredFieldExited = (currentFocus) => { 
+    this.props.onStructuredFieldExited(currentFocus);
   }
 
   render() {
@@ -97,17 +92,19 @@ class ClinicalNotes extends Component {
           </Row>
 
           <MyEditor 
-            tumorSize={this.props.tumorSize}
-            nodeSize={this.props.nodeSize}
-            metastasis={this.props.metastasis}
-
+            // Update functions
             onStructuredFieldEntered={this.handleStructuredFieldEntered}
             onStructuredFieldExited={this.handleStructuredFieldExited}
-
             onStagingTUpdate={this.handleStagingTUpdate}
             onStagingNUpdate={this.handleStagingNUpdate}
             onStagingMUpdate={this.handleStagingMUpdate}
-
+            onStageUpdate={this.handleStageUpdate}
+            // Helper functions
+            calculateStage={this.props.calculateStage}
+            // Properties
+            tumorSize={this.props.tumorSize}
+            nodeSize={this.props.nodeSize}
+            metastasis={this.props.metastasis}
             data={{patient: {name: 'Debra Hernandez672', age: '51', gender: 'female'}}} />
           <div>
             {message}

--- a/src/DataSummary.jsx
+++ b/src/DataSummary.jsx
@@ -56,11 +56,6 @@ class DataSummary extends Component {
     }
 
     render() {
-
-        // Current Staging
-
-        const Stage = `${this.props.stage}`;
-        const StageSubElements = `T${this.props.tumorSize} N${this.props.nodeSize} M${this.props.metastasis}`;
         // Check to see if example data is missing
         if (this.props.hasStagingData) {
             this.missingInfoString = '';
@@ -68,11 +63,23 @@ class DataSummary extends Component {
             this.missingInfoString = '*Missing Information';
         }
 
+        // Current Staging
+        const Stage = `${this.props.stage}`;
+        const StageSubElements = `T${this.props.tumorSize} N${this.props.nodeSize} M${this.props.metastasis}`;
+
+        const StageString = `Prognostic Stage: ${Stage}`;
+        const StageSubElementsString = `${StageSubElements}`;
+
         // Pathology Results
-        const HGA = 'HG2';
+        const HGA = `HG2`;
         const HER2Status = `${this.props.HER2Status}`;
         const ERStatus = `${this.props.ERStatus}`;
         const PRStatus = ` ${this.props.PRStatus}`;
+
+        const HGAString = `HGA: ${HGA}`;
+        const HER2StatusString = `HER2 Status: ${HER2Status}`;
+        const ERStatusString = `ER Status: ${ERStatus}`;
+        const PRStatusString = ` PR Status: ${PRStatus}`;
 
         // Event Dates
         const DiagnosisDate = '05/16/2012';
@@ -82,6 +89,14 @@ class DataSummary extends Component {
         const RadiationDate = '07/12/2012 - 08/16/2012';
         const TamoxifenDate = '09/01/2012 - 07/01/2014';
         const RecurrenceDate = '08/02/2015';
+
+        const DiagnosisDateString = `Diagnosis: ${DiagnosisDate}`;
+        const DiagnosisString = `${Diagnosis}`;
+        const SurgeryDateString = `Surgery: ${SurgeryDate}`;
+        const SurgeryString = `${Surgery}`;
+        const RadiationDateString = `RadiationDate: ${RadiationDate}`;
+        const TamoxifenDateString = `TamoxifenDate: ${TamoxifenDate}`;
+        const RecurrenceDateString = `RecurrenceDate: ${RecurrenceDate}`;
 
 
         return (
@@ -119,12 +134,21 @@ class DataSummary extends Component {
                     </Row>
                     <div id="summary-disease-heading">
                         <Row>
-                            <Col xs={10}> 
+                            <Col xs={9}> 
                                 <p className="summary-disease-heading-value">Lobular carcinoma of the breast</p>
                             </Col> 
-                            <Col xs={2}>
-                                <IconButton hoveredStyle={{"backgroundColor": "#EEEEEE"}} className="summary-disease-heading-button" iconClassName="fa fa-arrow-left"/>
-                                <IconButton disabled={true} hoveredStyle={{"backgroundColor": "#EEEEEE"}} className="summary-disease-heading-button" iconClassName="fa fa-arrow-right"/>
+                            <Col xs={3}>
+                                <IconButton 
+                                    hoveredStyle={{"backgroundColor": "#EEEEEE"}} 
+                                    className="summary-disease-heading-button" 
+                                    iconClassName="fa fa-arrow-left"
+                                />
+                                <IconButton 
+                                    disabled={true} 
+                                    hoveredStyle={{"backgroundColor": "#EEEEEE"}} 
+                                    className="summary-disease-heading-button" 
+                                    iconClassName="fa fa-arrow-right"
+                                />
                             </Col>
                         </Row>
 {/*                        <Row>
@@ -155,10 +179,10 @@ class DataSummary extends Component {
                                 <ul className="summary-section" id="summary-staging">
                                     <div className="summary-details">
                                         <li>
-                                            Prognostic Stage: <span onClick={(e) => this.handleItemSelected(e, Stage, StageSubElements)}>{Stage}</span>
+                                            <span onClick={(e) => this.handleItemSelected(e, StageString, StageSubElementsString)}>{StageString}</span>
                                         </li>
                                         <li className="sub-list">
-                                            <span onClick={(e) => this.handleItemSelected(e, Stage, StageSubElements)}>{StageSubElements}</span>
+                                            <span onClick={(e) => this.handleItemSelected(e, StageString, StageSubElementsString)}>{StageSubElementsString}</span>
                                         </li>
                                     </div>
                                     <span id="staging-missing-warning">{this.missingInfoString}</span>
@@ -168,16 +192,16 @@ class DataSummary extends Component {
                                 <h3>Pathology Results</h3>
                                 <ul className="summary-section" id="summary-pathology">
                                     <li>
-                                        HGA: <span onClick={(e) => this.handleItemSelected(e, HGA)}>{HGA}</span>
+                                        <span onClick={(e) => this.handleItemSelected(e, HGAString)}>{HGAString}</span>
                                     </li>
                                     <li>
-                                        HER2 Status: <span onClick={(e) => this.handleItemSelected(e, HER2Status)}>{HER2Status}</span>
+                                        <span onClick={(e) => this.handleItemSelected(e, HER2StatusString)}>{HER2StatusString}</span>
                                     </li>
                                     <li>
-                                        ER Status: <span onClick={(e) => this.handleItemSelected(e, ERStatus)}>{ERStatus}</span>
+                                        <span onClick={(e) => this.handleItemSelected(e, ERStatusString)}>{ERStatusString}</span>
                                     </li>
                                     <li>
-                                        PR Status: <span onClick={(e) => this.handleItemSelected(e, PRStatus)}>{PRStatus}</span>
+                                        <span onClick={(e) => this.handleItemSelected(e, PRStatusString)}>{PRStatusString}</span>
                                     </li>
                                 </ul>
                             </Col>
@@ -187,25 +211,25 @@ class DataSummary extends Component {
                                 <h3>Event Dates</h3>
                                 <ul className="summary-section" id="summary-dates">
                                     <li>
-                                        Diagnosis: <span onClick={(e) => this.handleItemSelected(e, DiagnosisDate, Diagnosis)}>{DiagnosisDate}</span>
+                                        <span onClick={(e) => this.handleItemSelected(e, DiagnosisDateString, DiagnosisString)}>{DiagnosisDateString}</span>
                                     </li>
                                         <li className="sub-list" >
-                                           <span onClick={(e) => this.handleItemSelected(e, DiagnosisDate, Diagnosis)}>{Diagnosis}</span>
+                                           <span onClick={(e) => this.handleItemSelected(e, DiagnosisDateString, DiagnosisString)}>{DiagnosisString}</span>
                                         </li>
                                     <li>
-                                       Surgery: <span onClick={(e) => this.handleItemSelected(e, SurgeryDate, Surgery)}>{SurgeryDate}</span>
+                                       <span onClick={(e) => this.handleItemSelected(e, SurgeryDateString, SurgeryString)}>{SurgeryDateString}</span>
                                     </li>
                                         <li className="sub-list" >
-                                           <span onClick={(e) => this.handleItemSelected(e, SurgeryDate, Surgery)}>{Surgery}</span>
+                                           <span onClick={(e) => this.handleItemSelected(e, SurgeryDateString, SurgeryString)}>{SurgeryString}</span>
                                         </li>
                                     <li>
-                                        RadiationDate: <span onClick={(e) => this.handleItemSelected(e, RadiationDate)}>{RadiationDate}</span>
+                                        <span onClick={(e) => this.handleItemSelected(e, RadiationDateString)}>{RadiationDateString}</span>
                                     </li>
                                     <li>
-                                        TamoxifenDate: <span onClick={(e) => this.handleItemSelected(e, TamoxifenDate)}>{TamoxifenDate}</span>
+                                        <span onClick={(e) => this.handleItemSelected(e, TamoxifenDateString)}>{TamoxifenDateString}</span>
                                     </li>
                                     <li>
-                                        RecurrenceDate: <span onClick={(e) => this.handleItemSelected(e, RecurrenceDate)}>{RecurrenceDate}</span>
+                                        <span onClick={(e) => this.handleItemSelected(e, RecurrenceDateString)}>{RecurrenceDateString}</span>
                                     </li>
                                 </ul>
                             </Col>

--- a/src/MyEditor.jsx
+++ b/src/MyEditor.jsx
@@ -10,7 +10,6 @@ import './MyEditor.css';
 import structuredDataRaw from './structuredDataRaw';
 const {staging}  = structuredDataRaw;
 
-
 const stagingState = Raw.deserialize(staging, { terse: true });
 
 const initialState = Raw.deserialize({
@@ -146,11 +145,11 @@ class MyEditor extends React.Component {
   onChange = (state) => {
     const stagingNode = getNodeById(state.document.nodes, 'staging');
     if(!stagingNode) { 
-      this.props.onStructuredFieldExited(null)
+      this.handleStructuredFieldExited(null)
       this.setState({ state })
     } else { 
      const stagingKeys = addKeysForNode(stagingNode, []);
-     (stagingKeys.includes(state.selection.startKey)) ?  this.props.onStructuredFieldEntered('staging') : this.props.onStructuredFieldExited('staging');
+     (stagingKeys.includes(state.selection.startKey)) ?  this.handleStructuredFieldEntered('staging') : this.handleStructuredFieldExited('staging');
      this.setState({ state })
     }
   }
@@ -165,6 +164,18 @@ class MyEditor extends React.Component {
 
   handleStagingMUpdate = (newVal) => {
     this.props.onStagingMUpdate(newVal);
+  }
+
+  handleStageUpdate = (newVal) => {
+    this.props.onStageUpdate(newVal);
+  }
+
+  handleStructuredFieldEntered = (currentFocus) => { 
+    this.props.onStructuredFieldEntered(currentFocus);
+  }
+
+  handleStructuredFieldExited = (currentFocus) => { 
+    this.props.onStructuredFieldExited(currentFocus);
   }
 
   onKeyDown = (event, data, state) => {
@@ -188,6 +199,7 @@ class MyEditor extends React.Component {
           if(event.keyCode >= 48 && event.keyCode <=57) {
             const val = event.keyCode - 48;
             this.handleStagingTUpdate(val)
+            this.handleStageUpdate(this.props.calculateStage(val, this.props.nodeSize, this.props.metastasis))
 
             event.preventDefault()
             return state
@@ -233,6 +245,7 @@ class MyEditor extends React.Component {
           if(event.keyCode >= 48 && event.keyCode <=57) {
             const val = event.keyCode - 48;
             this.handleStagingNUpdate(val)
+            this.handleStageUpdate(this.props.calculateStage(this.props.tumorSize, this.props.nodeSize, this.props.metastasis))
 
             event.preventDefault()
             return state
@@ -278,6 +291,7 @@ class MyEditor extends React.Component {
           if(event.keyCode >= 48 && event.keyCode <=57) {
             const val = event.keyCode - 48;
             this.handleStagingMUpdate(val)
+            this.handleStageUpdate(this.props.calculateStage(this.props.tumorSize, this.props.nodeSize, val))
             const emptyBlock = Block.create({'type': 'span', 'nodes': List([Text.createFromString('')])});
             const emptyBlockKey = emptyBlock.key;
             const afterEmpty = parseInt(emptyBlockKey, 10) + 2;

--- a/src/RightPanel.jsx
+++ b/src/RightPanel.jsx
@@ -24,10 +24,18 @@ class RightPanel extends Component {
         return ( 
             <StagingForm 
                 className={this.props.className}
-                tumorSize={this.props.tumorSize} nodeSize={this.props.nodeSize} metastasis={this.props.metastasis} stage={this.props.stage}
+                // Update functions
                 onStagingTUpdate={this.props.onStagingTUpdate}
                 onStagingNUpdate={this.props.onStagingNUpdate}
                 onStagingMUpdate={this.props.onStagingMUpdate}
+                onStageUpdate={this.props.onStageUpdate}
+                // Helper functions
+                calculateStage={this.props.calculateStage}
+                // Properties
+                tumorSize={this.props.tumorSize} 
+                nodeSize={this.props.nodeSize} 
+                metastasis={this.props.metastasis} 
+                stage={this.props.stage}
             />
         );
     }

--- a/src/StagingForm.jsx
+++ b/src/StagingForm.jsx
@@ -21,6 +21,34 @@ class StagingForm extends Component {
       };
   }
 
+  _currentlySelected(item, i) {
+    return (item === i ? true : false);
+  }
+
+  _handleTumorSizeClick = (e, i) => {
+    e.preventDefault();
+    console.log("StagingForm._handleTumorSizeClick T=" + i);
+    var stage = this.props.calculateStage(i, this.props.nodeSize, this.props.metastasis);
+    this.props.onStagingTUpdate(i);
+    this.props.onStageUpdate(stage);
+  }
+
+  _handleNodeClick = (e, i) => {
+    e.preventDefault();
+    console.log("StagingForm._handleNodeClick N=" + i);
+    var stage = this.props.calculateStage(this.props.tumorSize, i, this.props.metastasis);
+    this.props.onStagingNUpdate(i);
+    this.props.onStageUpdate(stage);
+  }
+  
+  _handleMetastasisClick = (e, i) => {
+    e.preventDefault();
+    console.log("StagingForm._handleMetastasisClick M=" + i);
+    var stage = this.props.calculateStage(this.props.tumorSize, this.props.nodeSize, i);
+    this.props.onStagingMUpdate(i);
+    this.props.onStageUpdate(stage);
+  }
+
   render() {
     // console.log("in render. t: " + this.props.t);
     return (
@@ -92,61 +120,6 @@ class StagingForm extends Component {
             </Paper>
         </div>
     );
-  }
-
-  _currentlySelected(item, i) {
-    return (item === i ? true : false);
-  }
-
-  _handleTumorSizeClick = (e, i) => {
-    e.preventDefault();
-    console.log("StagingForm._handleTumorSizeClick T=" + i);
-    var stage = this._prognosticStage(i, this.props.nodeSize, this.props.metastasis);
-    this.props.onStagingTUpdate(i, stage);
-  }
-
-  _handleNodeClick = (e, i) => {
-    e.preventDefault();
-    console.log("StagingForm._handleNodeClick N=" + i);
-    var stage = this._prognosticStage(this.props.tumorSize, i, this.props.metastasis);
-    this.props.onStagingNUpdate(i, stage);
-  }
-  
-  _handleMetastasisClick = (e, i) => {
-    e.preventDefault();
-    console.log("StagingForm._handleMetastasisClick M=" + i);
-    var stage = this._prognosticStage(this.props.tumorSize, this.props.nodeSize, i);
-    this.props.onStagingMUpdate(i, stage);
-  }
-
-  _prognosticStage= (t, n, m) =>  {
-    var stage;
-    // Metastisized cancer is always Stage IV
-    if (m === 1) {
-      stage = 'IV';
-      return stage;
-    }
-
-    // Lookup the rest based on T and N:
-    const lookup = [
-      ['0', 'IIA', 'IIIA', 'IIIC'], // T0
-      ['IA', 'IIA', 'IIIA', 'IIIC'], // T1
-      ['IIA', 'IIB', 'IIIA', 'IIIC'], // T2
-      ['IIB', 'IIIA', 'IIIA', 'IIIC'], // T3
-      ['IIIB', 'IIIB', 'IIIB', 'IIIC'] // T4
-    ];
-
-    // With N1M1 Values
-    // const lookup = [
-    //   ['0', 'IB', 'IIA', 'IIIA', 'IIIC'], // T0
-    //   ['IA', 'IB', 'IIA', 'IIIA', 'IIIC'], // T1
-    //   ['IIA', 'IIB', 'IIB', 'IIIA', 'IIIC'], // T2
-    //   ['IIB', 'IIIA', 'IIIA', 'IIIA', 'IIIC'], // T3
-    //   ['IIIB', 'IIIB', 'IIIB', 'IIIB', 'IIIC'] // T4
-    // ];
-
-    stage = lookup[t][n];
-    return stage;
   }
 }
 


### PR DESCRIPTION
From bug 136: Clinical notes doesn't update the stage (e.g. IIA) based on provided staging TNM values.

By moving stage calculations from Right panel into App, we now have assurance that all components are using the same mechanism to calculate new stage values. Additionally, by separating the Stage updates into its own function we a) lose the dependency  between current TMN and current stage (for better and worse), and; b) pave the road to our '.stage' inline helper. 