### PR TITLE
remove note header from editor panel when in no-patient mode

### DIFF
--- a/src/notes/ClinicalNotes.jsx
+++ b/src/notes/ClinicalNotes.jsx
@@ -60,9 +60,13 @@ class ClinicalNotes extends Component {
   }
 
   render() {
-    return (
-      <div id="clinical-notes" className="dashboard-panel">
-        <Paper className="panel-content trio">
+  
+  
+    let noteDescriptionContent = null;
+    if (this.props.patient == null) {
+        noteDescriptionContent = "";
+    } else {
+        noteDescriptionContent = (
           <div id="note-description">
             <Row>
               <Col xs={5}>
@@ -81,9 +85,15 @@ class ClinicalNotes extends Component {
                 <p className="note-description-detail-value">Dr. Brenda Zeiweger</p>
               </Col>
             </Row>
+  
+			<Divider className="divider" />
           </div>
-
-          <Divider className="divider" />
+        );
+    }
+    return (
+      <div id="clinical-notes" className="dashboard-panel">
+        <Paper className="panel-content trio">
+		  {noteDescriptionContent}
 
           <MyEditor
             // Update functions

--- a/src/views/FullApp.jsx
+++ b/src/views/FullApp.jsx
@@ -339,6 +339,7 @@ class FullApp extends Component {
                                     ERStatus={this.state.ERStatus}
                                     PRStatus={this.state.PRStatus}
                                     itemToBeInserted={this.state.SummaryItemToInsert}
+                                    patient={this.state.patient}
                                 />
                             </Col>
                             <Col sm={3}>


### PR DESCRIPTION
pass patient to clinical editor component and use as trigger for whether to include patient header or not.