### PR TITLE
Progression reasons without status

### DIFF
--- a/src/shortcuts/ProgressionShortcut.jsx
+++ b/src/shortcuts/ProgressionShortcut.jsx
@@ -34,6 +34,7 @@ class ProgressionShortcut extends Shortcut {
         } else { 
             statusString = `${curProgression.status}`
         }
+        return statusString;
     }
 
     /* 
@@ -42,7 +43,6 @@ class ProgressionShortcut extends Shortcut {
     getReasonString(curProgression) { 
         let reasonString = ""; 
         if (!Lang.isUndefined(curProgression.reason)) {
-            console.log(.reason);
             const numReasons = curProgression.reason.length;
             if (numReasons > 0) { 
                 reasonString = `based on `;

--- a/src/shortcuts/ProgressionShortcut.jsx
+++ b/src/shortcuts/ProgressionShortcut.jsx
@@ -24,38 +24,72 @@ class ProgressionShortcut extends Shortcut {
         console.log(`constructor for a new Progression object`)
         // more Progression-specific stuff here, maybe
     }
+
+    /* 
+     * Translate progression reasons into a string 
+     */
+    getReasonString() { 
+        let reasonString = ""; 
+        if (!Lang.isUndefined(this.progression.reason)) {
+            console.log(this.progression.reason);
+            const numReasons = this.progression.reason.length;
+            if (numReasons > 0) { 
+                reasonString = `based on `;
+                for (let i = 0; i < numReasons - 1; i++) { 
+                    reasonString += this.progression.reason[i];
+                    reasonString += `, `;
+                }
+                reasonString += this.progression.reason[numReasons - 1];
+            } 
+        }
+        return reasonString
+    }
+
+    /* 
+     * Translate progression date into a string 
+     */
+    getDateString() { 
+        const today = new Date();
+        let dateString;
+        if (!Lang.isUndefined(this.progression.startDate)) {
+            dateString = (this.progression.startDate.getDate() === today.getDate()) ? `` : `as of ${this.progression.startDate}`;
+        } else {
+            dateString = ``;
+        }
+        return dateString
+    }
     
+    /* 
+     * Translate the current shortcut into a string
+     */
     getAsString() { 
         if(Lang.isNull(this.progression.status) || Lang.isUndefined(this.progression.status)) { 
-            // 1. No status -- this case we just want a hash 
-            return `#progression`;
+            // 1. No status -- this case we just want a hash
+            if(Lang.isEmpty(this.progression.reason)) { 
+                return `#progression`;
+            } else {    
+                // No status but reasons -- show what we can and provide blank for status 
+                const statusString = `?`;
+                let reasonString   = this.getReasonString();
+                if (!Lang.isEmpty(reasonString)) {reasonString = ` ` + reasonString;}
+                let dateString     = this.getDateString();
+                if (!Lang.isEmpty(dateString)) {dateString = ` ` + dateString;}
+                return `#progression[${statusString}${reasonString}${dateString}]`;
+            } 
         } else { 
             const statusString = `${this.progression.status}`;
-            let reasonString = ""; 
-            if (!Lang.isUndefined(this.progression.reason)) {
-                console.log(this.progression.reason);
-                const numReasons = this.progression.reason.length;
-                if (numReasons > 0) { 
-                    reasonString = " based on ";
-                    for (let i = 0; i < numReasons - 1; i++) { 
-                        reasonString += this.progression.reason[i];
-                        reasonString += `, `;
-                    }
-                    reasonString += this.progression.reason[numReasons - 1];
-                } 
-            }
-            const today = new Date();
-            let dateString;
-            if (!Lang.isUndefined(this.progression.startDate)) {
-                dateString = (this.progression.startDate.getDate() === today.getDate()) ? `` : ` as of ${this.progression.startDate}`;
-            } else {
-                dateString = "";
-            }
+            let reasonString   = this.getReasonString();
+            if (!Lang.isEmpty(reasonString)) {reasonString = ` ` + reasonString;}
+            let dateString     = this.getDateString();
+            if (!Lang.isEmpty(dateString)) {dateString = ` ` + dateString;}
             // Don't put any spaces -- the spaces should be dictated by the current reason and date
             return `#progression[${statusString}${reasonString}${dateString}]`;
         }
     }
     
