### PR TITLE
Disable current button

### DIFF
--- a/lib/toxicity_lookup.js
+++ b/lib/toxicity_lookup.js
@@ -8731,7 +8731,7 @@ exports.isValidGradeForAdverseEvent = (possibleGrade, possibleAdverseEvent) => {
     if(Lang.isUndefined(possibleGrade)) { 
         // A null grade isn't valid
         return false;
-    } else if (Lang.isUndefined(possibleAdverseEvent)) { 
+    } else if (Lang.isUndefined(possibleAdverseEvent) || Lang.isNull(possibleAdverseEvent)) { 
         // Any grade is valid when there is no event
         return true;
     }

--- a/src/forms/ToxicityForm.jsx
+++ b/src/forms/ToxicityForm.jsx
@@ -151,8 +151,10 @@ class ToxicityForm extends Component {
   }
 
   render() {
-    let potentialToxicity = (Lang.isNull(this.state.potentialToxicity) ? {} : this.state.potentialToxicity);
-    const potentialGrade = (toxicityLookup.isValidGradeForAdverseEvent(potentialToxicity.grade, potentialToxicity.adverseEvent)) ? potentialToxicity.grade : null;
+    let potentialToxicity = Lang.isNull(this.state.potentialToxicity ? {} : this.state.potentialToxicity);
+    const potentialGrade = toxicityLookup.isValidGradeForAdverseEvent(potentialToxicity.grade, potentialToxicity.adverseEvent) ? potentialToxicity.grade : null;
+    const cannotAddCurrent = Lang.isEmpty(potentialToxicity) || Lang.isUndefined(potentialToxicity.grade) || Lang.isUndefined(potentialToxicity.status);
+    const cannotRemove = Lang.isEmpty(potentialToxicity) || (Array.findIndex(this.props.toxicity, potentialToxicity) === -1)
     // TODO: 
     return (
         <div>
@@ -199,12 +201,13 @@ class ToxicityForm extends Component {
               <RaisedButton
                   className="toxicity-button"
                   label="Add Current"
+                  disabled={cannotAddCurrent}
                   onClick={(e) => this.addToxicity(e)}
               />
               <RaisedButton
                   className="toxicity-button"
                   label="Remove Current"
-                  disabled={(Lang.isNull(this.state.potentialToxicity)) || (Array.findIndex(this.props.toxicity, this.state.potentialToxicity) === -1)}
+                  disabled={cannotRemove}
                   onClick={(e) => this.removeCurrentToxicity(e)}
               />
             </div>

--- a/src/forms/ToxicityForm.jsx
+++ b/src/forms/ToxicityForm.jsx
@@ -151,11 +151,12 @@ class ToxicityForm extends Component {
   }
 
   render() {
-    let potentialToxicity = Lang.isNull(this.state.potentialToxicity ? {} : this.state.potentialToxicity);
+    let potentialToxicity = Lang.isNull(this.state.potentialToxicity) ? {} : this.state.potentialToxicity;
+    
     const potentialGrade = toxicityLookup.isValidGradeForAdverseEvent(potentialToxicity.grade, potentialToxicity.adverseEvent) ? potentialToxicity.grade : null;
-    const cannotAddCurrent = Lang.isEmpty(potentialToxicity) || Lang.isUndefined(potentialToxicity.grade) || Lang.isUndefined(potentialToxicity.status);
+    const cannotAddCurrent = Lang.isEmpty(potentialToxicity) || Lang.isUndefined(potentialToxicity.grade) || Lang.isUndefined(potentialToxicity.adverseEventOptions);
     const cannotRemove = Lang.isEmpty(potentialToxicity) || (Array.findIndex(this.props.toxicity, potentialToxicity) === -1)
-    // TODO: 
+
     return (
         <div>
             <h1>Patient Toxicity</h1>

--- a/src/forms/ToxicityForm.jsx
+++ b/src/forms/ToxicityForm.jsx
@@ -154,7 +154,7 @@ class ToxicityForm extends Component {
     let potentialToxicity = Lang.isNull(this.state.potentialToxicity) ? {} : this.state.potentialToxicity;
     
     const potentialGrade = toxicityLookup.isValidGradeForAdverseEvent(potentialToxicity.grade, potentialToxicity.adverseEvent) ? potentialToxicity.grade : null;
-    const cannotAddCurrent = Lang.isEmpty(potentialToxicity) || Lang.isUndefined(potentialToxicity.grade) || Lang.isUndefined(potentialToxicity.adverseEventOptions);
+    const cannotAddCurrent = Lang.isEmpty(potentialToxicity) || Lang.isUndefined(potentialToxicity.grade) || Lang.isUndefined(potentialToxicity.adverseEvent);
     const cannotRemove = Lang.isEmpty(potentialToxicity) || (Array.findIndex(this.props.toxicity, potentialToxicity) === -1)
 
     return (

--- a/src/forms/ToxicityForm.jsx
+++ b/src/forms/ToxicityForm.jsx
@@ -118,8 +118,13 @@ class ToxicityForm extends Component {
     } else { 
       newToxicity = { ...this.state.potentialToxicity}; 
     }
-    newToxicity["adverseEvent"] = newAdverseEvent;
-    // Make sure grade is possible with given new tox
+    // A null or undefined value for newAdverseEvent should trigger the deletion of the current adverseEvent
+    if (Lang.isUndefined(newAdverseEvent) || Lang.isNull(newAdverseEvent)){ 
+      delete newToxicity.adverseEvent;
+    } else { 
+      newToxicity["adverseEvent"] = newAdverseEvent;
+      // Make sure grade is possible with given new tox
+    }
     const potentialGrade = (toxicityLookup.isValidGradeForAdverseEvent(newToxicity.grade, newAdverseEvent)) ? newToxicity.grade : null;
     if(Lang.isNull(potentialGrade)) { 
       delete newToxicity.grade;
@@ -137,6 +142,8 @@ class ToxicityForm extends Component {
     });
     if(toxicityLookup.isValidAdverseEvent(searchText)) { 
       this.handleAdverseEventSelection(searchText)
+    } else if (!toxicityLookup.isValidAdverseEvent(searchText) && toxicityLookup.isValidAdverseEvent(this.state.potentialToxicity.adverseEvent)) { 
+      this.handleAdverseEventSelection(null)
     }
   }
 


### PR DESCRIPTION
For task 315: In Toxicity Form, disable Add Current button unless both items entered

Pretty self explanatory. Does some checks to decide whether or not a current potentialTox can be added based on whether there is a potential tox and, if there is, if there are defined grades and adverse events.
