### PR TITLE
Right panel data element capture form

### DIFF
--- a/src/forms/DataCaptureForm.css
+++ b/src/forms/DataCaptureForm.css
@@ -1,0 +1,5 @@
+.btn_template {
+  float: left;
+  clear: left;
+  margin-bottom: 20px;
+}

--- a/src/forms/DataCaptureForm.jsx
+++ b/src/forms/DataCaptureForm.jsx
@@ -54,7 +54,7 @@ class DataCaptureForm extends Component {
         }
 
         return (
-            <Paper className="panel-content trio">
+            <div>
                 <h1>Data Capture</h1>
                 <Divider className="divider"/>
                 <div>
@@ -72,7 +72,8 @@ class DataCaptureForm extends Component {
                 </div>
                 <Divider className="divider"/>
                 {content}
-            </Paper>
+            </div>
+
 
         );
     }

--- a/src/forms/DataCaptureForm.jsx
+++ b/src/forms/DataCaptureForm.jsx
@@ -1,5 +1,7 @@
 // React imports
-import React, { Component } from 'react';
+import React, {Component} from 'react';
+// Our components
+import StagingForm from './StagingForm';
 // material-ui
 import Paper from 'material-ui/Paper';
 import DropDownMenu from 'material-ui/DropDownMenu';
@@ -9,22 +11,71 @@ import Divider from 'material-ui/Divider';
 // Styling
 import './DataCaptureForm.css';
 
+const styles = {
+    customWidth: {
+        width: 250
+    },
+};
+
 class DataCaptureForm extends Component {
-  constructor(props) {
+
+    constructor(props) {
         super(props);
         this.state = {
-            dropdownValue: 1
+            value: 1
         };
-  }
+    }
 
-  render() {
-    return (
-        <Paper className="panel-content trio">
-            <h1>Data Capture</h1>
-            <Divider className="divider"/>
-        </Paper>
-    );
-  }
+    handleChange = (event, index, value) => {
+        this.setState({value});
+    }
+
+    render() {
+        let content = null;
+
+        if (this.state.value === 2) {
+            content = (
+                <StagingForm
+                    onStagingTUpdate={this.props.onStagingTUpdate}
+                    onStagingNUpdate={this.props.onStagingNUpdate}
+                    onStagingMUpdate={this.props.onStagingMUpdate}
+                    onStageUpdate={this.props.onStageUpdate}
+
+                    calculateStage={this.props.calculateStage}
+
+                    tumorSize={this.props.tumorSize}
+                    nodeSize={this.props.nodeSize}
+                    metastasis={this.props.metastasis}
+                    stage={this.props.stage}
+                />
+            );
+        } else {
+            content = <p>Nothing to show</p>
+        }
+
+        return (
+            <Paper className="panel-content trio">
+                <h1>Data Capture</h1>
+                <Divider className="divider"/>
+                <div>
+                    <DropDownMenu
+                        value={this.state.value}
+                        onChange={this.handleChange}
+                        style={styles.customWidth}
+                        autoWidth={false}
+                    >
+                        <MenuItem value={1} primaryText="<Select Missing Data>"/>
+                        <MenuItem value={2} primaryText="Staging"/>
+                        <MenuItem value={3} primaryText="Progression"/>
+                        <MenuItem value={4} primaryText="Toxicity"/>
+                    </DropDownMenu>
+                </div>
+                <Divider className="divider"/>
+                {content}
+            </Paper>
+
+        );
+    }
 
 }
 export default DataCaptureForm;

--- a/src/forms/DataCaptureForm.jsx
+++ b/src/forms/DataCaptureForm.jsx
@@ -2,7 +2,9 @@
 import React, { Component } from 'react';
 // material-ui
 import Paper from 'material-ui/Paper';
-import RaisedButton from 'material-ui/RaisedButton';
+import DropDownMenu from 'material-ui/DropDownMenu';
+import MenuItem from 'material-ui/MenuItem';
+
 import Divider from 'material-ui/Divider';
 // Styling
 import './DataCaptureForm.css';
