### PR TITLE
Update clinical notes with staging

### DIFF
--- a/src/MyEditor.jsx
+++ b/src/MyEditor.jsx
@@ -117,9 +117,9 @@ class MyEditor extends React.Component {
 
   // This gets called when the state receives properties
   componentWillReceiveProps(nextProps) {
-    // console.log("[componentWillReceiveProps] t: " + nextProps.tumorSize);
-    // console.log("[componentWillReceiveProps] n: " + nextProps.nodeSize);
-    // console.log("[componentWillReceiveProps] m: " + nextProps.metastasis);
+    console.log("[componentWillReceiveProps] t: " + nextProps.tumorSize);
+    console.log("[componentWillReceiveProps] n: " + nextProps.nodeSize);
+    console.log("[componentWillReceiveProps] m: " + nextProps.metastasis);
 
     if (this.props.itemToBeInserted !== nextProps.itemToBeInserted) {
       this.handleSummaryUpdate(nextProps.itemToBeInserted);
@@ -127,37 +127,36 @@ class MyEditor extends React.Component {
 
     // Check if staging block exists
     const stagingNode = getNodeById(this.state.state.document.nodes, 'staging');
+    if (this.props.tumorSize !== nextProps.tumorSize) { 
+      if (stagingNode) {
+       console.log("exists")
+        // if it exists, populate the fields with the updated staging values
 
-    if (stagingNode) {
-     console.log("exists")
-      // if it exists, populate the fields with the updated staging values
+        for(const parentNode of this.state.state.document.nodes) {
+          const tNode = getNodeById(parentNode.nodes, 't-staging');
+          const nNode = getNodeById(parentNode.nodes, 'n-staging');
+          const mNode = getNodeById(parentNode.nodes, 'm-staging');
 
-      for(const parentNode of this.state.state.document.nodes) {
-        const tNode = getNodeById(parentNode.nodes, 't-staging');
-        const nNode = getNodeById(parentNode.nodes, 'n-staging');
-        const mNode = getNodeById(parentNode.nodes, 'm-staging');
+          if(tNode) {
+              console.log("trying to update value");
 
-        if(tNode) {
-            console.log("trying to update value");
-
-            const currentState = this.state.state;
-            const state = currentState
-                .transform()
-                .moveToRangeOf(tNode)
-                .moveStart(1)
-                .moveEnd(-1)
-                .deleteForward()
-                .insertText(nextProps.tumorSize)
-                .apply();
-            this.setState({ state: state })
+              const currentState = this.state.state;
+              const state = currentState
+                  .transform()
+                  .moveToRangeOf(tNode)
+                  .moveEnd(-1)
+                  .deleteForward()
+                  .insertText(nextProps.tumorSize)
+                  .apply();
+              this.setState({ state: state })
+          }
         }
       }
-    }
-    else {
-      console.log("doesn't exist")
+      else {
+        console.log("doesn't exist")
+      }
     }
   }
-
 
   // Add the plugin to your set of plugins...
   plugins = [

--- a/src/MyEditor.jsx
+++ b/src/MyEditor.jsx
@@ -68,7 +68,7 @@ function addKeysForNode(curNode, keys) {
   return keys;
 }
 
-// The list of special keys we want to trigger special beahvior
+// The list of special keys we want to trigger special behavior
 // TODO: link these keys with the specific changes in behavior
 const stagingKeyChars = ['T','N','M'];
 
@@ -117,27 +117,23 @@ class MyEditor extends React.Component {
 
   // This gets called when the before the component receives new properties
   componentWillReceiveProps(nextProps) {
-    console.log("[componentWillReceiveProps] t: " + nextProps.tumorSize);
-    console.log("[componentWillReceiveProps] n: " + nextProps.nodeSize);
-    console.log("[componentWillReceiveProps] m: " + nextProps.metastasis);
 
     if (this.props.itemToBeInserted !== nextProps.itemToBeInserted) {
       this.handleSummaryUpdate(nextProps.itemToBeInserted);
     }
 
-    // Check if staging block exists
+    // Check if staging block exists in the editor
     const stagingNode = getNodeById(this.state.state.document.nodes, 'staging');
 
+    // If it exists, populate the fields with the updated staging values
       if (stagingNode) {
-       console.log("exists");
-        // if it exists, populate the fields with the updated staging values
         for(const parentNode of this.state.state.document.nodes) {
           const tNode = getNodeById(parentNode.nodes, 't-staging');
           const nNode = getNodeById(parentNode.nodes, 'n-staging');
           const mNode = getNodeById(parentNode.nodes, 'm-staging');
 
+          // Set t value
           if(tNode && this.props.tumorSize !== nextProps.tumorSize) {
-
               const currentState = this.state.state;
               const state = currentState
                   .transform()
@@ -148,8 +144,9 @@ class MyEditor extends React.Component {
                   .apply();
               this.setState({ state: state })
           }
-          if(nNode && this.props.nodeSize !== nextProps.nodeSize) {
 
+          // Set n value
+          if(nNode && this.props.nodeSize !== nextProps.nodeSize) {
             const currentState = this.state.state;
             const state = currentState
                 .transform()
@@ -160,8 +157,9 @@ class MyEditor extends React.Component {
                 .apply();
             this.setState({ state: state })
           }
-          if(mNode && this.props.metastasis !== nextProps.metastasis) {
 
+          // Set m value
+          if(mNode && this.props.metastasis !== nextProps.metastasis) {
             const currentState = this.state.state;
             const state = currentState
                 .transform()
@@ -174,10 +172,6 @@ class MyEditor extends React.Component {
           }
         }
       }
-      else {
-        console.log("doesn't exist")
-      }
-
   }
 
   // Add the plugin to your set of plugins...

--- a/src/MyEditor.jsx
+++ b/src/MyEditor.jsx
@@ -115,7 +115,7 @@ class MyEditor extends React.Component {
     }
   }
 
-  // This gets called when the state receives properties
+  // This gets called when the before the component receives new properties
   componentWillReceiveProps(nextProps) {
     console.log("[componentWillReceiveProps] t: " + nextProps.tumorSize);
     console.log("[componentWillReceiveProps] n: " + nextProps.nodeSize);
@@ -127,18 +127,16 @@ class MyEditor extends React.Component {
 
     // Check if staging block exists
     const stagingNode = getNodeById(this.state.state.document.nodes, 'staging');
-    if (this.props.tumorSize !== nextProps.tumorSize) { 
-      if (stagingNode) {
-       console.log("exists")
-        // if it exists, populate the fields with the updated staging values
 
+      if (stagingNode) {
+       console.log("exists");
+        // if it exists, populate the fields with the updated staging values
         for(const parentNode of this.state.state.document.nodes) {
           const tNode = getNodeById(parentNode.nodes, 't-staging');
           const nNode = getNodeById(parentNode.nodes, 'n-staging');
           const mNode = getNodeById(parentNode.nodes, 'm-staging');
 
-          if(tNode) {
-              console.log("trying to update value");
+          if(tNode && this.props.tumorSize !== nextProps.tumorSize) {
 
               const currentState = this.state.state;
               const state = currentState
@@ -150,12 +148,36 @@ class MyEditor extends React.Component {
                   .apply();
               this.setState({ state: state })
           }
+          if(nNode && this.props.nodeSize !== nextProps.nodeSize) {
+
+            const currentState = this.state.state;
+            const state = currentState
+                .transform()
+                .moveToRangeOf(nNode)
+                .moveEnd(-1)
+                .deleteForward()
+                .insertText(nextProps.nodeSize)
+                .apply();
+            this.setState({ state: state })
+          }
+          if(mNode && this.props.metastasis !== nextProps.metastasis) {
+
+            const currentState = this.state.state;
+            const state = currentState
+                .transform()
+                .moveToRangeOf(mNode)
+                .moveEnd(-1)
+                .deleteForward()
+                .insertText(nextProps.metastasis)
+                .apply();
+            this.setState({ state: state })
+          }
         }
       }
       else {
         console.log("doesn't exist")
       }
-    }
+
   }
 
   // Add the plugin to your set of plugins...

--- a/src/MyEditor.jsx
+++ b/src/MyEditor.jsx
@@ -115,15 +115,47 @@ class MyEditor extends React.Component {
     }
   }
 
-  // This gets called when the state receives new updates 
+  // This gets called when the state receives properties
   componentWillReceiveProps(nextProps) {
-    // console.log("[componentDidUpdate] this.props.itemToBeInserted: " + this.props.itemToBeInserted);
-    // console.log("[componentDidUpdate] nextProps.itemToBeInserted: " + nextProps.itemToBeInserted);
+    console.log("[componentWillReceiveProps] t: " + nextProps.tumorSize);
+    console.log("[componentWillReceiveProps] n: " + nextProps.nodeSize);
+    console.log("[componentWillReceiveProps] m: " + nextProps.metastasis);
 
     if (this.props.itemToBeInserted !== nextProps.itemToBeInserted) {
       this.handleSummaryUpdate(nextProps.itemToBeInserted);
     }
+
+    // Check if staging block exists
+    const stagingNode = getNodeById(this.state.state.document.nodes, 'staging');
+
+    if (stagingNode) {
+     console.log("exists")
+      // if it exists, populate the fields with the updated staging values
+
+      // for(const parentNode of this.state.state.document.nodes) {
+      //   const tNode = getNodeById(parentNode.nodes, 't-staging');
+      //   const nNode = getNodeById(parentNode.nodes, 'n-staging');
+      //   const mNode = getNodeById(parentNode.nodes, 'm-staging');
+      //   console.log("tnode");
+      //   console.log(tNode);
+      //   if(tNode) {
+      //     return this.state.state
+      //         .transform()
+      //         .moveToRangeOf(tNode)
+      //         .moveStart(1)
+      //         .moveEnd(-1)
+      //         .deleteForward()
+      //         .insertText("test")
+      //         .apply();
+      //   }
+      // }
+
+    }
+    else {
+      console.log("doesn't exist")
+    }
   }
+
 
 
   // Add the plugin to your set of plugins...


### PR DESCRIPTION
Entering t, n, and m values from the right panel now updates the inline helper in clinical notes. Dylan helped with fixing the duplicate label issue and selection issue.

*Note: When a user enters TIS or N1MI in clinical notes in the inline helper, this does not get updated in the right panel or the summary panel. This issue is covered in jira task 194