### PR TITLE
Added breast cancer staging computations

### DIFF
--- a/lib/staging.js
+++ b/lib/staging.js
@@ -1,0 +1,63 @@
+const lookup = require('./staging_lookup');
+
+// Computes the prognostic stage of breast cancer given T, N, M.
+// Uses the 7th staging edition, see:
+// https://cancerstaging.org/references-tools/quickreferences/Documents/BreastMedium.pdf
+exports.breastCancerPrognosticStage = (t, n, m) => {
+  // Regardless of edition, metastatic cancer is always stage IV
+  if (m.toString().toUpperCase() == 'M1') {
+    return 'IV';
+  }
+
+  // 7th edition staging, lookup[T][N]
+  // null return values mean the staging is undefined for those T,N,M values
+  const ti = (lookup.getTsForEdition(7)).indexOf(t.toString().toUpperCase());
+  const ni = (lookup.getNsForEdition(7)).indexOf(n.toString().toUpperCase());
+
+  if (ti === -1 || ni === -1) {
+    // Urecognized T or N value
+    return null;
+  }
+  return lookup.getTableForEdition(7)[ti][ni];
+};
+
+
+// Converts a prognostic stage (e.g. 'IIIA') into a list of possible T,N,M
+// values based on the specified staging edition. If none specified, defaults
+// to the 7th edition.
+exports.breastCancerPossibleTNM = (prognosticStage, edition = 7) => {
+  let values = [];
+
+  // Lookup the needed values for the specified edition
+  const ed = parseInt(edition);
+  const ts = lookup.getTsForEdition(ed);
+  const ns = lookup.getNsForEdition(ed);
+  const table = lookup.getTableForEdition(ed);
+
+  // Regardless of edition, stage IV is handled the same way
+  const stage = prognosticStage.toString().toUpperCase();
+
+  if (stage === 'IV') {
+    ts.forEach((t) => {
+      ns.forEach((n) => {
+        values.push([t, n, 'M1']);
+      });
+    });
+    return values;
+  }
+
+  // No lookup means an invalid or unsupported edition
+  if (!table) {
+    return [];
+  }
+
+  // Find all T,N,M matches for the prognostic stage specified
+  table.forEach((row, t) => {
+    row.forEach((el, n) => {
+      if (el === stage) {
+        values.push([ts[t], ns[n], 'M0']);
+      }
+    });
+  });
+  return values;
+};

--- a/lib/staging_lookup.js
+++ b/lib/staging_lookup.js
@@ -1,0 +1,78 @@
+// Breast Cancer Staging lookups
+
+// 5th Edition, p.174:
+// https://cancerstaging.org/references-tools/deskreferences/Documents/AJCC5thEdCancerStagingManual.pdf
+const ts5thEdition = ['T0', 'T1', 'T2', 'T3', 'T4'];
+const ns5thEdition = ['N0', 'N1', 'N2', 'N3'];
+const table5thEdition = [
+  // N0 , N1 ,  N2  , N3
+    [null, 'IIA', 'IIIA', 'IIIB'], // T0
+    [null, 'IIA', 'IIIA', 'IIIB'], // T1
+    ['IIA', 'IIB', 'IIIA', 'IIIB'], // T2
+    ['IIB', 'IIIA', 'IIIA', 'IIIB'], // T3
+    ['IIIB', 'IIIB', 'IIIB', 'IIIB'] // T4
+];
+
+// 6th Edition, p.228:
+// https://cancerstaging.org/references-tools/deskreferences/Documents/AJCC6thEdCancerStagingManualPart2.pdf
+const ts6thEdition = ['TIS', 'T0', 'T1', 'T2', 'T3', 'T4'];
+const ns6thEdition = ['N0', 'N1', 'N2', 'N3'];
+const table6thEdition = [
+  // N0 , N1 ,  N2  , N3
+    ['0', null, null, 'IIIC'], // Tis
+    [null, 'IIA', 'IIIA', 'IIIC'], // T0
+    ['I', 'IIA', 'IIIA', 'IIIC'], // T1
+    ['IIA', 'IIB', 'IIIA', 'IIIC'], // T2
+    ['IIB', 'IIIA', 'IIIA', 'IIIC'], // T3
+    ['IIIB', 'IIIB', 'IIIB', 'IIIC'] // T4
+];
+
+// 7th Edition:
+// https://cancerstaging.org/references-tools/quickreferences/Documents/BreastMedium.pdf
+const ts7thEdition = ['TIS', 'T0', 'T1', 'T2', 'T3', 'T4'];
+const ns7thEdition = ['N0', 'N1MI', 'N1', 'N2', 'N3'];
+const table7thEdition = [
+  // N0 , N1mi , N1 ,  N2  , N3
+    ['0', null, null, null, 'IIIC'], // Tis
+    ['0', 'IB', 'IIA', 'IIIA', 'IIIC'], // T0
+    ['IA', 'IB', 'IIA', 'IIIA', 'IIIC'], // T1
+    ['IIA', null, 'IIB', 'IIIA', 'IIIC'], // T2
+    ['IIB', null, 'IIIA', 'IIIA', 'IIIC'], // T3
+    ['IIIB', null, 'IIIB', 'IIIB', 'IIIC'] // T4
+];
+
+exports.getTsForEdition = (ed) => {
+    switch (ed) {
+    case 5:
+        return ts5thEdition;
+    case 6:
+        return ts6thEdition;
+    case 7:
+        return ts7thEdition;
+    }
+    return [];
+};
+
+exports.getNsForEdition = (ed) => {
+    switch (ed) {
+    case 5:
+        return ns5thEdition;
+    case 6:
+        return ns6thEdition;
+    case 7:
+        return ns7thEdition;
+    }
+    return [];
+};
+
+exports.getTableForEdition = (ed) => {
+    switch (ed) {
+    case 5:
+        return table5thEdition;
+    case 6:
+        return table6thEdition;
+    case 7:
+        return table7thEdition;
+    }
+    return [];
+};

