### PR TITLE
Shortcut adt

### DIFF
--- a/lib/progression_shortcut.js
+++ b/lib/progression_shortcut.js
@@ -7,9 +7,33 @@ class Progression extends Shortcut {
         this.status = status;
         this.reason = reason; 
         this.observationDate = observationDate;
-        this.today = new Date();
         console.log(`constructor for a new Progression object`)
         // more Progression-specific stuff here, maybe
+    }
+
+    updateAttr(name="", value="") { 
+        // Let's validate our values a bit more intelligently.
+        if (name.toLowerCase() === `status`) { 
+            if(Lang.isString(name)) { 
+                super.updateAttr(name, value);
+            } else { 
+                console.error(`Trying to set the status attribute of a progression value to ${value}, which isn't a type "string" but a type ${typeof(value)}`);
+            }
+        } else if (name.toLowerCase() === `reason`) { 
+            if (Lang.isArray(value)) { 
+                super.updateAttr(name, value);
+            } else { 
+                console.error(`Trying to set the reason attribute of a progression value to ${value}, which isn't a type "array" but a type ${typeof(value)}`);
+            }
+        } else if (name.toLowerCase() === `observationDate`) { 
+            if(Lang.isDate(value)) {
+                super.updateAttr(name, value);
+            } else { 
+                console.error(`Trying to set the observationDate attribute of a progression value to ${value}, which isn't a type "date" but a type ${typeof(value)}`);
+            }
+        } else {    
+            console.error(`Trying to set the attribute ${name}, which isn't a valid attribute for Progression`);
+        }
     }
 
     getAsString() { 
@@ -18,15 +42,16 @@ class Progression extends Shortcut {
             return `#progression`;
         } else { 
             let reasonString = ""; 
-            const numReasons = reason.length;
-            if (reason.length > 0) { 
+            const numReasons = this.reason.length;
+            if (numReasons > 0) { 
                 reasonString = " based on ";
                 for (let i = 0; i < numReasons - 1; i++) { 
-                    reasonString += reason[i];
-                    reasonString += ", ";
+                    reasonString += this.reason[i];
+                    reasonString += `, `;
                 }
                 reasonString += reason[numReasons - 1];
             } 
+            const today = new Date();
             const dateString = (this.observationDate.getDate() === today.getDate()) ? `` : ` as of ${this.observationDate}`;
             // Don't put any spaces -- the spaces should be dictated by the current reason and date
             return `#progression[${this.status}${reasonString}${dateString}]`;

--- a/lib/progression_shortcut.js
+++ b/lib/progression_shortcut.js
@@ -1,0 +1,14 @@
+const Shortcut = require('./shortcut.js');
+
+class Progression extends Shortcut {
+    constructor(status="", reasons=[], observationDate=new Date()) {
+        super();
+        this.status = status;
+        this.reasons = reasons; 
+        this.observationDate = observationDate;
+        console.log(this.observationDate);
+        // more Progression-specific stuff here, maybe
+    }
+}
+
+module.exports = Progression; 

--- a/lib/progression_shortcut.js
+++ b/lib/progression_shortcut.js
@@ -1,13 +1,36 @@
+const Lang = require('lodash/lang')
 const Shortcut = require('./shortcut.js');
 
 class Progression extends Shortcut {
-    constructor(status="", reasons=[], observationDate=new Date()) {
+    constructor(status=null, reason=[], observationDate=new Date()) {
         super();
         this.status = status;
-        this.reasons = reasons; 
+        this.reason = reason; 
         this.observationDate = observationDate;
-        console.log(this.observationDate);
+        this.today = new Date();
+        console.log(`constructor for a new Progression object`)
         // more Progression-specific stuff here, maybe
+    }
+
+    getAsString() { 
+        if(Lang.isNull(this.status)) { 
+            // 1. No status -- this case we just want a hash 
+            return `#progression`;
+        } else { 
+            let reasonString = ""; 
+            const numReasons = reason.length;
+            if (reason.length > 0) { 
+                reasonString = " based on ";
+                for (let i = 0; i < numReasons - 1; i++) { 
+                    reasonString += reason[i];
+                    reasonString += ", ";
+                }
+                reasonString += reason[numReasons - 1];
+            } 
+            const dateString = (this.observationDate.getDate() === today.getDate()) ? `` : ` as of ${this.observationDate}`;
+            // Don't put any spaces -- the spaces should be dictated by the current reason and date
+            return `#progression[${this.status}${reasonString}${dateString}]`;
+        }
     }
 }
 

--- a/lib/shortcut.js
+++ b/lib/shortcut.js
@@ -11,11 +11,11 @@ class Shortcut {
         }
     }
 
-    getShortcut () { 
+    getAsString () { 
         return "Shortcut goes here"; 
     }
 
-    renderForm () { 
+    getForm () { 
         return '';
     }
 }

--- a/lib/shortcut.js
+++ b/lib/shortcut.js
@@ -1,0 +1,23 @@
+class Shortcut {
+    constructor() {
+        if (new.target === Shortcut) {
+            throw new TypeError("Cannot construct Shortcut instances directly");
+        }
+    }
+
+    updateAttr (name, value) {
+        if(name !== undefined && value !== undefined) {
+            this[name] = value; 
+        }
+    }
+
+    getShortcut () { 
+        return "Shortcut goes here"; 
+    }
+
+    renderForm () { 
+        return '';
+    }
+}
+
+module.exports = Shortcut;

--- a/lib/toxicity_shortcut.js
+++ b/lib/toxicity_shortcut.js
@@ -1,0 +1,14 @@
+const Shortcut = require('./shortcut.js');
+
+class Toxicity extends Shortcut {
+    constructor(status="", reasons=[], observationDate=new Date()) {
+        super();
+        this.status = status;
+        this.reasons = reasons; 
+        this.observationDate = observationDate;
+        console.log(`constructor for a new Toxicity object`)
+        // more Toxicity-specific stuff here, maybe
+    }
+}
+
+module.exports = Toxicity; 

--- a/src/forms/ProgressionForm.jsx
+++ b/src/forms/ProgressionForm.jsx
@@ -1,7 +1,6 @@
 // React imports
 import React, { Component } from 'react';
 // material-ui
-import Paper from 'material-ui/Paper';
 import Divider from 'material-ui/Divider';
 import SelectField from 'material-ui/SelectField';
 import MenuItem from 'material-ui/MenuItem';

--- a/src/views/SlimApp.jsx
+++ b/src/views/SlimApp.jsx
@@ -5,12 +5,17 @@ import {Grid, Row, Col} from 'react-flexbox-grid';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import lightBaseTheme from 'material-ui/styles/baseThemes/lightBaseTheme';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
+import Paper from 'material-ui/Paper';
 // Application components:
 import NavBar from '../nav/NavBar';
-import ClinicalNotes from '../notes/ClinicalNotes';
 import FormTray from '../forms/FormTray';
+// Shortcut Classes
 import Progression from '../../lib/progression_shortcut.js'
+import Toxicity from '../../lib/toxicity_shortcut.js'
+// Lodash component
+import Lang from 'lodash'
 
+// Styling
 import './SlimApp.css';
 
 class SlimApp extends Component {
@@ -18,47 +23,46 @@ class SlimApp extends Component {
         super(props);
 
         this.state = {
-            /* staging */
-            tumorSize: '',
-            nodeSize: '',
-            metastasis: '',
-            SummaryItemToInsert: '',
-            withinStructuredField: null,
-            patient: null
+            shortcut: null
         };
     }
 
-    handleStructuredFieldEntered(field) {
+    changeShortcut(shortcutType) {
         // console.log("structured field entered: " + field);
-        this.setState({
-            withinStructuredField: field
-        })
-    }
-
-    handleStructuredFieldExited(field) {
-        // console.log("structured field exited: " + field);
-        this.setState({
-            withinStructuredField: null
-        })
+        if (Lang.isNull(shortcutType)) {   
+            this.setState({
+                currentShortcut: null
+            });
+        } else { 
+            switch (shortcutType.toLowerCase()) { 
+                case "progression": 
+                    this.setState({
+                        currentShortcut: new Progression()
+                    });
+                case "toxicity": 
+                    this.setState({
+                        currentShortcut: new Toxicity()
+                    });
+                default: 
+                    console.error(`Error: Trying to change shortcut to ${shortcutType.toLowerCase()}, which is an invalid shortcut type`);
+            }
+        }
     }
 
     render() {
         const curProgression = new Progression();
-        console.log(curProgression.getShortcut());
+        console.log(curProgression.getAsString());
         return (
             <MuiThemeProvider muiTheme={getMuiTheme(lightBaseTheme)}>
                 <div className="SlimApp">
-                    <NavBar
-                        onStructuredFieldEntered={this.handleStructuredFieldEntered}
-                        onStructuredFieldExited={this.handleStructuredFieldExited}
-                    />
+                    <NavBar />
                     <Grid className="SlimApp-content" fluid>
                         <Row center="xs">
                            <Col sm={5}>
                               <FormTray />
                            </Col>
                             <Col sm={7}>
-                                <ClinicalNotes />
+                                <Paper style={{minWidth: "100%", minHeight: "100%", marginTop: "16px"}}/>
                             </Col>
                         </Row>
                     </Grid>

--- a/src/views/SlimApp.jsx
+++ b/src/views/SlimApp.jsx
@@ -9,6 +9,7 @@ import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import NavBar from '../nav/NavBar';
 import ClinicalNotes from '../notes/ClinicalNotes';
 import FormTray from '../forms/FormTray';
+import Progression from '../../lib/progression_shortcut.js'
 
 import './SlimApp.css';
 
@@ -25,13 +26,6 @@ class SlimApp extends Component {
             withinStructuredField: null,
             patient: null
         };
-
-        this.handleStagingTUpdate = this.handleStagingTUpdate.bind(this);
-        this.handleStagingNUpdate = this.handleStagingNUpdate.bind(this);
-        this.handleStagingMUpdate = this.handleStagingMUpdate.bind(this);
-        this.handleSummaryItemSelected = this.handleSummaryItemSelected.bind(this);
-        this.handleStructuredFieldEntered = this.handleStructuredFieldEntered.bind(this);
-        this.handleStructuredFieldExited = this.handleStructuredFieldExited.bind(this);
     }
 
     handleStructuredFieldEntered(field) {
@@ -48,32 +42,9 @@ class SlimApp extends Component {
         })
     }
 
-    componentDidUpdate(a, b) {
-        // Nothing right now
-    }
-
-    handleSummaryItemSelected(itemText) {
-        if (itemText) {
-            this.setState({SummaryItemToInsert: itemText});
-        }
-    }
-
-  	handleStagingTUpdate(t) {
-        console.log(`Updated: ${t}`);
-        (t !== "") && this.setState({tumorSize: t});
-  	}
-
-  	handleStagingNUpdate(n) {
-        console.log(`Updated: ${n}`);
-        (n !== "") && this.setState({nodeSize: n});
-  	}
-
-  	handleStagingMUpdate(m) {
-        console.log(`Updated: ${m}`);
-        (m !== "") && this.setState({metastasis: m});
-  	}
-
     render() {
+        const curProgression = new Progression();
+        console.log(curProgression.getShortcut());
         return (
             <MuiThemeProvider muiTheme={getMuiTheme(lightBaseTheme)}>
                 <div className="SlimApp">
@@ -83,39 +54,11 @@ class SlimApp extends Component {
                     />
                     <Grid className="SlimApp-content" fluid>
                         <Row center="xs">
-                           <Col sm={4}>
-                              <FormTray
-                                   // Update functions
-                                   onStagingTUpdate={this.handleStagingTUpdate}
-                                   onStagingNUpdate={this.handleStagingNUpdate}
-                                   onStagingMUpdate={this.handleStagingMUpdate}
-                                   // Properties
-                                   tumorSize={this.state.tumorSize}
-                                   nodeSize={this.state.nodeSize}
-                                   metastasis={this.state.metastasis}
-                                   withinStructuredField={this.state.withinStructuredField}
-                              />
+                           <Col sm={5}>
+                              <FormTray />
                            </Col>
                             <Col sm={7}>
-                                <ClinicalNotes
-                                    // Update functions
-                                    onStagingTUpdate={this.handleStagingTUpdate}
-                                    onStagingNUpdate={this.handleStagingNUpdate}
-                                    onStagingMUpdate={this.handleStagingMUpdate}
-                                    onHER2StatusChange={this.changeHER2Status}
-                                    onERStatusChange={this.changeERStatus}
-                                    onPRStatusChange={this.changePRStatus}
-                                    onStructuredFieldEntered={this.handleStructuredFieldEntered}
-                                    onStructuredFieldExited={this.handleStructuredFieldExited}
-                                    // Properties
-                                    tumorSize={this.state.tumorSize}
-                                    nodeSize={this.state.nodeSize}
-                                    metastasis={this.state.metastasis}
-                                    HER2Status={this.state.HER2Status}
-                                    ERStatus={this.state.ERStatus}
-                                    PRStatus={this.state.PRStatus}
-                                    itemToBeInserted={this.state.SummaryItemToInsert}
-                                />
+                                <ClinicalNotes />
                             </Col>
                         </Row>
                     </Grid>

--- a/src/views/SlimApp.jsx
+++ b/src/views/SlimApp.jsx
@@ -63,8 +63,8 @@ class SlimApp extends Component {
                            </Col>
                             <Col sm={7}>
                                 <Paper style={{minWidth: "100%", minHeight: "100%", marginTop: "16px"}}> 
-                                    <button onClick={(e) => { curProgression.updateAttr("status", "Stable"); console.log(curProgression.getAsString()); }}>
-                                    </button>
+{/*                                    <button onClick={(e) => { curProgression.updateAttr("status", "Stable"); console.log(curProgression.getAsString()); }}>
+                                    </button>*/}
                                 </Paper>
                             </Col>
                         </Row>

--- a/src/views/SlimApp.jsx
+++ b/src/views/SlimApp.jsx
@@ -50,8 +50,8 @@ class SlimApp extends Component {
     }
 
     render() {
-        const curProgression = new Progression();
-        console.log(curProgression.getAsString());
+/*        const curProgression = new Progression();
+        console.log(curProgression.getAsString());*/
         return (
             <MuiThemeProvider muiTheme={getMuiTheme(lightBaseTheme)}>
                 <div className="SlimApp">

--- a/src/views/SlimApp.jsx
+++ b/src/views/SlimApp.jsx
@@ -62,7 +62,10 @@ class SlimApp extends Component {
                               <FormTray />
                            </Col>
                             <Col sm={7}>
-                                <Paper style={{minWidth: "100%", minHeight: "100%", marginTop: "16px"}}/>
+                                <Paper style={{minWidth: "100%", minHeight: "100%", marginTop: "16px"}}> 
+                                    <button onClick={(e) => { curProgression.updateAttr("status", "Stable"); console.log(curProgression.getAsString()); }}>
+                                    </button>
+                                </Paper>
                             </Col>
                         </Row>
                     </Grid>

--- a/src/views/SlimApp.jsx
+++ b/src/views/SlimApp.jsx
@@ -39,10 +39,14 @@ class SlimApp extends Component {
                     this.setState({
                         currentShortcut: new Progression()
                     });
+                    break;
+
                 case "toxicity": 
                     this.setState({
                         currentShortcut: new Toxicity()
                     });
+                    break;
+
                 default: 
                     console.error(`Error: Trying to change shortcut to ${shortcutType.toLowerCase()}, which is an invalid shortcut type`);
             }


### PR DESCRIPTION
As a subtask of task 291: No patient mode should replace editor with data item viewer and "Done" button

We've got a base class for shortcuts, an class called progression that extends shortcut, and in slimapp we have a shortcut tracked in state and a function for changing that shortcut. 

This feels a bit quick for my usual turnover, but it feels like this might be all we need in terms of modeling for task 291.  Can you all take a look at this, and if it looks good let's merge it to master; if you see things missing or think of other functions/features to add, let me know and I can get working on those.