+    /* 
+     * Return the form for progression
+     */
     getForm() {
         return (
             <ProgressionForm

--- a/src/shortcuts/ProgressionShortcut.jsx
+++ b/src/shortcuts/ProgressionShortcut.jsx
@@ -22,24 +22,35 @@ class ProgressionShortcut extends Shortcut {
         this.onUpdate = onUpdate;
         this.handleProgressionUpdate = this.handleProgressionUpdate.bind(this);
         console.log(`constructor for a new Progression object`)
-        // more Progression-specific stuff here, maybe
+    }
+
+    /* 
+     * Translate progression status into a string 
+     */
+    getStatusString(curProgression) { 
+        let statusString = ``;
+        if (Lang.isNull(curProgression.status) || Lang.isUndefined(curProgression.status)) { 
+            statusString = `?`;
+        } else { 
+            statusString = `${curProgression.status}`
+        }
     }
 
     /* 
      * Translate progression reasons into a string 
      */
-    getReasonString() { 
+    getReasonString(curProgression) { 
         let reasonString = ""; 
-        if (!Lang.isUndefined(this.progression.reason)) {
-            console.log(this.progression.reason);
-            const numReasons = this.progression.reason.length;
+        if (!Lang.isUndefined(curProgression.reason)) {
+            console.log(.reason);
+            const numReasons = curProgression.reason.length;
             if (numReasons > 0) { 
                 reasonString = `based on `;
                 for (let i = 0; i < numReasons - 1; i++) { 
-                    reasonString += this.progression.reason[i];
+                    reasonString += curProgression.reason[i];
                     reasonString += `, `;
                 }
-                reasonString += this.progression.reason[numReasons - 1];
+                reasonString += curProgression.reason[numReasons - 1];
             } 
         }
         return reasonString
@@ -48,11 +59,11 @@ class ProgressionShortcut extends Shortcut {
     /* 
      * Translate progression date into a string 
      */
-    getDateString() { 
+    getDateString(curProgression) { 
         const today = new Date();
         let dateString;
-        if (!Lang.isUndefined(this.progression.startDate)) {
-            dateString = (this.progression.startDate.getDate() === today.getDate()) ? `` : `as of ${this.progression.startDate}`;
+        if (!Lang.isUndefined(curProgression.startDate)) {
+            dateString = (curProgression.startDate.getDate() === today.getDate()) ? `` : `as of ${this.progression.startDate}`;
         } else {
             dateString = ``;
         }
@@ -69,18 +80,18 @@ class ProgressionShortcut extends Shortcut {
                 return `#progression`;
             } else {    
                 // No status but reasons -- show what we can and provide blank for status 
-                const statusString = `?`;
-                let reasonString   = this.getReasonString();
+                const statusString = this.getStatusString(this.progression);
+                let reasonString   = this.getReasonString(this.progression);
                 if (!Lang.isEmpty(reasonString)) {reasonString = ` ` + reasonString;}
-                let dateString     = this.getDateString();
+                let dateString     = this.getDateString(this.progression);
                 if (!Lang.isEmpty(dateString)) {dateString = ` ` + dateString;}
                 return `#progression[${statusString}${reasonString}${dateString}]`;
             } 
         } else { 
-            const statusString = `${this.progression.status}`;
-            let reasonString   = this.getReasonString();
+            const statusString = this.getStatusString(this.progression);
+            let reasonString   = this.getReasonString(this.progression);
             if (!Lang.isEmpty(reasonString)) {reasonString = ` ` + reasonString;}
-            let dateString     = this.getDateString();
+            let dateString     = this.getDateString(this.progression);
             if (!Lang.isEmpty(dateString)) {dateString = ` ` + dateString;}
             // Don't put any spaces -- the spaces should be dictated by the current reason and date
             return `#progression[${statusString}${reasonString}${dateString}]`;


### PR DESCRIPTION
For task 309: Progression shortcut only displays based on value if there's a progression value

Refactored the string creation to split up components into their own functions; and now when there are reasons but no progression status a '?' is displayed where the status would be. 