### PR TITLE
Shortcut viewer component

### DIFF
--- a/src/viewer/ShortcutViewer.jsx
+++ b/src/viewer/ShortcutViewer.jsx
@@ -9,19 +9,21 @@ import './ShortcutViewer.css';
 class ShortcutViewer extends Component {
 
     render() {
+        let string = "";
 
         if (this.props.currentDataItem == null) {
-            console.log("current data item is null");
+            string = "Choose a template from the left panel";
         }
         else {
-            console.log("current data is not null");
-            console.log(this.props.currentDataItem);
+            if(this.props.currentDataItem.shortcut) {
+                string = this.props.currentDataItem.shortcut;
+            }
         }
         return (
             <div id="shortcut-viewer" className="dashboard-panel">
                 <Paper className="panel-content trio">
                     <div>
-                        This is where the shortcut preview goes
+                        {string}
                     </div>
                 </Paper>
             </div>

--- a/src/viewer/ShortcutViewer.jsx
+++ b/src/viewer/ShortcutViewer.jsx
@@ -1,0 +1,32 @@
+// React imports
+import React, {Component} from 'react';
+
+// material-ui
+import Paper from 'material-ui/Paper';
+// Styling
+import './ShortcutViewer.css';
+
+class ShortcutViewer extends Component {
+
+    render() {
+
+        if (this.props.currentDataItem == null) {
+            console.log("current data item is null");
+        }
+        else {
+            console.log("current data is not null");
+            console.log(this.props.currentDataItem);
+        }
+        return (
+            <div id="shortcut-viewer" className="dashboard-panel">
+                <Paper className="panel-content trio">
+                    <div>
+                        This is where the shortcut preview goes
+                    </div>
+                </Paper>
+            </div>
+        )
+    }
+}
+
+export default ShortcutViewer;

--- a/src/views/SlimApp.jsx
+++ b/src/views/SlimApp.jsx
@@ -23,7 +23,7 @@ class SlimApp extends Component {
         super(props);
 
         this.state = {
-            shortcut: null
+            currentShortcut: null
         };
     }
 

--- a/src/views/SlimApp.jsx
+++ b/src/views/SlimApp.jsx
@@ -7,7 +7,7 @@ import lightBaseTheme from 'material-ui/styles/baseThemes/lightBaseTheme';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
 // Application components:
 import NavBar from '../nav/NavBar';
-import ClinicalNotes from '../notes/ClinicalNotes';
+import ShortcutViewer from '../viewer/ShortcutViewer';
 import FormTray from '../forms/FormTray';
 
 import './SlimApp.css';
@@ -23,7 +23,8 @@ class SlimApp extends Component {
             metastasis: '',
             SummaryItemToInsert: '',
             withinStructuredField: null,
-            patient: null
+            patient: null,
+            currentDataItem: null
         };
 
         this.handleStagingTUpdate = this.handleStagingTUpdate.bind(this);
@@ -58,20 +59,20 @@ class SlimApp extends Component {
         }
     }
 
-  	handleStagingTUpdate(t) {
+    handleStagingTUpdate(t) {
         console.log(`Updated: ${t}`);
         (t !== "") && this.setState({tumorSize: t});
-  	}
+    }
 
-  	handleStagingNUpdate(n) {
+    handleStagingNUpdate(n) {
         console.log(`Updated: ${n}`);
         (n !== "") && this.setState({nodeSize: n});
-  	}
+    }
 
-  	handleStagingMUpdate(m) {
+    handleStagingMUpdate(m) {
         console.log(`Updated: ${m}`);
         (m !== "") && this.setState({metastasis: m});
-  	}
+    }
 
     render() {
         return (
@@ -83,39 +84,23 @@ class SlimApp extends Component {
                     />
                     <Grid className="SlimApp-content" fluid>
                         <Row center="xs">
-                           <Col sm={4}>
-                              <FormTray
-                                   // Update functions
-                                   onStagingTUpdate={this.handleStagingTUpdate}
-                                   onStagingNUpdate={this.handleStagingNUpdate}
-                                   onStagingMUpdate={this.handleStagingMUpdate}
-                                   // Properties
-                                   tumorSize={this.state.tumorSize}
-                                   nodeSize={this.state.nodeSize}
-                                   metastasis={this.state.metastasis}
-                                   withinStructuredField={this.state.withinStructuredField}
-                              />
-                           </Col>
-                            <Col sm={7}>
-                                <ClinicalNotes
+                            <Col sm={4}>
+                                <FormTray
                                     // Update functions
                                     onStagingTUpdate={this.handleStagingTUpdate}
                                     onStagingNUpdate={this.handleStagingNUpdate}
                                     onStagingMUpdate={this.handleStagingMUpdate}
-                                    onHER2StatusChange={this.changeHER2Status}
-                                    onERStatusChange={this.changeERStatus}
-                                    onPRStatusChange={this.changePRStatus}
-                                    onStructuredFieldEntered={this.handleStructuredFieldEntered}
-                                    onStructuredFieldExited={this.handleStructuredFieldExited}
                                     // Properties
                                     tumorSize={this.state.tumorSize}
                                     nodeSize={this.state.nodeSize}
                                     metastasis={this.state.metastasis}
-                                    HER2Status={this.state.HER2Status}
-                                    ERStatus={this.state.ERStatus}
-                                    PRStatus={this.state.PRStatus}
-                                    itemToBeInserted={this.state.SummaryItemToInsert}
+                                    withinStructuredField={this.state.withinStructuredField}
                                 />
+                            </Col>
+                            <Col sm={7}>
+                               <ShortcutViewer
+                                   currentDataItem={this.state.currentDataItem}
+                               />
                             </Col>
                         </Row>
                     </Grid>

--- a/src/views/SlimApp.jsx
+++ b/src/views/SlimApp.jsx
@@ -50,8 +50,7 @@ class SlimApp extends Component {
     }
 
     render() {
-        const curProgression = new Progression();
-
+      
         return (
             <MuiThemeProvider muiTheme={getMuiTheme(lightBaseTheme)}>
                 <div className="SlimApp">

--- a/src/views/SlimApp.jsx
+++ b/src/views/SlimApp.jsx
@@ -24,7 +24,9 @@ class SlimApp extends Component {
             SummaryItemToInsert: '',
             withinStructuredField: null,
             patient: null,
-            currentDataItem: null
+            currentDataItem: {
+                shortcut: "place holder string for shortcut"
+            }
         };
 
         this.handleStagingTUpdate = this.handleStagingTUpdate.bind(this);
@@ -98,9 +100,9 @@ class SlimApp extends Component {
                                 />
                             </Col>
                             <Col sm={7}>
-                               <ShortcutViewer
-                                   currentDataItem={this.state.currentDataItem}
-                               />
+                                <ShortcutViewer
+                                    currentDataItem={this.state.currentDataItem}
+                                />
                             </Col>
                         </Row>
                     </Grid>

--- a/src/views/SlimApp.jsx
+++ b/src/views/SlimApp.jsx
@@ -28,6 +28,8 @@ class SlimApp extends Component {
     }
 
     changeShortcut(shortcutType) {
+        console.log("shortcut type");
+        console.log(shortcutType);
         // console.log("structured field entered: " + field);
         if (Lang.isNull(shortcutType)) {   
             this.setState({
@@ -39,10 +41,14 @@ class SlimApp extends Component {
                     this.setState({
                         currentShortcut: new Progression()
                     });
+                    break;
+
                 case "toxicity": 
                     this.setState({
                         currentShortcut: new Toxicity()
                     });
+                    break;
+
                 default: 
                     console.error(`Error: Trying to change shortcut to ${shortcutType.toLowerCase()}, which is an invalid shortcut type`);
             }
@@ -50,7 +56,7 @@ class SlimApp extends Component {
     }
 
     render() {
-      
+
         return (
             <MuiThemeProvider muiTheme={getMuiTheme(lightBaseTheme)}>
                 <div className="SlimApp">
@@ -64,8 +70,7 @@ class SlimApp extends Component {
                                 <ShortcutViewer
                                     currentShortcut={this.state.currentShortcut}
                                 />
-                                <button onClick={(e) => {this.changeShortcut("progression"); }}>Test
-                                </button>
+                                <button onClick={(e) => {this.changeShortcut("progression");}}>Test</button>
                             </Col>
                         </Row>
                     </Grid>


### PR DESCRIPTION
Created ShortcutViewer component which replaces the notes section in no patient mode. In SlimApp, added a currentDataItem field with a "shortcut" field. The shortcut field value is a string that is displayed in the ShortcutViewer component. currentDataItem gets passed from SlimApp to Shorcut Viewer. In Shortcut Viewer, it checks if currentDataItem is null. If it's not null, it displays the string value. If it is null, it displays a string that tells the user to pick a template from the left panel.

To test, run the app. By default the data model looks like this for currentDataItem:
```
 
currentDataItem: {
                shortcut: "place holder string for shortcut"
            }

```

For this case, the viewer displays "place holder string for shortcut". To test the null case I changed the data model to this:

`currentDataItem: null`

In this case the viewer displays "Choose a template from the left panel"

*NOTE: (See entry in null: https://www.w3schools.com/js/js_datatypes.asp). If currentDataItem is empty, as in it has no value:
 
```
currentDataItem: {
             
            }
```
then  when I do a null check, it still says that an object exists. It is an object that contains nothing so it fails the null check. I can completely remove the currentDataItem and then the null check works because the property doesn't exist so it's null, but based on the meeting this morning it sounded like we still wanted the property there just null. What I did instead was set the value to be null and then it evaluates to null in the null check. Let me know if there's a better way to handle this.