### PR TITLE
Add copy reset buttons

### DIFF
--- a/src/viewer/ShortcutViewer.css
+++ b/src/viewer/ShortcutViewer.css
@@ -1,0 +1,3 @@
+div#viewer-buttons {
+    display:inline
+}

--- a/src/viewer/ShortcutViewer.css
+++ b/src/viewer/ShortcutViewer.css
@@ -1,3 +1,3 @@
-div#viewer-buttons {
-    display:inline
+.btn_viewer {
+    margin-left: 5px;
 }

--- a/src/viewer/ShortcutViewer.jsx
+++ b/src/viewer/ShortcutViewer.jsx
@@ -24,19 +24,19 @@ class ShortcutViewer extends Component {
         return (
             <div id="shortcut-viewer" className="dashboard-panel">
                 <Paper className="panel-content trio">
-                    <div id="viewer-buttons">
+
                         <RaisedButton
-                            className="btn_template"
+                            className="btn_viewer"
                             label="Copy"
                             onClick={(e) => this._handleClick(e)}
                         />
 
                         <RaisedButton
-                            className="btn_template"
+                            className="btn_viewer"
                             label="Restart"
                             onClick={(e) => this._handleClick(e)}
                         />
-                    </div>
+
 
                     <Divider className="divider"/>
                     <div>

--- a/src/viewer/ShortcutViewer.jsx
+++ b/src/viewer/ShortcutViewer.jsx
@@ -33,8 +33,8 @@ class ShortcutViewer extends Component {
 
                         <RaisedButton
                             className="btn_viewer"
-                            label="Restart"
-                            onClick={(e) => this._handleClick(e)}
+                            label="Reset"
+                            onClick={(e) => this._handleResetClick(e)}
                         />
 
 
@@ -51,6 +51,11 @@ class ShortcutViewer extends Component {
         console.log("clicked a button")
     }
 
+    _handleResetClick(e) {
+        e.preventDefault
+        console.log("clicked reset button");
+        this.props.onShortcutUpdate(null);
+    }
 }
 
 export default ShortcutViewer;

--- a/src/viewer/ShortcutViewer.jsx
+++ b/src/viewer/ShortcutViewer.jsx
@@ -3,6 +3,8 @@ import React, {Component} from 'react';
 
 // material-ui
 import Paper from 'material-ui/Paper';
+import Divider from 'material-ui/Divider';
+import RaisedButton from 'material-ui/RaisedButton';
 // Styling
 import './ShortcutViewer.css';
 
@@ -15,13 +17,28 @@ class ShortcutViewer extends Component {
             string = "Choose a template from the left panel";
         }
         else {
-            if(this.props.currentShortcut) {
+            if (this.props.currentShortcut) {
                 string = this.props.currentShortcut.getAsString();
             }
         }
         return (
             <div id="shortcut-viewer" className="dashboard-panel">
                 <Paper className="panel-content trio">
+                    <div id="viewer-buttons">
+                        <RaisedButton
+                            className="btn_template"
+                            label="Copy"
+                            onClick={(e) => this._handleClick(e)}
+                        />
+
+                        <RaisedButton
+                            className="btn_template"
+                            label="Restart"
+                            onClick={(e) => this._handleClick(e)}
+                        />
+                    </div>
+
+                    <Divider className="divider"/>
                     <div>
                         {string}
                     </div>
@@ -29,6 +46,11 @@ class ShortcutViewer extends Component {
             </div>
         )
     }
+
+    _handleClick(e) {
+        console.log("clicked a button")
+    }
+
 }
 
 export default ShortcutViewer;

--- a/src/viewer/ShortcutViewer.jsx
+++ b/src/viewer/ShortcutViewer.jsx
@@ -52,7 +52,7 @@ class ShortcutViewer extends Component {
     }
 
     _handleResetClick(e) {
-        e.preventDefault
+        e.preventDefault();
         this.props.onShortcutUpdate(null);
     }
 }

--- a/src/views/SlimApp.jsx
+++ b/src/views/SlimApp.jsx
@@ -67,6 +67,11 @@ class SlimApp extends Component {
 		});
 	}
 
+	handleShortcutUpdate = (s) =>{
+	    console.log(`Updated: ${s}`);
+        (s !== "") && this.setState({currentShortcut: s});
+    }
+
     render() {
 	
         return (
@@ -85,6 +90,7 @@ class SlimApp extends Component {
                             <Col sm={7}>
                                 <ShortcutViewer
                                     currentShortcut={this.state.currentShortcut}
+                                    onShortcutUpdate={this.handleShortcutUpdate}
                                 />
                             </Col>
                         </Row>


### PR DESCRIPTION
Copy and reset buttons added to top of shortcut viewer.

Implemented reset button. Clicking on progression or toxicity shortcuts  then clicking on reset button brings the form back to currentShortcut is null state. 