@@ -10,9 +12,8 @@ import './DataCaptureForm.css';
 class DataCaptureForm extends Component {
   constructor(props) {
         super(props);
-
         this.state = {
-
+            dropdownValue: 1
         };
   }
 

--- a/src/forms/DataCaptureForm.jsx
+++ b/src/forms/DataCaptureForm.jsx
@@ -1,0 +1,29 @@
+// React imports
+import React, { Component } from 'react';
+// material-ui
+import Paper from 'material-ui/Paper';
+import RaisedButton from 'material-ui/RaisedButton';
+import Divider from 'material-ui/Divider';
+// Styling
+import './DataCaptureForm.css';
+
+class DataCaptureForm extends Component {
+  constructor(props) {
+        super(props);
+
+        this.state = {
+
+        };
+  }
+
+  render() {
+    return (
+        <Paper className="panel-content trio">
+            <h1>Data Capture</h1>
+            <Divider className="divider"/>
+        </Paper>
+    );
+  }
+
+}
+export default DataCaptureForm;

--- a/src/forms/DataCaptureForm.jsx
+++ b/src/forms/DataCaptureForm.jsx
@@ -3,7 +3,6 @@ import React, {Component} from 'react';
 // Our components
 import StagingForm from './StagingForm';
 // material-ui
-import Paper from 'material-ui/Paper';
 import DropDownMenu from 'material-ui/DropDownMenu';
 import MenuItem from 'material-ui/MenuItem';
 
@@ -73,10 +72,7 @@ class DataCaptureForm extends Component {
                 <Divider className="divider"/>
                 {content}
             </div>
-
-
         );
     }
-
 }
 export default DataCaptureForm;