--- a/test/staging_test.js
+++ b/test/staging_test.js
@@ -1,0 +1,114 @@
+const assert = require('assert');
+const staging = require('../lib/staging');
+const lookup = require('../lib/staging_lookup');
+
+describe('breastCancerPrognosticStage', () => {
+
+  it('should compute valid prognostic stages given T, N, M', () => {
+    assert.equal(staging.breastCancerPrognosticStage('Tis','N0','M0'), '0');
+    assert.equal(staging.breastCancerPrognosticStage('T0','N0','M0'), '0');
+    assert.equal(staging.breastCancerPrognosticStage('T1','N1mi','M0'), 'IB');
+    assert.equal(staging.breastCancerPrognosticStage('T3','N2','M0'), 'IIIA');
+    assert.equal(staging.breastCancerPrognosticStage('T1','N2','M1'), 'IV');
+  });
+
+  it('should return null for invalid T, N, M values', () => {
+    assert.equal(staging.breastCancerPrognosticStage(1,2,0), null);
+    assert.equal(staging.breastCancerPrognosticStage('foo','bar',11.5), null);
+  });
+
+  it('should return null for undefined staging given T, N, M', () => {
+    assert.equal(staging.breastCancerPrognosticStage('T4','N1mi','M0'), null);
+    assert.equal(staging.breastCancerPrognosticStage('Tis','N1','M0'), null);
+  });
+
+  it('should be case-insensitive', () => {
+    assert.equal(staging.breastCancerPrognosticStage('Tis','N0','M0'), '0');
+    assert.equal(staging.breastCancerPrognosticStage('TIS','n0','M0'), '0');
+    assert.equal(staging.breastCancerPrognosticStage('T1','N1mi','m0'), 'IB');
+    assert.equal(staging.breastCancerPrognosticStage('t0','n1mI','M0'), 'IB');
+  });
+});
+
+
+describe('breastCancerPossibleTNM', () => {
+
+  it('should return a list of possible T, N, M tuples given a prognostic stage', () => {
+    // 5th edition, stage 'IIB'
+    let expected = [
+      ['T2','N1','M0'],
+      ['T3','N0','M0']
+    ];
+    assert.deepStrictEqual(staging.breastCancerPossibleTNM('IIB', 5), expected);
+
+    // 6th edition, stage 'IIA'
+    expected = [
+      ['T0','N1','M0'],
+      ['T1','N1','M0'],
+      ['T2','N0','M0']
+    ];
+    assert.deepStrictEqual(staging.breastCancerPossibleTNM('IIA', 6), expected);
+
+    // 7th edition, stage 'IB'
+    expected = [
+      ['T0','N1MI','M0'],
+      ['T1','N1MI','M0']
+    ];
+    assert.deepStrictEqual(staging.breastCancerPossibleTNM('IB', 7), expected);
+  });
+
+  it('should return all permutations of T and N for stage IV', () => {
+    assert.deepStrictEqual(
+      staging.breastCancerPossibleTNM('IV', 5),
+      metastaticPermute(lookup.getTsForEdition(5), lookup.getNsForEdition(5))
+    );
+
+    assert.deepStrictEqual(
+      staging.breastCancerPossibleTNM('IV', 6),
+      metastaticPermute(lookup.getTsForEdition(6), lookup.getNsForEdition(6))
+    );
+
+    assert.deepStrictEqual(
+      staging.breastCancerPossibleTNM('IV', 7),
+      metastaticPermute(lookup.getTsForEdition(7), lookup.getNsForEdition(7))
+    );
+  });
+
+  it('should return an empty list for an invalid staging edition', () => {
+    assert.deepStrictEqual(staging.breastCancerPossibleTNM('IIB', 3), []);
+    assert.deepStrictEqual(staging.breastCancerPossibleTNM('IIB', 'foo'), []);
+  });
+
+  it('should return an empty list for an unknown prognostic stage', () => {
+    // these two are valid in other editions:
+    assert.deepStrictEqual(staging.breastCancerPossibleTNM('I', 5), []);
+    assert.deepStrictEqual(staging.breastCancerPossibleTNM('IA', 6), []);
+
+    // there is no stage 'V' cancer
+    assert.deepStrictEqual(staging.breastCancerPossibleTNM('V', 7), []);
+  });
+
+  it('should default to the 7th edition if none is specified', () => {
+    // 7th edition, stage 'IA'
+    const expected = [
+      ['T1','N0','M0']
+    ];
+    assert.deepStrictEqual(staging.breastCancerPossibleTNM('IA'), expected);
+  });
+
+  it('should be case-insensitive', () => {
+    assert.deepStrictEqual(staging.breastCancerPossibleTNM('IIIB'), staging.breastCancerPossibleTNM('iiib'));
+    assert.deepStrictEqual(staging.breastCancerPossibleTNM('iA'), staging.breastCancerPossibleTNM('Ia'));
+    assert.deepStrictEqual(staging.breastCancerPossibleTNM('N1mi'), staging.breastCancerPossibleTNM('N1MI'));
+  });
+});
+
+function metastaticPermute(ts, ns) {
+  let values = [];
+  ts.forEach((t) => {
+    ns.forEach((n) => {
+      values.push([t, n, 'M1']);
+    });
+  });
+  return values;
+}


