### PR TITLE
Added hover over for insert buttons in summary panel 

### DIFF
--- a/src/summary/ConditionSelection.css
+++ b/src/summary/ConditionSelection.css
@@ -31,6 +31,7 @@
 
 .arrow a:hover {
     color: #666;
+    cursor: pointer;
 }
 
 /* Disable arrow */

--- a/src/summary/ConditionSelection.jsx
+++ b/src/summary/ConditionSelection.jsx
@@ -36,10 +36,10 @@ class ConditionSelection extends Component {
         <Divider className="divider" />
           <div className="selected-condition">
               <span className="title">{activeCondition.name}</span>
-              <span id="left-arrow" className={leftArrowClass} style={{cursor:'pointer'}}>
+              <span id="left-arrow" className={leftArrowClass}>
                   <a onClick={(e) => this.previousCondition(e)}><i className="fa fa-arrow-left"></i></a>
               </span>
-              <span id="right-arrow" className={rightArrowClass} style={{cursor:'pointer'}}>
+              <span id="right-arrow" className={rightArrowClass}>
                   <a onClick={(e) => this.nextCondition(e)}><i className="fa fa-arrow-right"></i></a>
               </span>
           </div>

--- a/src/summary/ConditionSelection.jsx
+++ b/src/summary/ConditionSelection.jsx
@@ -36,10 +36,10 @@ class ConditionSelection extends Component {
         <Divider className="divider" />
           <div className="selected-condition">
               <span className="title">{activeCondition.name}</span>
-              <span id="left-arrow" className={leftArrowClass}>
+              <span id="left-arrow" className={leftArrowClass} style={{cursor:'pointer'}}>
                   <a onClick={(e) => this.previousCondition(e)}><i className="fa fa-arrow-left"></i></a>
               </span>
-              <span id="right-arrow" className={rightArrowClass}>
+              <span id="right-arrow" className={rightArrowClass} style={{cursor:'pointer'}}>
                   <a onClick={(e) => this.nextCondition(e)}><i className="fa fa-arrow-right"></i></a>
               </span>
           </div>

--- a/src/summary/DataSummaryTable.css
+++ b/src/summary/DataSummaryTable.css
@@ -50,4 +50,8 @@ td.captured {
     color: #333;
     background-color: #d9ebf9;
 }
-    
+
+span.button-hover {
+    cursor: pointer;
+}
+

--- a/src/summary/DataSummaryTable.jsx
+++ b/src/summary/DataSummaryTable.jsx
@@ -75,7 +75,7 @@ class DataSummaryTable extends Component {
                         <tr key={i} className={rowClass}>
                             <td width="40%">{item.name}</td>
                             <td width="55%" className={itemClass}>{itemText}</td>
-                            <td width="5%" onClick={(e) => this.props.onItemClicked(itemText)}><span style={{cursor:'pointer'}}><i className="fa fa-plus-square fa-lg"></i></span></td>
+                            <td width="5%" onClick={(e) => this.props.onItemClicked(itemText)}><span className="button-hover"><i className="fa fa-plus-square fa-lg"></i></span></td>
                         </tr>
                     );
                 })}

--- a/src/summary/DataSummaryTable.jsx
+++ b/src/summary/DataSummaryTable.jsx
@@ -75,7 +75,7 @@ class DataSummaryTable extends Component {
                         <tr key={i} className={rowClass}>
                             <td width="40%">{item.name}</td>
                             <td width="55%" className={itemClass}>{itemText}</td>
-                            <td width="5%" onClick={(e) => this.props.onItemClicked(itemText)}><i className="fa fa-plus-square fa-lg"></i></td>
+                            <td width="5%" onClick={(e) => this.props.onItemClicked(itemText)}><span style={{cursor:'pointer'}}><i className="fa fa-plus-square fa-lg"></i></span></td>
                         </tr>
                     );
                 })}


### PR DESCRIPTION
When the user hovers over the insert buttons in the summary panel, the cursor changes to a pointer (similar behavior to the buttons). Also added cursor change to arrows in condition selection section of summary panel so that mouse cursor changes to pointer when hovering over the arrows.