### PR TITLE
Included "Add" button to insert summary info into clinical notes

### DIFF
--- a/src/DataSummary.css
+++ b/src/DataSummary.css
@@ -105,6 +105,18 @@
     padding-left: 20px;
 }
 
+#data-summary #summary-condition-details .summary-condition-button .fa {
+    font-size:.8rem!important;
+    color: #00d6b2 !important;
+}
+#data-summary #summary-condition-details .summary-condition-button {
+    height: auto!important;
+    width: auto!important;
+    padding:5px!important;
+    /*margin-top: 10px!important;*/
+}
+
+
 #data-summary #summary-condition-details #staging-missing-warning {
     font-size: .8rem;
     color: red;

--- a/src/DataSummary.jsx
+++ b/src/DataSummary.jsx
@@ -179,10 +179,20 @@ class DataSummary extends Component {
                                 <ul className="summary-section" id="summary-staging">
                                     <div className="summary-details">
                                         <li>
-                                            <span onClick={(e) => this.handleItemSelected(e, StageString, StageSubElementsString)}>{StageString}</span>
+                                            <span>{StageString}</span>
+                                            <IconButton
+                                                className="summary-condition-button"
+                                                iconClassName="fa fa-plus-square"
+                                                onClick={(e) => this.handleItemSelected(e, StageString, StageSubElementsString)}
+                                            />
                                         </li>
                                         <li className="sub-list">
-                                            <span onClick={(e) => this.handleItemSelected(e, StageString, StageSubElementsString)}>{StageSubElementsString}</span>
+                                            <span>{StageSubElementsString}</span>
+                                            <IconButton
+                                                className="summary-condition-button"
+                                                iconClassName="fa fa-plus-square"
+                                                onClick={(e) => this.handleItemSelected(e, StageString, StageSubElementsString)}
+                                            />
                                         </li>
                                     </div>
                                     <span id="staging-missing-warning">{this.missingInfoString}</span>
@@ -192,16 +202,36 @@ class DataSummary extends Component {
                                 <h3>Pathology Results</h3>
                                 <ul className="summary-section" id="summary-pathology">
                                     <li>
-                                        <span onClick={(e) => this.handleItemSelected(e, HGAString)}>{HGAString}</span>
+                                        <span>{HGAString}</span>
+                                        <IconButton
+                                            className="summary-condition-button"
+                                            iconClassName="fa fa-plus-square"
+                                            onClick={(e) => this.handleItemSelected(e, HGAString)}
+                                        />
                                     </li>
                                     <li>
-                                        <span onClick={(e) => this.handleItemSelected(e, HER2StatusString)}>{HER2StatusString}</span>
+                                        <span>{HER2StatusString}</span>
+                                        <IconButton
+                                            className="summary-condition-button"
+                                            iconClassName="fa fa-plus-square"
+                                            onClick={(e) => this.handleItemSelected(e, HER2StatusString)}
+                                        />
                                     </li>
                                     <li>
-                                        <span onClick={(e) => this.handleItemSelected(e, ERStatusString)}>{ERStatusString}</span>
+                                        <span>{ERStatusString}</span>
+                                        <IconButton
+                                            className="summary-condition-button"
+                                            iconClassName="fa fa-plus-square"
+                                            onClick={(e) => this.handleItemSelected(e, ERStatusString)}
+                                        />
                                     </li>
                                     <li>
-                                        <span onClick={(e) => this.handleItemSelected(e, PRStatusString)}>{PRStatusString}</span>
+                                        <span>{PRStatusString}</span>
+                                        <IconButton
+                                            className="summary-condition-button"
+                                            iconClassName="fa fa-plus-square"
+                                            onClick={(e) => this.handleItemSelected(e, PRStatusString)}
+                                        />
                                     </li>
                                 </ul>
                             </Col>
@@ -211,25 +241,60 @@ class DataSummary extends Component {
                                 <h3>Event Dates</h3>
                                 <ul className="summary-section" id="summary-dates">
                                     <li>
-                                        <span onClick={(e) => this.handleItemSelected(e, DiagnosisDateString, DiagnosisString)}>{DiagnosisDateString}</span>
+                                        <span>{DiagnosisDateString}</span>
+                                        <IconButton
+                                            className="summary-condition-button"
+                                            iconClassName="fa fa-plus-square"
+                                            onClick={(e) => this.handleItemSelected(e, DiagnosisDateString, DiagnosisString)}
+                                        />
                                     </li>
                                         <li className="sub-list" >
-                                           <span onClick={(e) => this.handleItemSelected(e, DiagnosisDateString, DiagnosisString)}>{DiagnosisString}</span>
+                                           <span>{DiagnosisString}</span>
+                                            <IconButton
+                                                className="summary-condition-button"
+                                                iconClassName="fa fa-plus-square"
+                                                onClick={(e) => this.handleItemSelected(e, DiagnosisDateString, DiagnosisString)}
+                                            />
                                         </li>
                                     <li>
-                                       <span onClick={(e) => this.handleItemSelected(e, SurgeryDateString, SurgeryString)}>{SurgeryDateString}</span>
+                                       <span>{SurgeryDateString}</span>
+                                        <IconButton
+                                            className="summary-condition-button"
+                                            iconClassName="fa fa-plus-square"
+                                            onClick={(e) => this.handleItemSelected(e, SurgeryDateString, SurgeryString)}
+                                        />
                                     </li>
                                         <li className="sub-list" >
-                                           <span onClick={(e) => this.handleItemSelected(e, SurgeryDateString, SurgeryString)}>{SurgeryString}</span>
+                                           <span>{SurgeryString}</span>
+                                            <IconButton
+                                                className="summary-condition-button"
+                                                iconClassName="fa fa-plus-square"
+                                                onClick={(e) => this.handleItemSelected(e, SurgeryDateString, SurgeryString)}
+                                            />
                                         </li>
                                     <li>
-                                        <span onClick={(e) => this.handleItemSelected(e, RadiationDateString)}>{RadiationDateString}</span>
+                                        <span>{RadiationDateString}</span>
+                                        <IconButton
+                                            className="summary-condition-button"
+                                            iconClassName="fa fa-plus-square"
+                                            onClick={(e) => this.handleItemSelected(e, RadiationDateString)}
+                                        />
                                     </li>
                                     <li>
-                                        <span onClick={(e) => this.handleItemSelected(e, TamoxifenDateString)}>{TamoxifenDateString}</span>
+                                        <span>{TamoxifenDateString}</span>
+                                        <IconButton
+                                            className="summary-condition-button"
+                                            iconClassName="fa fa-plus-square"
+                                            onClick={(e) => this.handleItemSelected(e, TamoxifenDateString)}
+                                        />
                                     </li>
                                     <li>
-                                        <span onClick={(e) => this.handleItemSelected(e, RecurrenceDateString)}>{RecurrenceDateString}</span>
+                                        <span>{RecurrenceDateString}</span>
+                                        <IconButton
+                                            className="summary-condition-button"
+                                            iconClassName="fa fa-plus-square"
+                                            onClick={(e) => this.handleItemSelected(e, RecurrenceDateString)}
+                                        />
                                     </li>
                                 </ul>
                             </Col>


### PR DESCRIPTION
Added plus icon next to the items in the summary panel. Moved onclick event from the label (span text) to the add button. 

The functionality is the same except instead of clicking on summary item text, click on the plus button next to it. Clicking the button inserts text into a span under the clinical notes.

Next steps:
- Insert text into clinical notes (MyEditor)
- Determine what should be displayed in clinical notes