### PR TITLE
Right panel hover on buttons

### DIFF
--- a/lib/staging.js
+++ b/lib/staging.js
@@ -17,8 +17,8 @@ exports.breastCancerPrognosticStage = (t, n, m) => {
 
   // 7th edition staging, lookup[T][N]
   // null return values mean the staging is undefined for those T,N,M values
-  const ti = (lookup.getTsForEdition(7)).indexOf(t.toString().toUpperCase());
-  const ni = (lookup.getNsForEdition(7)).indexOf(n.toString().toUpperCase());
+  const ti = (lookup.getTsNamesForEdition(7)).indexOf(t.toString().toUpperCase());
+  const ni = (lookup.getNsNamesForEdition(7)).indexOf(n.toString().toUpperCase());
 
   if (ti === -1 || ni === -1) {
     // Urecognized T or N value

--- a/lib/staging_lookup.js
+++ b/lib/staging_lookup.js
@@ -2,7 +2,15 @@
 
 // 5th Edition, p.174:
 // https://cancerstaging.org/references-tools/deskreferences/Documents/AJCC5thEdCancerStagingManual.pdf
-const ts5thEdition = ['T0', 'T1', 'T2', 'T3', 'T4'];
+// const ts5thEdition = ['T0', 'T1', 'T2', 'T3', 'T4'];
+const ts5thEdition = [
+    {name: 'TIS', description: "Carcinoma in situ"},
+    {name: 'T0', description: "No evidence of primary tumor"},
+    {name: 'T1', description: "Tumor ≤ 20 mm in greatest dimension"},
+    {name: 'T2', description: "20 mm < Tumor ≤ 50 mm in greatest dimension"},
+    {name: 'T3', description: "Tumor > 50 mm in greatest dimension"},
+    {name: 'T4', description: "Tumor of any size with direct extension to the chest wall and/or to the skin (ulceration or skin nodules)"}
+];
 const ns5thEdition = ['N0', 'N1', 'N2', 'N3'];
 const table5thEdition = [
   // N0 , N1 ,  N2  , N3
@@ -15,7 +23,16 @@ const table5thEdition = [
 
 // 6th Edition, p.228:
 // https://cancerstaging.org/references-tools/deskreferences/Documents/AJCC6thEdCancerStagingManualPart2.pdf
-const ts6thEdition = ['TIS', 'T0', 'T1', 'T2', 'T3', 'T4'];
+
+// const ts6thEdition = ['TIS', 'T0', 'T1', 'T2', 'T3', 'T4']; //original array
+const ts6thEdition = [
+    {name: 'TIS', description: "Carcinoma in situ"},
+    {name: 'T0', description: "No evidence of primary tumor"},
+    {name: 'T1', description: "Tumor ≤ 20 mm in greatest dimension"},
+    {name: 'T2', description: "20 mm < Tumor ≤ 50 mm in greatest dimension"},
+    {name: 'T3', description: "Tumor > 50 mm in greatest dimension"},
+    {name: 'T4', description: "Tumor of any size with direct extension to the chest wall and/or to the skin (ulceration or skin nodules)"}
+];
 const ns6thEdition = ['N0', 'N1', 'N2', 'N3'];
 const table6thEdition = [
   // N0 , N1 ,  N2  , N3
@@ -29,15 +46,15 @@ const table6thEdition = [
 
 // 7th Edition:
 // https://cancerstaging.org/references-tools/quickreferences/Documents/BreastMedium.pdf
+
+// const ts7thEdition = ['T1', 'T2', 'T3', 'T4']; //original array
 const ts7thEdition = [
     {name: 'TIS', description: "Carcinoma in situ"},
     {name: 'T0', description: "No evidence of primary tumor"},
     {name: 'T1', description: "Tumor ≤ 1 mm in greatest dimension"},
-    {name: 'T2', description: "Tumor > 20 mm but ≤ 50 mm in greatest dimension"},
+    {name: 'T2', description: "20 < Tumor ≤ 50 mm in greatest dimension"},
     {name: 'T3', description: "Tumor > 50 mm in greatest dimension"},
     {name: 'T4', description: "Tumor of any size with direct extension to the chest wall and/or to the skin (ulceration or skin nodules)"}
-    // original ts7thEdition
-    // {'T1', 'T2', 'T3', 'T4'}
 ];
 const ns7thEdition = ['N0', 'N1MI', 'N1', 'N2', 'N3'];
 const table7thEdition = [

--- a/lib/staging_lookup.js
+++ b/lib/staging_lookup.js
@@ -2,15 +2,15 @@
 
 // 5th Edition, p.174:
 // https://cancerstaging.org/references-tools/deskreferences/Documents/AJCC5thEdCancerStagingManual.pdf
-// const ts5thEdition = ['T0', 'T1', 'T2', 'T3', 'T4'];
-const ts5thEdition = [
-    {name: 'TIS', description: "Carcinoma in situ"},
-    {name: 'T0', description: "No evidence of primary tumor"},
-    {name: 'T1', description: "Tumor ≤ 20 mm in greatest dimension"},
-    {name: 'T2', description: "20 mm < Tumor ≤ 50 mm in greatest dimension"},
-    {name: 'T3', description: "Tumor > 50 mm in greatest dimension"},
-    {name: 'T4', description: "Tumor of any size with direct extension to the chest wall and/or to the skin (ulceration or skin nodules)"}
-];
+const ts5thEdition = ['T0', 'T1', 'T2', 'T3', 'T4'];
+// const ts5thEdition = [
+//     {name: 'TIS', description: "Carcinoma in situ"},
+//     {name: 'T0', description: "No evidence of primary tumor"},
+//     {name: 'T1', description: "Tumor ≤ 20 mm in greatest dimension"},
+//     {name: 'T2', description: "20 mm < Tumor ≤ 50 mm in greatest dimension"},
+//     {name: 'T3', description: "Tumor > 50 mm in greatest dimension"},
+//     {name: 'T4', description: "Tumor of any size with direct extension to the chest wall and/or to the skin (ulceration or skin nodules)"}
+// ];
 const ns5thEdition = ['N0', 'N1', 'N2', 'N3'];
 const table5thEdition = [
   // N0 , N1 ,  N2  , N3
@@ -24,15 +24,15 @@ const table5thEdition = [
 // 6th Edition, p.228:
 // https://cancerstaging.org/references-tools/deskreferences/Documents/AJCC6thEdCancerStagingManualPart2.pdf
 
-// const ts6thEdition = ['TIS', 'T0', 'T1', 'T2', 'T3', 'T4']; //original array
-const ts6thEdition = [
-    {name: 'TIS', description: "Carcinoma in situ"},
-    {name: 'T0', description: "No evidence of primary tumor"},
-    {name: 'T1', description: "Tumor ≤ 20 mm in greatest dimension"},
-    {name: 'T2', description: "20 mm < Tumor ≤ 50 mm in greatest dimension"},
-    {name: 'T3', description: "Tumor > 50 mm in greatest dimension"},
-    {name: 'T4', description: "Tumor of any size with direct extension to the chest wall and/or to the skin (ulceration or skin nodules)"}
-];
+const ts6thEdition = ['TIS', 'T0', 'T1', 'T2', 'T3', 'T4']; //original array
+// const ts6thEdition = [
+//     {name: 'TIS', description: "Carcinoma in situ"},
+//     {name: 'T0', description: "No evidence of primary tumor"},
+//     {name: 'T1', description: "Tumor ≤ 20 mm in greatest dimension"},
+//     {name: 'T2', description: "20 mm < Tumor ≤ 50 mm in greatest dimension"},
+//     {name: 'T3', description: "Tumor > 50 mm in greatest dimension"},
+//     {name: 'T4', description: "Tumor of any size with direct extension to the chest wall and/or to the skin (ulceration or skin nodules)"}
+// ];
 const ns6thEdition = ['N0', 'N1', 'N2', 'N3'];
 const table6thEdition = [
   // N0 , N1 ,  N2  , N3
@@ -57,6 +57,13 @@ const ts7thEdition = [
     {name: 'T4', description: "Tumor of any size with direct extension to the chest wall and/or to the skin (ulceration or skin nodules)"}
 ];
 const ns7thEdition = ['N0', 'N1MI', 'N1', 'N2', 'N3'];
+// const ns7thEdition = [
+//     {name: 'N0', description: "No regional lymph node metastases"},
+//     {name: 'N1MI', description: "Micrometastases (greater than 0.2 mm and/or more than 200 cells, but none greater than 2.0 mm)"},
+//     {name: 'N1', description: "Micrometastases; or metastases in 1–3 axillary lymph nodes; and/or in internal mammary nodes with metastases detected by sentinel lymph node biopsy but not clinically detected"},
+//     {name: 'N2', description: "Metastases in 4–9 axillary lymph nodes; or in clinically detected internal mammary lymph nodes in the absence of axillary lymph node metastases"},
+//     {name: 'N3', description: "Metastases in 10 or more axillary lymph nodes; or in infraclavicular (level III axillary) lymph nodes; or in clinically detected ipsilateral internal mammary lymph nodes in the presence of one or more positive level I, II axillary lymph nodes; or in more than three axillary lymph nodes and in internal mammary lymph nodes with micrometastases or macrometastases detected by sentinel lymph node biopsy but not clinically detected; or in ipsilateral supraclavicular lymph nodes"}
+// ];
 const table7thEdition = [
   // N0 , N1mi , N1 ,  N2  , N3
     ['0', null, null, null, 'IIIC'], // Tis

--- a/lib/staging_lookup.js
+++ b/lib/staging_lookup.js
@@ -60,7 +60,7 @@ const table6thEdition = [
 // 7th Edition:
 // https://cancerstaging.org/references-tools/quickreferences/Documents/BreastMedium.pdf
 
-// const ts7thEdition = ['T1', 'T2', 'T3', 'T4']; //original array
+// const ts7thEdition = ['TIS', 'T0', 'T1', 'T2', 'T3', 'T4']; //original array
 const ts7thEdition = [
     {name: 'TIS', description: "Carcinoma in situ"},
     {name: 'T0', description: "No evidence of primary tumor"},
@@ -99,6 +99,31 @@ exports.getTsForEdition = (ed) => {
     return [];
 };
 
+// Returns just the names of the T values(without the tool tip text)
+exports.getTsNamesForEdition = (ed) => {
+    switch (ed) {
+        case 5:
+            var namesArray = [];
+            for (var i = 0; i < ts5thEdition.length; i++) {
+                namesArray.push(ts5thEdition[i].name);
+            }
+            return namesArray;
+        case 6:
+            var namesArray = [];
+            for (var i = 0; i < ts6thEdition.length; i++) {
+                namesArray.push(ts6thEdition[i].name);
+            }
+            return namesArray;
+        case 7:
+            var namesArray = [];
+            for (var i = 0; i < ts7thEdition.length; i++) {
+                namesArray.push(ts7thEdition[i].name);
+            }
+            return namesArray;
+    }
+    return [];
+}
+
 exports.getNsForEdition = (ed) => {
     switch (ed) {
     case 5:
@@ -110,6 +135,31 @@ exports.getNsForEdition = (ed) => {
     }
     return [];
 };
+
+// Returns just the names of the N values(without the tool tip text)
+exports.getNsNamesForEdition = (ed) => {
+    switch (ed) {
+        case 5:
+            var namesArray = [];
+            for (var i = 0; i < ns5thEdition.length; i++) {
+                namesArray.push(ns5thEdition[i].name);
+            }
+            return namesArray;
+        case 6:
+            var namesArray = [];
+            for (var i = 0; i < ns6thEdition.length; i++) {
+                namesArray.push(ns6thEdition[i].name);
+            }
+            return namesArray;
+        case 7:
+            var namesArray = [];
+            for (var i = 0; i < ns7thEdition.length; i++) {
+                namesArray.push(ns7thEdition[i].name);
+            }
+            return namesArray;
+    }
+    return [];
+}
 
 exports.getTableForEdition = (ed) => {
     switch (ed) {

--- a/lib/staging_lookup.js
+++ b/lib/staging_lookup.js
@@ -29,7 +29,16 @@ const table6thEdition = [
 
 // 7th Edition:
 // https://cancerstaging.org/references-tools/quickreferences/Documents/BreastMedium.pdf
-const ts7thEdition = ['TIS', 'T0', 'T1', 'T2', 'T3', 'T4'];
+const ts7thEdition = [
+    {name: 'TIS', description: "Carcinoma in situ"},
+    {name: 'T0', description: "No evidence of primary tumor"},
+    {name: 'T1', description: "Tumor ≤ 1 mm in greatest dimension"},
+    {name: 'T2', description: "Tumor > 20 mm but ≤ 50 mm in greatest dimension"},
+    {name: 'T3', description: "Tumor > 50 mm in greatest dimension"},
+    {name: 'T4', description: "Tumor of any size with direct extension to the chest wall and/or to the skin (ulceration or skin nodules)"}
+    // original ts7thEdition
+    // {'T1', 'T2', 'T3', 'T4'}
+];
 const ns7thEdition = ['N0', 'N1MI', 'N1', 'N2', 'N3'];
 const table7thEdition = [
   // N0 , N1mi , N1 ,  N2  , N3

--- a/lib/staging_lookup.js
+++ b/lib/staging_lookup.js
@@ -2,16 +2,23 @@
 
 // 5th Edition, p.174:
 // https://cancerstaging.org/references-tools/deskreferences/Documents/AJCC5thEdCancerStagingManual.pdf
-const ts5thEdition = ['T0', 'T1', 'T2', 'T3', 'T4'];
-// const ts5thEdition = [
-//     {name: 'TIS', description: "Carcinoma in situ"},
-//     {name: 'T0', description: "No evidence of primary tumor"},
-//     {name: 'T1', description: "Tumor ≤ 20 mm in greatest dimension"},
-//     {name: 'T2', description: "20 mm < Tumor ≤ 50 mm in greatest dimension"},
-//     {name: 'T3', description: "Tumor > 50 mm in greatest dimension"},
-//     {name: 'T4', description: "Tumor of any size with direct extension to the chest wall and/or to the skin (ulceration or skin nodules)"}
-// ];
-const ns5thEdition = ['N0', 'N1', 'N2', 'N3'];
+// const ts5thEdition = ['T0', 'T1', 'T2', 'T3', 'T4'];
+const ts5thEdition = [
+    {name: 'TIS', description: "Carcinoma in situ"},
+    {name: 'T0', description: "No evidence of primary tumor"},
+    {name: 'T1', description: "Tumor ≤ 20 mm in greatest dimension"},
+    {name: 'T2', description: "20 mm < Tumor ≤ 50 mm in greatest dimension"},
+    {name: 'T3', description: "Tumor > 50 mm in greatest dimension"},
+    {name: 'T4', description: "Tumor of any size with direct extension to the chest wall and/or to the skin (ulceration or skin nodules)"}
+];
+// const ns5thEdition = ['N0', 'N1', 'N2', 'N3'];
+const ns5thEdition = [
+    {name: 'N0', description: "No regional lymph node metastasis"},
+    {name: 'N1', description: "Metastasis to movable ipsilateral axillary lypmh node(s)"},
+    {name: 'N2', description: "Metastasis to ipsilateral axillary lymph node(s) fixed to one another or to other structures"},
+    {name: 'N3', description: "Metastasis to ipsilateral internal mammary lymph node(s)"}
+];
+
 const table5thEdition = [
   // N0 , N1 ,  N2  , N3
     [null, 'IIA', 'IIIA', 'IIIB'], // T0
@@ -24,16 +31,22 @@ const table5thEdition = [
 // 6th Edition, p.228:
 // https://cancerstaging.org/references-tools/deskreferences/Documents/AJCC6thEdCancerStagingManualPart2.pdf
 
-const ts6thEdition = ['TIS', 'T0', 'T1', 'T2', 'T3', 'T4']; //original array
-// const ts6thEdition = [
-//     {name: 'TIS', description: "Carcinoma in situ"},
-//     {name: 'T0', description: "No evidence of primary tumor"},
-//     {name: 'T1', description: "Tumor ≤ 20 mm in greatest dimension"},
-//     {name: 'T2', description: "20 mm < Tumor ≤ 50 mm in greatest dimension"},
-//     {name: 'T3', description: "Tumor > 50 mm in greatest dimension"},
-//     {name: 'T4', description: "Tumor of any size with direct extension to the chest wall and/or to the skin (ulceration or skin nodules)"}
-// ];
-const ns6thEdition = ['N0', 'N1', 'N2', 'N3'];
+// const ts6thEdition = ['TIS', 'T0', 'T1', 'T2', 'T3', 'T4']; //original array
+const ts6thEdition = [
+    {name: 'TIS', description: "Carcinoma in situ"},
+    {name: 'T0', description: "No evidence of primary tumor"},
+    {name: 'T1', description: "Tumor ≤ 20 mm in greatest dimension"},
+    {name: 'T2', description: "20 mm < Tumor ≤ 50 mm in greatest dimension"},
+    {name: 'T3', description: "Tumor > 50 mm in greatest dimension"},
+    {name: 'T4', description: "Tumor of any size with direct extension to the chest wall and/or to the skin (ulceration or skin nodules)"}
+];
+// const ns6thEdition = ['N0', 'N1', 'N2', 'N3'];
+const ns6thEdition = [
+    {name: 'N0', description: "No regional lymph node metastasis"},
+    {name: 'N1', description: "Metastasis to movable ipsilateral axillary lymph node(s)"},
+    {name: 'N2', description: "Metastases in ipsilateral axillary lymph nodes fixed or matted, or in clinically apparent ipsilaterial internal mammary nodes in the absence of clinically evident axillary lymph node metastasis"},
+    {name: 'N3', description: "Metastasis in ipsilateral infraclavicular lymph node(s) with or without axillary lymph node involvement, or in clinically apparent ipsilateral internal mammary lymph node(s) and in the presence of clinically evident axiillary lymph node metastasis; or metastasis in ipsilateral supraclavicular lymph node(s) with or without axillary or internal mammary node involvement"}
+];
 const table6thEdition = [
   // N0 , N1 ,  N2  , N3
     ['0', null, null, 'IIIC'], // Tis
@@ -56,14 +69,14 @@ const ts7thEdition = [
     {name: 'T3', description: "Tumor > 50 mm in greatest dimension"},
     {name: 'T4', description: "Tumor of any size with direct extension to the chest wall and/or to the skin (ulceration or skin nodules)"}
 ];
-const ns7thEdition = ['N0', 'N1MI', 'N1', 'N2', 'N3'];
-// const ns7thEdition = [
-//     {name: 'N0', description: "No regional lymph node metastases"},
-//     {name: 'N1MI', description: "Micrometastases (greater than 0.2 mm and/or more than 200 cells, but none greater than 2.0 mm)"},
-//     {name: 'N1', description: "Micrometastases; or metastases in 1–3 axillary lymph nodes; and/or in internal mammary nodes with metastases detected by sentinel lymph node biopsy but not clinically detected"},
-//     {name: 'N2', description: "Metastases in 4–9 axillary lymph nodes; or in clinically detected internal mammary lymph nodes in the absence of axillary lymph node metastases"},
-//     {name: 'N3', description: "Metastases in 10 or more axillary lymph nodes; or in infraclavicular (level III axillary) lymph nodes; or in clinically detected ipsilateral internal mammary lymph nodes in the presence of one or more positive level I, II axillary lymph nodes; or in more than three axillary lymph nodes and in internal mammary lymph nodes with micrometastases or macrometastases detected by sentinel lymph node biopsy but not clinically detected; or in ipsilateral supraclavicular lymph nodes"}
-// ];
+// const ns7thEdition = ['N0', 'N1MI', 'N1', 'N2', 'N3'];
+const ns7thEdition = [
+    {name: 'N0', description: "No regional lymph node metastases"},
+    {name: 'N1MI', description: "Micrometastases (greater than 0.2 mm and/or more than 200 cells, but none greater than 2.0 mm)"},
+    {name: 'N1', description: "Micrometastases; or metastases in 1–3 axillary lymph nodes; and/or in internal mammary nodes with metastases detected by sentinel lymph node biopsy but not clinically detected"},
+    {name: 'N2', description: "Metastases in 4–9 axillary lymph nodes; or in clinically detected internal mammary lymph nodes in the absence of axillary lymph node metastases"},
+    {name: 'N3', description: "Metastases in 10 or more axillary lymph nodes; or in infraclavicular (level III axillary) lymph nodes; or in clinically detected ipsilateral internal mammary lymph nodes in the presence of one or more positive level I, II axillary lymph nodes; or in more than three axillary lymph nodes and in internal mammary lymph nodes with micrometastases or macrometastases detected by sentinel lymph node biopsy but not clinically detected; or in ipsilateral supraclavicular lymph nodes"}
+];
 const table7thEdition = [
   // N0 , N1mi , N1 ,  N2  , N3
     ['0', null, null, null, 'IIIC'], // Tis

--- a/src/StagingForm.css
+++ b/src/StagingForm.css
@@ -32,3 +32,41 @@
   font-size: 26px !important;
   margin-bottom: 20px;
 }
+
+.tooltip {
+    position: relative;
+    display: inline-block;
+}
+
+.tooltip .tooltiptext {
+    visibility: hidden;
+    width: 120px;
+    background-color: #555;
+    color: #fff;
+    text-align: center;
+    border-radius: 6px;
+    padding: 5px 0;
+    position: absolute;
+    z-index: 1;
+    bottom: 125%;
+    left: 50%;
+    margin-left: -60px;
+    opacity: 0;
+    transition: opacity 1s;
+}
+
+.tooltip .tooltiptext::after {
+    content: "";
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    margin-left: -5px;
+    border-width: 5px;
+    border-style: solid;
+    border-color: #555 transparent transparent transparent;
+}
+
+.tooltip:hover .tooltiptext {
+    visibility: visible;
+    opacity: 1;
+}

--- a/src/StagingForm.css
+++ b/src/StagingForm.css
@@ -53,6 +53,7 @@
     margin-left: -60px;
     opacity: 0;
     transition: opacity 1s;
+    font-size: .8rem;
 }
 
 .tooltip .tooltiptext::after {

--- a/src/StagingForm.css
+++ b/src/StagingForm.css
@@ -40,12 +40,12 @@
 
 .tooltip .tooltiptext {
     visibility: hidden;
-    width: 120px;
+    width: 150px;
     background-color: #555;
     color: #fff;
     text-align: center;
     border-radius: 6px;
-    padding: 5px 0;
+    padding: 10px 10px;
     position: absolute;
     z-index: 1;
     bottom: 125%;

--- a/src/StagingForm.css
+++ b/src/StagingForm.css
@@ -56,6 +56,10 @@
     font-size: .8rem;
 }
 
+.tooltip #T4, .tooltip #N1, .tooltip #N2, .tooltip #N3, .tooltip #M1 {
+    width: 200px !important;
+}
+
 .tooltip .tooltiptext::after {
     content: "";
     position: absolute;

--- a/src/StagingForm.css
+++ b/src/StagingForm.css
@@ -69,4 +69,5 @@
 .tooltip:hover .tooltiptext {
     visibility: visible;
     opacity: 1;
+    transition-delay: 0.5s;
 }

--- a/src/StagingForm.jsx
+++ b/src/StagingForm.jsx
@@ -19,7 +19,10 @@ class StagingForm extends Component {
       this.state = {
         tumorSizes: lookup.getTsForEdition(7),
         nodes: lookup.getNsForEdition(7),
-        metastases: ['M0', 'M1']
+        metastases: [
+            {name: 'M0', description: 'No clinical or radiographic evidence of distant metastases'},
+            {name: 'M1', description: 'Distant detectable metastases as determined by classic clinical and radiographic means and/or histologically proven larger than 0.2 mm'}
+        ]
       };
   }
 
@@ -29,22 +32,20 @@ class StagingForm extends Component {
 
   _handleTumorSizeClick = (e, i) => {
     e.preventDefault();
-    console.log("StagingForm._handleTumorSizeClick T=" + i);
-      console.log(this.state.tumorSizes);
-      console.log(this.state.tumorSizes[i]);
+    // console.log("StagingForm._handleTumorSizeClick T=" + i);
     this.props.onStagingTUpdate(this.state.tumorSizes[i].name);
   }
 
   _handleNodeClick = (e, i) => {
     e.preventDefault();
-    console.log("StagingForm._handleNodeClick N=" + i);
-    this.props.onStagingNUpdate(this.state.nodes[i]);
+    // console.log("StagingForm._handleNodeClick N=" + i);
+    this.props.onStagingNUpdate(this.state.nodes[i].name);
   }
 
   _handleMetastasisClick = (e, i) => {
     e.preventDefault();
     // console.log("StagingForm._handleMetastasisClick M=" + i);
-    this.props.onStagingMUpdate(this.state.metastases[i]);
+    this.props.onStagingMUpdate(this.state.metastases[i].name);
   }
 
   render() {
@@ -77,7 +78,6 @@ class StagingForm extends Component {
                                     disabled={this._currentlySelected(this.props.tumorSize, this.state.tumorSizes[i].name)}
                                 />
                                 </div>
-
                             );
                         })}
                     </Row>
@@ -87,13 +87,16 @@ class StagingForm extends Component {
                     <Row>
                         {this.state.nodes.map((n, i) => {
                             return (
+                                <div key={n.name} className="tooltip">
+                                    <span className="tooltiptext">{n.description}</span>
                                 <RaisedButton
                                     className="btn node"
                                     key={i}
-                                    label={n}
+                                    label={n.name}
                                     onClick={(e) => this._handleNodeClick(e, i)}
-                                    disabled={this._currentlySelected(this.props.nodeSize, this.state.nodes[i])}
+                                    disabled={this._currentlySelected(this.props.nodeSize, this.state.nodes[i].name)}
                                 />
+                                </div>
                             );
                         })}
                     </Row>
@@ -103,13 +106,17 @@ class StagingForm extends Component {
                     <Row>
                         {this.state.metastases.map((m, i) => {
                             return (
+                                <div key={m.name} className="tooltip">
+                                    <span className="tooltiptext">{m.description}</span>
                                 <RaisedButton
                                     className="btn metastasis"
                                     key={i}
-                                    label={m}
+                                    label={m.name}
                                     onClick={(e) => this._handleMetastasisClick(e, i)}
-                                    disabled={this._currentlySelected(this.props.metastasis, this.state.metastases[i])}
-                                />);
+                                    disabled={this._currentlySelected(this.props.metastasis, this.state.metastases[i].name)}
+                                />
+                                </div>
+                            );
                         })}
                     </Row>
                     <Row>

--- a/src/StagingForm.jsx
+++ b/src/StagingForm.jsx
@@ -29,13 +29,15 @@ class StagingForm extends Component {
 
   _handleTumorSizeClick = (e, i) => {
     e.preventDefault();
-    // console.log("StagingForm._handleTumorSizeClick T=" + i);
-    this.props.onStagingTUpdate(this.state.tumorSizes[i]);
+    console.log("StagingForm._handleTumorSizeClick T=" + i);
+      console.log(this.state.tumorSizes);
+      console.log(this.state.tumorSizes[i]);
+    this.props.onStagingTUpdate(this.state.tumorSizes[i].name);
   }
 
   _handleNodeClick = (e, i) => {
     e.preventDefault();
-    // console.log("StagingForm._handleNodeClick N=" + i);
+    console.log("StagingForm._handleNodeClick N=" + i);
     this.props.onStagingNUpdate(this.state.nodes[i]);
   }
 
@@ -72,7 +74,7 @@ class StagingForm extends Component {
                                     key={i}
                                     label={t.name}
                                     onClick={(e) => this._handleTumorSizeClick(e, i)}
-                                    disabled={this._currentlySelected(this.props.tumorSize, this.state.tumorSizes[i])}
+                                    disabled={this._currentlySelected(this.props.tumorSize, this.state.tumorSizes[i].name)}
                                 />
                                 </div>
 

--- a/src/StagingForm.jsx
+++ b/src/StagingForm.jsx
@@ -65,12 +65,12 @@ class StagingForm extends Component {
                     <Row>
                         {this.state.tumorSizes.map((t, i) => {
                             return (
-                                <div key={t} className="tooltip">
-                                    <span className="tooltiptext">some text</span>
+                                <div key={t.name} className="tooltip">
+                                    <span className="tooltiptext">{t.description}</span>
                                 <RaisedButton
                                     className="btn tumor-size"
                                     key={i}
-                                    label={t}
+                                    label={t.name}
                                     onClick={(e) => this._handleTumorSizeClick(e, i)}
                                     disabled={this._currentlySelected(this.props.tumorSize, this.state.tumorSizes[i])}
                                 />

--- a/src/StagingForm.jsx
+++ b/src/StagingForm.jsx
@@ -69,7 +69,7 @@ class StagingForm extends Component {
                         {this.state.tumorSizes.map((t, i) => {
                             return (
                                 <div key={t.name} className="tooltip">
-                                    <span className="tooltiptext">{t.description}</span>
+                                    <span id={t.name} className="tooltiptext">{t.description}</span>
                                 <RaisedButton
                                     className="btn tumor-size"
                                     key={i}
@@ -88,7 +88,7 @@ class StagingForm extends Component {
                         {this.state.nodes.map((n, i) => {
                             return (
                                 <div key={n.name} className="tooltip">
-                                    <span className="tooltiptext">{n.description}</span>
+                                    <span id={n.name} className="tooltiptext">{n.description}</span>
                                 <RaisedButton
                                     className="btn node"
                                     key={i}
@@ -107,7 +107,7 @@ class StagingForm extends Component {
                         {this.state.metastases.map((m, i) => {
                             return (
                                 <div key={m.name} className="tooltip">
-                                    <span className="tooltiptext">{m.description}</span>
+                                    <span id={m.name} className="tooltiptext">{m.description}</span>
                                 <RaisedButton
                                     className="btn metastasis"
                                     key={i}

--- a/src/StagingForm.jsx
+++ b/src/StagingForm.jsx
@@ -65,7 +65,7 @@ class StagingForm extends Component {
                     <Row>
                         {this.state.tumorSizes.map((t, i) => {
                             return (
-                                <div className="tooltip">
+                                <div key={t} className="tooltip">
                                     <span className="tooltiptext">some text</span>
                                 <RaisedButton
                                     className="btn tumor-size"

--- a/src/StagingForm.jsx
+++ b/src/StagingForm.jsx
@@ -65,6 +65,8 @@ class StagingForm extends Component {
                     <Row>
                         {this.state.tumorSizes.map((t, i) => {
                             return (
+                                <div className="tooltip">
+                                    <span className="tooltiptext">some text</span>
                                 <RaisedButton
                                     className="btn tumor-size"
                                     key={i}
@@ -72,6 +74,8 @@ class StagingForm extends Component {
                                     onClick={(e) => this._handleTumorSizeClick(e, i)}
                                     disabled={this._currentlySelected(this.props.tumorSize, this.state.tumorSizes[i])}
                                 />
+                                </div>
+
                             );
                         })}
                     </Row>


### PR DESCRIPTION
Added tool tips to the buttons in the right panel so that when users hover over the buttons, additional information about that value is displayed.

- Added descriptions (text displayed in tool tips) to the T map, N map, and M map. Updated all editions (5th, 6th, and 7th) based on cancer staging manual pdfs referenced in staging_lookup.js

- Updated variables in StagingForm.jsx to make sure data bindings still work (updating staging information)

Please note:

- For some of the buttons, the tool tip text is VERY long (i.e T4, N1, N2, N3, M1). For the text, I copied and pasted the information from the breast cancer pdf. I don't know how much of the text is actually needed by clinicians. There are some options for handling the long text: cut down on the amount of text displayed (need to make sure we aren't removing anything essential) or instead of a tool tip make a help/info icon that when clicked opens a modal dialogue that displays all of the text

- I am open to other styling ideas and suggestions for the tool tips  