### PR DESCRIPTION
Added methods and lookups to convert T,N,M to prognostic stage and prognostic stage to T,N,M for the 5th, 6th, and 7th editions of clinical staging for breast cancer.

```js
const staging = require('lib/staging');

// uses only the 7th edition for these computations:
const prognosticStage = staging.breastCancerPrognosticStage('T1', 'N2', 'M0');

// 5th, 6th, and 7th editions are all valid (defaults to 7th):
const values7thEd = staging.breastCancerPossibleTNM('IIB');
const values6thEd = staging.breastCancerPossibleTNM('I', 6);
```

The `prognosticStage` is returned as a display-ready string, e.g. `'IIIA'`.

Possible TNM values are returned as 2D array, e.g.:
```js
[ ['T1','N1','M0'], ['T1','N2','M0'] ]
```

Also added unit tests for these library functions. I'm not sure how `yarn test` is configured for react, so I've just been using good ol' fashioned `mocha`:

From the top-level project directory, simply run:
```
mocha
```

You should see something like:
```

  breastCancerPrognosticStage
    ✓ should compute valid prognostic stages given T, N, M
    ✓ should return null for invalid T, N, M values
    ✓ should return null for undefined staging given T, N, M
    ✓ should be case-insensitive

  breastCancerPossibleTNM
    ✓ should return a list of possible T, N, M tuples given a prognostic stage
    ✓ should return all permutations of T and N for stage IV
    ✓ should return an empty list for an invalid staging edition
    ✓ should return an empty list for an unknown prognostic stage
    ✓ should default to the 7th edition if none is specified
    ✓ should be case-insensitive


  10 passing (12ms)
```

Now that we have unit tests for something, perhaps we should also setup Travis CI?