### PR TITLE
Added copy button to editor tool bar

### DIFF
--- a/src/notes/ClinicalNotes.jsx
+++ b/src/notes/ClinicalNotes.jsx
@@ -131,6 +131,7 @@ class ClinicalNotes extends Component {
             metastasis={this.props.metastasis}
             data={{patient: {name: 'Debra Hernandez672', age: '51', gender: 'female'}}}
             itemToBeInserted={this.props.itemToBeInserted}
+            patient={this.props.patient}
 
           />
         </Paper>

--- a/src/notes/EditorToolbar.css
+++ b/src/notes/EditorToolbar.css
@@ -57,3 +57,11 @@
   margin: 10px 0;
   width: 100%;  
 }
+
+#copy-button a {
+    color: #ccc;
+}
+
+#copy-button a:hover {
+    color: black;
+}

--- a/src/notes/EditorToolbar.jsx
+++ b/src/notes/EditorToolbar.jsx
@@ -2,103 +2,124 @@
 import React from 'react'
 // Font awesome for icons
 import 'font-awesome/css/font-awesome.min.css';
+// material-ui
+import RaisedButton from 'material-ui/RaisedButton';
 // Styling
 import './EditorToolbar.css';
 
 class EditorToolbar extends React.Component {
-  constructor(props) {
-    super(props);
-  }   
+    constructor(props) {
+        super(props);
+    }
 
-  handleMarkCheck = (type) =>  {
-    return this.props.onMarkCheck(type);
-  }
+    handleMarkCheck = (type) => {
+        return this.props.onMarkCheck(type);
+    }
 
-  handleBlockCheck = (type) =>  {
-    return this.props.onBlockCheck(type);
-  }
+    handleBlockCheck = (type) => {
+        return this.props.onBlockCheck(type);
+    }
 
-  handleMarkUpdate = (type) =>  {
-    return this.props.onMarkUpdate(type);
-  }
+    handleMarkUpdate = (type) => {
+        return this.props.onMarkUpdate(type);
+    }
 
-  handleBlockUpdate = (type) =>  {
-    return this.props.onBlockUpdate(type)
-  }
-  
-  /**
-   * When a mark button is clicked, toggle the current mark.
-   */
-  onClickMark = (e, type) => {
-    e.preventDefault()
-    this.handleMarkUpdate(type);
-  }
+    handleBlockUpdate = (type) => {
+        return this.props.onBlockUpdate(type)
+    }
 
-  /**
-   * When a block button is clicked, toggle the block type.
-   */
-  onClickBlock = (e, type) => {
-    e.preventDefault()
-    this.handleBlockUpdate(type);
-  }
+    handleCopyClick = (type) => {
+        console.log("clicked copy");
+    }
 
-  /**
-   * Render a mark-toggling toolbar button.
-   */
-  renderMarkButton = (type, icon) => {
-    const isActive = this.handleMarkCheck(type)
-    const onMouseDown = e => this.onClickMark(e, type)
+    /**
+     * When a mark button is clicked, toggle the current mark.
+     */
+    onClickMark = (e, type) => {
+        e.preventDefault()
+        this.handleMarkUpdate(type);
+    }
 
-    return (
-      <span className="button" onMouseDown={onMouseDown} data-active={isActive}>
+    /**
+     * When a block button is clicked, toggle the block type.
+     */
+    onClickBlock = (e, type) => {
+        e.preventDefault()
+        this.handleBlockUpdate(type);
+    }
+
+    /**
+     * Render a mark-toggling toolbar button.
+     */
+    renderMarkButton = (type, icon) => {
+        const isActive = this.handleMarkCheck(type)
+        const onMouseDown = e => this.onClickMark(e, type)
+
+        return (
+            <span className="button" onMouseDown={onMouseDown} data-active={isActive}>
         <i className={"fa fa-fw " + icon} aria-label={"Make text " + type}></i>
       </span>
-    )
-  }
-  /**
-   * Render a block-toggling toolbar button.
-   */
-  renderBlockButton = (type, icon) => {
-    const isActive = this.handleBlockCheck(type)
-    const onMouseDown = e => this.onClickBlock(e, type)
+        )
+    }
+    /**
+     * Render a block-toggling toolbar button.
+     */
+    renderBlockButton = (type, icon) => {
+        const isActive = this.handleBlockCheck(type)
+        const onMouseDown = e => this.onClickBlock(e, type)
 
-    return (
-      <span className="button" onMouseDown={onMouseDown} data-active={isActive}>
+        return (
+            <span className="button" onMouseDown={onMouseDown} data-active={isActive}>
         <i className={"fa fa-fw " + icon} aria-label={"Make text " + type}></i>
       </span>
-    )
-  }
-  /**
-   * Render the toolbar.
-   */
-  renderToolbar = () => {
-    return (
-      <div className="menu toolbar-menu">
-        {this.renderMarkButton('bold', 'fa-bold ')}
-        {this.renderMarkButton('italic', 'fa-italic')}
-        {this.renderMarkButton('underlined', 'fa-underline')}
-        {this.renderMarkButton('code', 'fa-code')}
-        {this.renderBlockButton('bulleted-list', 'fa-list')}
-        {this.renderBlockButton('numbered-list', 'fa-list-ol')}
-      </div>
-    )
-  }
+        )
+    }
+    /**
+     * Render the toolbar.
+     */
+    renderToolbar = () => {
+        return (
+            <div className="menu toolbar-menu">
+                {this.renderMarkButton('bold', 'fa-bold ')}
+                {this.renderMarkButton('italic', 'fa-italic')}
+                {this.renderMarkButton('underlined', 'fa-underline')}
+                {this.renderMarkButton('code', 'fa-code')}
+                {this.renderBlockButton('bulleted-list', 'fa-list')}
+                {this.renderBlockButton('numbered-list', 'fa-list-ol')}
+            </div>
+        )
+    }
 
-  /**
-   * Render the toolbar.
-   */
-  render = () => {
-    return (
-      <div className="menu toolbar-menu">
-        {this.renderMarkButton('bold', 'fa-bold ')}
-        {this.renderMarkButton('italic', 'fa-italic')}
-        {this.renderMarkButton('underlined', 'fa-underline')}
-        {this.renderMarkButton('code', 'fa-code')}
-        {this.renderBlockButton('bulleted-list', 'fa-list')}
-        {this.renderBlockButton('numbered-list', 'fa-list-ol')}
-      </div>
-    )
-  }
+    /**
+     * Render the toolbar.
+     */
+    render = () => {
+
+        let content = "";
+
+        if (this.props.patient == null) {
+            content = (
+                <span id="copy-button" style={{cursor:'pointer'}}>
+                <a onClick={(e) => this.handleCopyClick(e)}><i className="fa fa-files-o" aria-hidden="true"></i></a>
+                </span>
+            )
+
+        } else {
+            content = "";
+        }
+
+        return (
+            <div className="menu toolbar-menu">
+                {this.renderMarkButton('bold', 'fa-bold ')}
+                {this.renderMarkButton('italic', 'fa-italic')}
+                {this.renderMarkButton('underlined', 'fa-underline')}
+                {this.renderMarkButton('code', 'fa-code')}
+                {this.renderBlockButton('bulleted-list', 'fa-list')}
+                {this.renderBlockButton('numbered-list', 'fa-list-ol')}
+                {content}
+            </div>
+        )
+    }
 }
 
 export default EditorToolbar;

--- a/src/notes/MyEditor.jsx
+++ b/src/notes/MyEditor.jsx
@@ -991,6 +991,7 @@ class MyEditor extends React.Component {
 
           onMarkUpdate={this.handleMarkUpdate} 
           onBlockUpdate={this.handleBlockUpdate}
+          patient={this.props.patient}
         />
         {this.renderDropdown()}
         {this.renderShorthandDropdown()}


### PR DESCRIPTION
Added copy button to editor toolbar.

- Copy button only shows up when in no patient mode

- Added cursor change to pointer when user hovers over copy icon (consistent with the other buttons in the tool bar)

- Hovering over copy button changes copy icon from grey to black 

- Clicking the copy button currently outputs a console log ("clicked copy")