--- a/src/forms/FormTray.jsx
+++ b/src/forms/FormTray.jsx
@@ -20,7 +20,7 @@ class FormTray extends Component {
         if (this.props.withinStructuredField == null) {
             //console.log("FormTray. selectedText = " + this.props.selectedText);
 
-            // When select text in the notes section, change the panel content
+            // When highlighting text in the notes section, change the panel content to display the data capture form
             if (this.props.selectedText != null) {
 
                 panelContent = (

--- a/src/forms/FormTray.jsx
+++ b/src/forms/FormTray.jsx
@@ -42,7 +42,21 @@ class FormTray extends Component {
             );
         } else {
             panelContent = (
-              <DataCaptureForm/>
+              <DataCaptureForm
+
+                  // Staging Form data
+                  onStagingTUpdate={this.props.onStagingTUpdate}
+                  onStagingNUpdate={this.props.onStagingNUpdate}
+                  onStagingMUpdate={this.props.onStagingMUpdate}
+                  onStageUpdate={this.props.onStageUpdate}
+
+                  calculateStage={this.props.calculateStage}
+
+                  tumorSize={this.props.tumorSize}
+                  nodeSize={this.props.nodeSize}
+                  metastasis={this.props.metastasis}
+                  stage={this.props.stage}
+              />
             );
         }
     }

--- a/src/forms/FormTray.jsx
+++ b/src/forms/FormTray.jsx
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 // Our components
 import StagingForm from './StagingForm';
 import TemplateForm from './TemplateForm';
+import DataCaptureForm from './DataCaptureForm';
 // Styling
 import './FormTray.css';
 
@@ -19,22 +20,29 @@ class FormTray extends Component {
             <TemplateForm />
         );
     } else {
-        panelContent = (
-            <StagingForm
-                // Update functions
-                onStagingTUpdate={this.props.onStagingTUpdate}
-                onStagingNUpdate={this.props.onStagingNUpdate}
-                onStagingMUpdate={this.props.onStagingMUpdate}
-                onStageUpdate={this.props.onStageUpdate}
-                // Helper functions
-                calculateStage={this.props.calculateStage}
-                // Properties
-                tumorSize={this.props.tumorSize}
-                nodeSize={this.props.nodeSize}
-                metastasis={this.props.metastasis}
-                stage={this.props.stage}
-            />
-        );
+
+        if (this.props.withinStructuredField === "staging") {
+            panelContent = (
+                <StagingForm
+                    // Update functions
+                    onStagingTUpdate={this.props.onStagingTUpdate}
+                    onStagingNUpdate={this.props.onStagingNUpdate}
+                    onStagingMUpdate={this.props.onStagingMUpdate}
+                    onStageUpdate={this.props.onStageUpdate}
+                    // Helper functions
+                    calculateStage={this.props.calculateStage}
+                    // Properties
+                    tumorSize={this.props.tumorSize}
+                    nodeSize={this.props.nodeSize}
+                    metastasis={this.props.metastasis}
+                    stage={this.props.stage}
+                />
+            );
+        } else {
+            panelContent = (
+              <DataCaptureForm/>
+            );
+        }
     }
     return (
       <div id="forms-panel" className="dashboard-panel">

--- a/src/forms/FormTray.jsx
+++ b/src/forms/FormTray.jsx
@@ -4,6 +4,8 @@ import React, {Component} from 'react';
 import StagingForm from './StagingForm';
 import TemplateForm from './TemplateForm';
 import DataCaptureForm from './DataCaptureForm';
+// material-ui
+import Paper from 'material-ui/Paper';
 // Styling
 import './FormTray.css';
 
@@ -23,7 +25,6 @@ class FormTray extends Component {
 
                 panelContent = (
                     <DataCaptureForm
-
                         // Staging Form data
                         onStagingTUpdate={this.props.onStagingTUpdate}
                         onStagingNUpdate={this.props.onStagingNUpdate}
@@ -67,7 +68,9 @@ class FormTray extends Component {
         }
         return (
             <div id="forms-panel" className="dashboard-panel">
+                <Paper className="panel-content trio">
                 {panelContent}
+                </Paper>
             </div>
         )
     }

--- a/src/forms/StagingForm.jsx
+++ b/src/forms/StagingForm.jsx
@@ -1,7 +1,6 @@
 // React imports
 import React, { Component } from 'react';
 // material-ui
-import Paper from 'material-ui/Paper';
 import Divider from 'material-ui/Divider';
 import RaisedButton from 'material-ui/RaisedButton';
 // Libraries

--- a/src/forms/StagingForm.jsx
+++ b/src/forms/StagingForm.jsx
@@ -46,7 +46,7 @@ class StagingForm extends Component {
   render() {
     // console.log("in render. t: " + this.props.t);
     return (
-        <Paper className="panel-content trio">
+       <div>
             <h1>Current Staging</h1>
             <Divider className="divider" />
 
@@ -100,7 +100,7 @@ class StagingForm extends Component {
 
             <h4>Prognostic Stage</h4>
             <div className="stage">{staging.breastCancerPrognosticStage(this.props.tumorSize, this.props.nodeSize, this.props.metastasis) || 'Undefined'}</div>
-        </Paper>
+        </div>
     );
   }
 }

--- a/src/forms/TemplateForm.jsx
+++ b/src/forms/TemplateForm.jsx
@@ -1,7 +1,6 @@
 // React imports
 import React, { Component } from 'react';
 // material-ui
-import Paper from 'material-ui/Paper';
 import RaisedButton from 'material-ui/RaisedButton';
 import Divider from 'material-ui/Divider';
 // Styling

--- a/src/forms/TemplateForm.jsx
+++ b/src/forms/TemplateForm.jsx
@@ -28,7 +28,7 @@ class TemplateForm extends Component {
 
   render() {
     return (
-        <Paper className="panel-content trio">
+       <div>
             <h1>{this.state.heading}</h1>
             <Divider className="divider"/>
             {this.state.templates.map((t, i) => {
@@ -41,7 +41,7 @@ class TemplateForm extends Component {
                     />
                 );
             })}
-        </Paper>
+        </div>
     );
   }
 

--- a/src/nav/NavBar.jsx
+++ b/src/nav/NavBar.jsx
@@ -35,20 +35,6 @@ class NavBar extends Component {
     this.props.onStructuredFieldExited("staging");
   }
 
-  handleEnterDataCapture() {
-    this.setState({
-      open: false
-    });
-    this.props.onStructuredFieldEntered("dataCapture");
-  }
-
-  handleExitDataCapture() {
-    this.setState({
-      open: false
-    });
-    this.props.onStructuredFieldExited("dataCapture");
-  }
-
   render() {
     return (
       <div>
@@ -62,8 +48,6 @@ class NavBar extends Component {
          >
           <MenuItem onTouchTap={this.handleEnterStaging.bind(this)}>Enter Staging</MenuItem>
           <MenuItem onTouchTap={this.handleExitStaging.bind(this)}>Exit Staging</MenuItem>
-          <MenuItem onTouchTap={this.handleEnterDataCapture.bind(this)}>Enter Data Capture</MenuItem>
-          <MenuItem onTouchTap={this.handleExitDataCapture.bind(this)}>Exit Data Capture</MenuItem>
         </Drawer>
       </div>
     );

--- a/src/nav/NavBar.jsx
+++ b/src/nav/NavBar.jsx
@@ -10,7 +10,10 @@ class NavBar extends Component {
 
   constructor(props) {
     super(props);
-    this.state = {open: false};
+    this.state = {
+      open: false,
+      openDataCapture: false
+    };
   }
 
   toggleDrawer() {
@@ -33,6 +36,20 @@ class NavBar extends Component {
     this.props.onStructuredFieldExited("staging");
   }
 
+  handleEnterDataCapture() {
+    this.setState({
+      openDataCapture: false
+    });
+    this.props.onStructuredFieldEntered("dataCapture");
+  }
+
+  handleExitDataCapture() {
+    this.setState({
+      openDataCapture: false
+    });
+    this.props.onStructuredFieldExited("dataCapture");
+  }
+
   render() {
     return (
       <div>
@@ -42,9 +59,12 @@ class NavBar extends Component {
           title="Flux Notes"/>
         <Drawer
           containerStyle={{'top': '64px'}}
-          open={this.state.open}>
+          open={this.state.open}
+          openDataCapture={this.state.openDataCapture}>
           <MenuItem onTouchTap={this.handleEnterStaging.bind(this)}>Enter Staging</MenuItem>
           <MenuItem onTouchTap={this.handleExitStaging.bind(this)}>Exit Staging</MenuItem>
+          <MenuItem onTouchTap={this.handleEnterDataCapture.bind(this)}>Enter Data Capture</MenuItem>
+          <MenuItem onTouchTap={this.handleExitDataCapture.bind(this)}>Exit Data Capture</MenuItem>
         </Drawer>
       </div>
     );

--- a/src/nav/NavBar.jsx
+++ b/src/nav/NavBar.jsx
@@ -11,8 +11,7 @@ class NavBar extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      open: false,
-      openDataCapture: false
+      open: false
     };
   }
 
@@ -38,14 +37,14 @@ class NavBar extends Component {
 
   handleEnterDataCapture() {
     this.setState({
-      openDataCapture: false
+      open: false
     });
     this.props.onStructuredFieldEntered("dataCapture");
   }
 
   handleExitDataCapture() {
     this.setState({
-      openDataCapture: false
+      open: false
     });
     this.props.onStructuredFieldExited("dataCapture");
   }
@@ -60,7 +59,7 @@ class NavBar extends Component {
         <Drawer
           containerStyle={{'top': '64px'}}
           open={this.state.open}
-          openDataCapture={this.state.openDataCapture}>
+         >
           <MenuItem onTouchTap={this.handleEnterStaging.bind(this)}>Enter Staging</MenuItem>
           <MenuItem onTouchTap={this.handleExitStaging.bind(this)}>Exit Staging</MenuItem>
           <MenuItem onTouchTap={this.handleEnterDataCapture.bind(this)}>Enter Data Capture</MenuItem>


### PR DESCRIPTION
- In patient mode, when user highlights/selects text in clinical notes, the data capture form is displayed

- User selects what type of data is missing from the drop down. Currently selecting progression and toxicity does not bring up the point of sales displays since they have not yet been created. 

- Selecting staging as the missing data brings up the staging form within the data capture panel

- Staging form within the data capture panel works and updates staging information in the summary panel and the inline helper

- Updating the staging information in the notes also updates the staging form in the data capture panel