### PR TITLE
Current shortcut refactor

### DIFF
--- a/lib/staging.js
+++ b/lib/staging.js
@@ -1,10 +1,14 @@
 const lookup = require('./staging_lookup');
+const Lang = require('lodash/lang');
 
 // Computes the prognostic stage of breast cancer given T, N, M.
 // Uses the 7th staging edition, see:
 // https://cancerstaging.org/references-tools/quickreferences/Documents/BreastMedium.pdf
 exports.breastCancerPrognosticStage = (t, n, m) => {
   // Regardless of edition, metastatic cancer is always stage IV
+  if (Lang.isUndefined(t) || Lang.isUndefined(n) || Lang.isUndefined(m)) { 
+    return null;
+  }
   const M = m.toString().toUpperCase();
   if (M == 'M1') {
     return 'IV';

--- a/lib/staging_lookup.js
+++ b/lib/staging_lookup.js
@@ -172,13 +172,6 @@ exports.getTableForEdition = (ed) => {
 
 exports.isValidT = (possibleT, ed=7) => {
     const possibleTValues = getTsForEdition(ed);
-    console.log(possibleTValues)
-    console.log(possibleT)
-    for( const val of possibleTValues) {
-        console.log(possibleT.toLowerCase()) 
-        console.log(val.name.toLowerCase())
-        console.log(possibleT.toLowerCase() === val.name.toLowerCase())
-    }
     return possibleTValues.some((tValue) => tValue.name.toLowerCase() === possibleT.toLowerCase())
 }
 exports.isValidN = (possibleN, ed=7) => {

--- a/lib/staging_lookup.js
+++ b/lib/staging_lookup.js
@@ -169,3 +169,23 @@ exports.getTableForEdition = (ed) => {
     }
     return [];
 };
+
+exports.isValidT = (possibleT, ed=7) => {
+    const possibleTValues = getTsForEdition(ed);
+    console.log(possibleTValues)
+    console.log(possibleT)
+    for( const val of possibleTValues) {
+        console.log(possibleT.toLowerCase()) 
+        console.log(val.name.toLowerCase())
+        console.log(possibleT.toLowerCase() === val.name.toLowerCase())
+    }
+    return possibleTValues.some((tValue) => tValue.name.toLowerCase() === possibleT.toLowerCase())
+}
+exports.isValidN = (possibleN, ed=7) => {
+    const possibleNValues = getNsForEdition(ed);
+    return possibleNValues.some((nValue) => nValue.name.toLowerCase() === possibleN.toLowerCase())
+}
+exports.isValidM = (possibleM, ed=7) => {
+    const possibleMValues = getMsForEdition(ed);
+    return possibleMValues.some((mValue) => mValue.name.toLowerCase() === possibleM.toLowerCase())
+}

--- a/src/forms/DataCaptureForm.jsx
+++ b/src/forms/DataCaptureForm.jsx
@@ -1,12 +1,11 @@
 // React imports
 import React, {Component} from 'react';
-// Our components
-import StagingForm from './StagingForm';
 // material-ui
 import DropDownMenu from 'material-ui/DropDownMenu';
 import MenuItem from 'material-ui/MenuItem';
-
 import Divider from 'material-ui/Divider';
+// Lodash component
+import Lang from 'lodash'
 // Styling
 import './DataCaptureForm.css';
 
@@ -31,26 +30,22 @@ class DataCaptureForm extends Component {
 
     render() {
         let content = null;
-
-        if (this.state.value === 2) {
-            content = (
-                <StagingForm
-                    onStagingTUpdate={this.props.onStagingTUpdate}
-                    onStagingNUpdate={this.props.onStagingNUpdate}
-                    onStagingMUpdate={this.props.onStagingMUpdate}
-                    onStageUpdate={this.props.onStageUpdate}
-
-                    calculateStage={this.props.calculateStage}
-
-                    tumorSize={this.props.tumorSize}
-                    nodeSize={this.props.nodeSize}
-                    metastasis={this.props.metastasis}
-                    stage={this.props.stage}
-                />
-            );
-        } else if (this.state.value === 3) {
-            content = this.props.progressionShortcut.getForm();
-        } else {
+        const isCurrentShortcut = (!Lang.isNull(this.props.currentShortcut));
+        let currentShortcutType = "";
+        if (isCurrentShortcut) {
+            currentShortcutType = this.props.currentShortcut.getShortcutType()
+        }
+        if (this.state.value === "") {
+        } else if (this.state.value === "staging" && this.state.value === currentShortcutType) {            
+            content = this.props.currentShortcut.getForm();
+        } else if (this.state.value === "progression" && this.state.value === currentShortcutType) {
+            content = this.props.currentShortcut.getForm();
+        } else if (this.state.value === "toxicity" && this.state.value === currentShortcutType) {
+            content = this.props.currentShortcut.getForm();
+        } else if (this.state.value === "staging" || this.state.value === "progression" || this.state.value === "toxicity") {
+            console.log('We might want to figure out how to change currentShortcut from this position')
+            content = <p>Nothing to show</p>
+        } else { 
             content = <p>Nothing to show</p>
         }
 
@@ -65,10 +60,10 @@ class DataCaptureForm extends Component {
                         style={styles.customWidth}
                         autoWidth={false}
                     >
-                        <MenuItem value={1} primaryText="<Select Missing Data>"/>
-                        <MenuItem value={2} primaryText="Staging"/>
-                        <MenuItem value={3} primaryText="Progression"/>
-                        <MenuItem value={4} primaryText="Toxicity"/>
+                        <MenuItem value={""} primaryText="<Select Missing Data>"/>
+                        <MenuItem value={"staging"} primaryText="Staging"/>
+                        <MenuItem value={"progression"} primaryText="Progression"/>
+                        <MenuItem value={"toxicity"} primaryText="Toxicity"/>
                     </DropDownMenu>
                 </div>
                 <Divider className="divider"/>

--- a/src/forms/FormTray.jsx
+++ b/src/forms/FormTray.jsx
@@ -32,7 +32,7 @@ class FormTray extends Component {
     }
     render() {
         let panelContent = null;
-        if (Lang.isUndefined(this.props.patient)) {
+        if (Lang.isUndefined(this.props.patient)) { // NO PATIENT MODE
             if (!Lang.isNull(this.props.currentShortcut)) {
                 panelContent = this.props.currentShortcut.getForm();
             } else {
@@ -45,14 +45,12 @@ class FormTray extends Component {
                     />
                 );
             }
-        } else {
-            if (Lang.isNull(this.props.withinStructuredField)) {
-                // console.log("FormTray. selectedText = " + this.props.selectedText);
-
-                // When highlighting text in the notes section, change the panel content to display the data capture form
-                if (this.props.selectedText != null) {
-                    console.log(this.props);
-                    panelContent = (
+        } else { // PATIENT MODE
+            if (!Lang.isNull(this.props.currentShortcut)) {
+                panelContent = this.props.currentShortcut.getForm();
+			} else if (this.props.selectedText != null) {
+                console.log(this.props);
+                panelContent = (
                         <DataCaptureForm
                             // Staging Form data
                             // Update functions
@@ -72,27 +70,18 @@ class FormTray extends Component {
                             // Update functions
                             changeCurrentShortcut={this.changeCurrentShortcut}
                             // Properties
-                            progressionShortcut={this.props.progressionShortcut}
+                            currentShortcut={this.props.currentShortcut}
                         />
-                    );
-
-                } else {
-                    panelContent = (
+                );
+            } else {
+                panelContent = (
                         <TemplateForm
                             patient={this.props.patient}
                             heading="Available Templates"
                             templates={['op note', 'follow-up', 'consult note']}
                             handleClick={this._insertTemplate}
                         />
-                    );
-                }
-            } else if (this.props.withinStructuredField === "staging") {
-                console.log('trying to get staging form')
-                console.log(this.props.stagingShortcut)
-                panelContent = this.props.stagingShortcut.getForm();
-            } else if (this.props.withinStructuredField === "progression") { 
-                console.log('trying to get progression form')
-                panelContent = this.props.progressionShortcut.getForm();
+                );
             }
         }
         return (

--- a/src/forms/StagingForm.jsx
+++ b/src/forms/StagingForm.jsx
@@ -5,7 +5,7 @@ import Divider from 'material-ui/Divider';
 import RaisedButton from 'material-ui/RaisedButton';
 // Libraries
 import staging from '../../lib/staging';
-import lookup from '../../lib/staging_lookup';
+import stagingLookup from '../../lib/staging_lookup';
 // Lodash
 import Lang from 'lodash'
 // Styling
@@ -16,9 +16,9 @@ class StagingForm extends Component {
       super(props);
 
       this.state = {
-        tumorValues: lookup.getTsForEdition(7),
-        nodeValues: lookup.getNsForEdition(7),
-        metastasisValues: lookup.getMsForEdition(7)
+        tumorValues: stagingLookup.getTsForEdition(7),
+        nodeValues: stagingLookup.getNsForEdition(7),
+        metastasisValues: stagingLookup.getMsForEdition(7)
       };
   }
 

--- a/src/notes/ClinicalNotes.jsx
+++ b/src/notes/ClinicalNotes.jsx
@@ -15,7 +15,7 @@ import EditorToolbar from './EditorToolbar';
 // Shortcut components
 import ProgressionShortcut from '../shortcuts/ProgressionShortcut';
 import StagingShortcut from '../shortcuts/StagingShortcut';
-import ToxicityShortcut from '../shortcuts/ToxicityShortcut';
+// import ToxicityShortcut from '../shortcuts/ToxicityShortcut';
 // Lookup libraries 
 import progressionLookup from '../../lib/progression_lookup';
 import stagingLookup from '../../lib/staging_lookup';

--- a/src/notes/ClinicalNotes.jsx
+++ b/src/notes/ClinicalNotes.jsx
@@ -1,25 +1,24 @@
 // Import React 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-
 // Other libraries
 import { Editor, Block, Raw, Text, Plain } from 'slate'
 import AutoReplace from 'slate-auto-replace'
 import { List } from 'immutable'
 import getOffsets from 'positions'
 import { Row, Col } from 'react-flexbox-grid';
-
 // Material UI component imports
 import Paper from 'material-ui/Paper';
 import Divider from 'material-ui/Divider';
-
 // Application Components:
 import EditorToolbar from './EditorToolbar';
+// Shortcut components
 import ProgressionShortcut from '../shortcuts/ProgressionShortcut';
 import StagingShortcut from '../shortcuts/StagingShortcut';
+import ToxicityShortcut from '../shortcuts/ToxicityShortcut';
+// Lookup libraries 
 import progressionLookup from '../../lib/progression_lookup';
 import stagingLookup from '../../lib/staging_lookup';
-
 // Lodash component
 import Lang from 'lodash'
 // Styling
@@ -227,7 +226,6 @@ class ClinicalNotes extends Component {
     const progressionKeys = (progressionNode)? addKeysForNode(progressionNode, []) : [];
 
     if (stagingNode && stagingKeys.includes(state.selection.startKey)) {
-      console.log('entering staging')
       this.handleStructuredFieldEntered('staging')
     } else if (progressionNode && progressionKeys.includes(state.selection.startKey))  {
       this.handleStructuredFieldEntered('progression')
@@ -274,9 +272,8 @@ class ClinicalNotes extends Component {
    * Handle updates to the current T value based on newly typed values
    */
   handleStagingTUpdate = (newTValue, nextNode) => {
-    console.log(newTValue)
     if (stagingLookup.isValidT(newTValue)) { 
-      console.log(`is a valid T value; updating with new value ${newTValue}`)
+      // console.log(`is a valid T value; updating with new value ${newTValue}`)
       const newStaging = Lang.clone(this.props.currentShortcut.staging);
       newStaging['tumorSize'] = newTValue;  
       const stateTransform = this.state.state.transform();
@@ -295,7 +292,7 @@ class ClinicalNotes extends Component {
    */
   handleStagingNUpdate = (newNValue, nextNode) => {
     if (stagingLookup.isValidN(newNValue)) { 
-      console.log(`is a valid N value; updating with new value ${newNValue}`)
+      // console.log(`is a valid N value; updating with new value ${newNValue}`)
       const newStaging = Lang.clone(this.props.currentShortcut.staging);
       newStaging['nodeSize'] = newNValue;  
       const stateTransform = this.state.state.transform();
@@ -314,10 +311,10 @@ class ClinicalNotes extends Component {
    */
   handleStagingMUpdate = (newMValue, editorState) => {
     if (stagingLookup.isValidM(newMValue)) { 
+      // console.log(`is a valid M value; updating with new value ${newMValue}`)
+      const newStaging = Lang.clone(this.props.currentShortcut.staging);
       const stagingNode = getNodeById(editorState.document.nodes, 'staging')
 
-      console.log(`is a valid M value; updating with new value ${newMValue}`)
-      const newStaging = Lang.clone(this.props.currentShortcut.staging);
       newStaging['metastasis'] = newMValue;  
       const stateTransform = editorState.transform();
       const newStateSelection = stateTransform.collapseToEndOf(stagingNode).insertBlock(this.createEmptyBlock()).apply()
@@ -336,7 +333,7 @@ class ClinicalNotes extends Component {
    */
   handleProgressionStatusUpdate = (newStatusValue, nextNode) => {
     if (progressionLookup.isValidStatus(newStatusValue)) { 
-      console.log(`is a valid progression status; updating with new value ${newStatusValue}`)
+      // console.log(`is a valid progression status; updating with new value ${newStatusValue}`)
       const newProgression = Lang.clone(this.props.currentShortcut.progression);
       newProgression['status'] = newStatusValue;  
       const stateTransform = this.state.state.transform();
@@ -349,7 +346,7 @@ class ClinicalNotes extends Component {
       this.state.previousShortcut.handleProgressionUpdate(newProgression);
       this.props.currentShortcut.handleProgressionUpdate(newProgression);
     } else { 
-      console.log(`trying to update with invalid status ${newStatusValue}`);
+      console.error(`trying to update with invalid status ${newStatusValue}`);
     }
   }
 
@@ -845,7 +842,6 @@ class ClinicalNotes extends Component {
             return;
           } 
           if (prevProgressionReasonNode.text !== curProgressionReasonNode.text) {
-            console.log(curProgressionReasonNode.text[curProgressionReasonNode.text.length - 1])
             if (curProgressionReasonNode.text[curProgressionReasonNode.text.length - 1] === "]") {
               this.handleProgressionFinish(prevState);
             }  else { 
@@ -876,7 +872,6 @@ class ClinicalNotes extends Component {
         } else {
           // If these nodes are old, update values where applicable
           if (curTNode.text !== prevTNode.text) { 
-            console.log(curTNode.text)
             this.handleStagingTUpdate(curTNode.text.trim(), curNNode) 
             return;
           }
@@ -935,8 +930,6 @@ class ClinicalNotes extends Component {
           const mNode = getNodeById(parentNode.nodes, 'm-staging');
 
           // Set t value
-          console.log(nextProps.currentShortcut)
-          console.log(this.state.previousShortcut)
           if (tNode && 
             !Lang.isEmpty(nextProps.currentShortcut.staging.tumorSize) && 
             (this.state.previousShortcut.staging.tumorSize !== nextProps.currentShortcut.staging.tumorSize)) { 
@@ -1007,7 +1000,7 @@ class ClinicalNotes extends Component {
               }
             );
           } else if (progressionReasonNode && !this.arrayEquality(this.state.previousShortcut.progression.reason, nextProps.currentShortcut.progression.reason)) {  
-            console.log(`changing progression node`)
+            console.log(`changing progression reason`)
             // Process reason text into proper format
             let reasonText = "";
             const reasonLength = nextProps.currentShortcut.progression.reason.length;
@@ -1020,7 +1013,6 @@ class ClinicalNotes extends Component {
             } else { 
               reasonText = "__ "
             }
-            console.log(reasonText);
             const currentState = this.state.state;
             const state = currentState
                 .transform()

--- a/src/notes/ClinicalNotes.jsx
+++ b/src/notes/ClinicalNotes.jsx
@@ -18,6 +18,7 @@ import EditorToolbar from './EditorToolbar';
 import ProgressionShortcut from '../shortcuts/ProgressionShortcut';
 import StagingShortcut from '../shortcuts/StagingShortcut';
 import progressionLookup from '../../lib/progression_lookup';
+import stagingLookup from '../../lib/staging_lookup';
 
 // Lodash component
 import Lang from 'lodash'
@@ -92,8 +93,7 @@ class ClinicalNotes extends Component {
       statusOptions: progressionLookup.getStatusOptions(),
       reasonOptions: progressionLookup.getReasonOptions(),
       // Shortcut tracking 
-      previousProgressionShortcut: null,
-      previousStagingShortcut: null,
+      previousShortcut: null,
       // State of editor config
       state: initialState,
       schema: {
@@ -271,22 +271,83 @@ class ClinicalNotes extends Component {
   }
 
   /*
+   * Handle updates to the current T value based on newly typed values
+   */
+  handleStagingTUpdate = (newTValue, nextNode) => {
+    console.log(newTValue)
+    if (stagingLookup.isValidT(newTValue)) { 
+      console.log(`is a valid T value; updating with new value ${newTValue}`)
+      const newStaging = Lang.clone(this.props.currentShortcut.staging);
+      newStaging['tumorSize'] = newTValue;  
+      const stateTransform = this.state.state.transform();
+      const newStateSelection = stateTransform.moveToRangeOf(nextNode).moveStart(1).moveEnd(-1).apply();
+      this.setState({
+        state: newStateSelection
+      });
+      this.state.previousShortcut.handleStagingUpdate(newStaging);
+      this.props.currentShortcut.handleStagingUpdate(newStaging);
+    } else { 
+      console.error(`trying to update with invalid T value:${newTValue}`);
+    }
+  }
+  /*
+   * Handle updates to the current N value based on newly typed values
+   */
+  handleStagingNUpdate = (newNValue, nextNode) => {
+    if (stagingLookup.isValidN(newNValue)) { 
+      console.log(`is a valid N value; updating with new value ${newNValue}`)
+      const newStaging = Lang.clone(this.props.currentShortcut.staging);
+      newStaging['nodeSize'] = newNValue;  
+      const stateTransform = this.state.state.transform();
+      const newStateSelection = stateTransform.moveToRangeOf(nextNode).moveStart(1).moveEnd(-1).apply();
+      this.setState({
+        state: newStateSelection
+      });
+      this.state.previousShortcut.handleStagingUpdate(newStaging);
+      this.props.currentShortcut.handleStagingUpdate(newStaging);
+    } else { 
+      console.error(`trying to update with invalid N ${newNValue}`);
+    }
+  }
+  /*
+   * Handle updates to the current M value based on newly typed values
+   */
+  handleStagingMUpdate = (newMValue, editorState) => {
+    if (stagingLookup.isValidM(newMValue)) { 
+      const stagingNode = getNodeById(editorState.document.nodes, 'staging')
+
+      console.log(`is a valid M value; updating with new value ${newMValue}`)
+      const newStaging = Lang.clone(this.props.currentShortcut.staging);
+      newStaging['metastasis'] = newMValue;  
+      const stateTransform = editorState.transform();
+      const newStateSelection = stateTransform.collapseToEndOf(stagingNode).insertBlock(this.createEmptyBlock()).apply()
+      this.setState({
+        state: newStateSelection
+      });
+      this.state.previousShortcut.handleStagingUpdate(newStaging);
+      this.props.currentShortcut.handleStagingUpdate(newStaging);
+    } else { 
+      console.error(`trying to update with invalid M ${newMValue}`);
+    }
+  }
+
+  /*
    * Handle updates to the current progression status
    */
   handleProgressionStatusUpdate = (newStatusValue, nextNode) => {
     if (progressionLookup.isValidStatus(newStatusValue)) { 
       console.log(`is a valid progression status; updating with new value ${newStatusValue}`)
-      const newProgression = Lang.clone(this.props.progressionShortcut.progression);
+      const newProgression = Lang.clone(this.props.currentShortcut.progression);
       newProgression['status'] = newStatusValue;  
       const stateTransform = this.state.state.transform();
-      console.log(nextNode)
       const newStateSelection = stateTransform.moveToRangeOf(nextNode).apply();
 
       this.setState({
         state: newStateSelection
       });
 
-      this.props.progressionShortcut.handleProgressionUpdate(newProgression);
+      this.state.previousShortcut.handleProgressionUpdate(newProgression);
+      this.props.currentShortcut.handleProgressionUpdate(newProgression);
     } else { 
       console.log(`trying to update with invalid status ${newStatusValue}`);
     }
@@ -297,13 +358,13 @@ class ClinicalNotes extends Component {
    */
   handleProgressionReasonUpdate = (newProgressionReasons, currentNode) => {
     // Avoid deep copy
-    let newProgression = {...this.props.progressionShortcut.progression};
+    let newProgression = {...this.props.currentShortcut.progression};
     // get a list of new valid reasons, 
     const validNewProgressionReasons = this.validateProgressionReasons(newProgressionReasons)
-    if(!this.arrayEquality(this.props.progressionShortcut.progression.reason,validNewProgressionReasons)) { 
+    if(!this.arrayEquality(this.props.currentShortcut.progression.reason,validNewProgressionReasons)) { 
       newProgression['reason'] = validNewProgressionReasons;
-      this.state.previousProgressionShortcut.handleProgressionUpdate(newProgression);
-      this.props.progressionShortcut.handleProgressionUpdate(newProgression);
+      this.state.previousShortcut.handleProgressionUpdate(newProgression);
+      this.props.currentShortcut.handleProgressionUpdate(newProgression);
     }
   }
 
@@ -750,85 +811,7 @@ class ClinicalNotes extends Component {
           // Paste a block containing a zero width space 
           .insertBlock(Block.create({'type': 'paragraph-span', 'nodes': List([Text.createFromString('​')])}))
           .apply();
-      } else {
-        // Search all nodes to find if structured nodes that need checking 
-        for(const parentNode of state.document.nodes) { 
-          // Handle staging structured data 
-          const tNode = getNodeById(parentNode.nodes, 't-staging');
-          const nNode = getNodeById(parentNode.nodes, 'n-staging');
-          const mNode = getNodeById(parentNode.nodes, 'm-staging');
-          const stagingNode = getNodeById(state.document.nodes, 'staging');
-
-          if(tNode && nNode && mNode) { 
-            const tKeys = addKeysForNode(tNode, []);
-            const nKeys = addKeysForNode(nNode, []);
-            const mKeys = addKeysForNode(mNode, []);
-            if (tKeys.includes(state.selection.startKey)) { 
-              if(event.keyCode >= 48 && event.keyCode <=57) {
-                const val = event.keyCode - 48;
-                let newStaging = Lang.clone(this.state.previousStagingShortcut.staging);
-                console.log(this.state.previousStagingShortcut);
-                console.log(this.state.previousStagingShortcut.staging);  
-                newStaging["tumorSize"] = 'T' + val.toString();
-                console.log()
-                this.state.previousStagingShortcut.handleStagingUpdate(newStaging);
-                this.props.stagingShortcut.handleStagingUpdate(newStaging)
-
-                event.preventDefault()
-                return state
-                  .transform()
-                  .moveToRangeOf(tNode)
-                  .moveStart(1)
-                  .moveEnd(-1)
-                  .insertText(String.fromCharCode(event.keyCode))
-                  .moveToRangeOf(nNode)
-                  .moveStart(1)
-                  .moveEnd(-1)
-                  .apply();
-              } 
-            } else if (nKeys.includes(state.selection.startKey)) { 
-              if(event.keyCode >= 48 && event.keyCode <=57) {
-                const val = event.keyCode - 48;
-                let newStaging = Lang.clone(this.state.previousStagingShortcut.staging);
-                newStaging["nodeSize"] = 'N' + val.toString();
-                this.state.previousStagingShortcut.handleStagingUpdate(newStaging);
-                this.props.stagingShortcut.handleStagingUpdate(newStaging)
-
-                event.preventDefault()
-                return state
-                  .transform()
-                  .moveToRangeOf(nNode)
-                  .moveStart(1)
-                  .moveEnd(-1)
-                  .insertText(String.fromCharCode(event.keyCode))
-                  .moveToRangeOf(mNode)
-                  .moveStart(1)
-                  .moveEnd(-1)
-                  .apply();
-              } 
-            } else if (mKeys.includes(state.selection.startKey))  { 
-              if(event.keyCode >= 48 && event.keyCode <=57) {
-                const val = event.keyCode - 48;
-                let newStaging = Lang.clone(this.state.previousStagingShortcut.staging);
-                newStaging["metastasis"] = 'M' + val.toString();
-                this.state.previousStagingShortcut.handleStagingUpdate(newStaging);
-                this.props.stagingShortcut.handleStagingUpdate(newStaging)
-
-                event.preventDefault()
-                return state
-                  .transform()
-                  .moveToRangeOf(mNode)
-                  .moveStart(1)
-                  .moveEnd(-1)
-                  .insertText(String.fromCharCode(event.keyCode))
-                  .collapseToEndOf(stagingNode)
-                  .insertBlock(this.createEmptyBlock())
-                  .apply();
-              } 
-            }
-          }
-        } 
-      }
+      } 
     }
   }
   
@@ -840,7 +823,6 @@ class ClinicalNotes extends Component {
 
     // Handle progression structured data
     for(const parentNode of this.state.state.document.nodes) {
-
       const curProgressionStatusNode = getNodeById(parentNode.nodes, 'progression-value');
       const curProgressionReasonNode = getNodeById(parentNode.nodes, 'progression-cause');     
       if (curProgressionStatusNode && curProgressionReasonNode) {
@@ -852,7 +834,7 @@ class ClinicalNotes extends Component {
           prevProgressionReasonNode = !!(getNodeById(parentNode.nodes, 'progression-cause')) ? getNodeById(parentNode.nodes, 'progression-cause') : prevProgressionReasonNode;
         }          
         // If both of these nodes are new, make a new progression value 
-        if (! (prevProgressionStatusNode || prevProgressionReasonNode)) {
+        if (Lang.isNull(prevProgressionStatusNode) && Lang.isNull(prevProgressionReasonNode)) {
           console.log('first prog')
           this.props.changeCurrentShortcut("progression")
         } else {
@@ -873,6 +855,41 @@ class ClinicalNotes extends Component {
           }  
         }
       }
+      const curTNode = getNodeById(parentNode.nodes, 't-staging');
+      const curNNode = getNodeById(parentNode.nodes, 'n-staging');
+      const curMNode = getNodeById(parentNode.nodes, 'm-staging');
+
+      if (curTNode && curNNode && curMNode) {
+        let prevTNode = null; 
+        let prevNNode = null; 
+        let prevMNode = null;
+        // Check to see if these nodes exists in old set
+        for(const parentNode of prevState.state.document.nodes) {
+          prevTNode = !!(getNodeById(parentNode.nodes, 't-staging')) ? getNodeById(parentNode.nodes, 't-staging') : prevTNode;
+          prevNNode = !!(getNodeById(parentNode.nodes, 'n-staging')) ? getNodeById(parentNode.nodes, 'n-staging') : prevNNode;
+          prevMNode = !!(getNodeById(parentNode.nodes, 'm-staging')) ? getNodeById(parentNode.nodes, 'm-staging') : prevMNode;
+        }          
+        // If all three of these nodes are new, make a new Staging value 
+        if (Lang.isNull(prevTNode) && Lang.isNull(prevNNode) && Lang.isNull(prevMNode)) {
+          console.log('first prog')
+          this.props.changeCurrentShortcut("staging")
+        } else {
+          // If these nodes are old, update values where applicable
+          if (curTNode.text !== prevTNode.text) { 
+            console.log(curTNode.text)
+            this.handleStagingTUpdate(curTNode.text.trim(), curNNode) 
+            return;
+          }
+          if (curNNode.text !== prevNNode.text) { 
+            this.handleStagingNUpdate(curNNode.text.trim(), curMNode) 
+            return;
+          }
+          if (curMNode.text !== prevMNode.text) { 
+            this.handleStagingMUpdate(curMNode.text.trim(), this.state.state) 
+            return;
+          }
+        }
+      }
     }
   }
 
@@ -882,111 +899,124 @@ class ClinicalNotes extends Component {
     if (this.props.itemToBeInserted !== nextProps.itemToBeInserted) {
       this.handleSummaryUpdate(nextProps.itemToBeInserted);
     }
-    if (Lang.isNull(nextProps.progressionShortcut) && Lang.isNull(this.state.previousProgressionShortcut)) { 
+    if (Lang.isNull(nextProps.currentShortcut) && Lang.isNull(this.state.previousShortcut)) { 
       //Do nothing 
-    } else if (!Lang.isNull(nextProps.progressionShortcut) && Lang.isNull(this.state.previousProgressionShortcut)) { 
+    } else if (!Lang.isNull(nextProps.currentShortcut) && nextProps.currentShortcut.getShortcutType() === "progression" && (Lang.isNull(this.state.previousShortcut) || this.state.previousShortcut.getShortcutType() === "staging")) { 
       console.log('should trigger on first insert of progression')
       this.setState({
-        previousProgressionShortcut: new ProgressionShortcut(() => {}, nextProps.progressionShortcut.progression)
+        previousShortcut: new ProgressionShortcut(() => {}, nextProps.currentShortcut.progression)
       })
-    } else if (Lang.isNull(nextProps.progressionShortcut) && !Lang.isNull(this.state.previousProgressionShortcut)) { 
-      this.setState({
-        previousProgressionShortcut: null
-      });
-    } else if (!Lang.isNull(nextProps.stagingShortcut) && Lang.isNull(this.state.previousStagingShortcut)) { 
+    } else if (!Lang.isNull(nextProps.currentShortcut) && nextProps.currentShortcut.getShortcutType() === "staging" && (Lang.isNull(this.state.previousShortcut) || this.state.previousShortcut.getShortcutType() === "progression")) { 
       console.log('should trigger on first insert of staging')
       this.setState({
-        previousStagingShortcut: new StagingShortcut(() => {}, nextProps.stagingShortcut.staging)
+        previousShortcut: new StagingShortcut(() => {}, nextProps.currentShortcut.staging)
       })
-    } else if (Lang.isNull(nextProps.stagingShortcut) && !Lang.isNull(this.state.previousStagingShortcut)) { 
+    } else if (Lang.isNull(nextProps.currentShortcut) && !Lang.isNull(this.state.previousShortcut)) { 
       this.setState({
-        previousStagingShortcut: null
+        previousShortcut: null
       });
     } else { 
-      // Check if staging block exists in the editor
+      // Check if staging block exists in the editor and what shortcut we're in
       const stagingNode = getNodeById(this.state.state.document.nodes, 'staging');
       const progressionNode = getNodeById(this.state.state.document.nodes, 'progression');
+      const isCurrentShortcut = (!Lang.isNull(this.props.currentShortcut));
+      let isStagingShortcut = false;
+      let isProgressionShortcut = false;
+      if (isCurrentShortcut) {
+          isStagingShortcut = (this.props.currentShortcut.getShortcutType() === "staging");
+          isProgressionShortcut = (this.props.currentShortcut.getShortcutType() === "progression");
+      }
 
       // If it exists, populate the fields with the updated staging values
-      if (stagingNode) {
+      if (stagingNode && isStagingShortcut) {
         for(const parentNode of this.state.state.document.nodes) {
           const tNode = getNodeById(parentNode.nodes, 't-staging');
           const nNode = getNodeById(parentNode.nodes, 'n-staging');
           const mNode = getNodeById(parentNode.nodes, 'm-staging');
 
           // Set t value
-
-          if (tNode && !Lang.isEmpty(nextProps.stagingShortcut.staging.tumorSize) && (this.state.previousStagingShortcut.staging.tumorSize !== nextProps.stagingShortcut.staging.tumorSize)) { 
+          console.log(nextProps.currentShortcut)
+          console.log(this.state.previousShortcut)
+          if (tNode && 
+            !Lang.isEmpty(nextProps.currentShortcut.staging.tumorSize) && 
+            (this.state.previousShortcut.staging.tumorSize !== nextProps.currentShortcut.staging.tumorSize)) { 
               const currentState = this.state.state;
               const state = currentState
                   .transform()
                   .moveToRangeOf(tNode)
                   .moveEnd(-1)
                   .deleteForward()
-                  .insertText(nextProps.stagingShortcut.staging.tumorSize)
+                  .insertText(nextProps.currentShortcut.staging.tumorSize)
                   .apply();
-              this.setState({ state: state })
+              this.setState({ 
+                state: state,
+                previousShortcut: new StagingShortcut(() => {}, nextProps.currentShortcut.staging)
+              });
           }
 
           // Set n value
-          if (nNode && !Lang.isEmpty(nextProps.stagingShortcut.staging.nodeSize) && (this.state.previousStagingShortcut.staging.nodeSize !== nextProps.stagingShortcut.staging.nodeSize)) { 
+          if (nNode && !Lang.isEmpty(nextProps.currentShortcut.staging.nodeSize) && (this.state.previousShortcut.staging.nodeSize !== nextProps.currentShortcut.staging.nodeSize)) { 
             const currentState = this.state.state;
             const state = currentState
                 .transform()
                 .moveToRangeOf(nNode)
                 .moveEnd(-1)
                 .deleteForward()
-                .insertText(nextProps.stagingShortcut.staging.nodeSize)
+                .insertText(nextProps.currentShortcut.staging.nodeSize)
                 .apply();
-            this.setState({ state: state })
+            this.setState({ 
+              state: state,
+              previousShortcut: new StagingShortcut(() => {}, nextProps.currentShortcut.staging)
+            });
           }
 
           // Set m value
-          if (mNode && !Lang.isEmpty(nextProps.stagingShortcut.staging.metastasis) && (this.state.previousStagingShortcut.staging.metastasis !== nextProps.stagingShortcut.staging.metastasis)) { 
+          if (mNode && !Lang.isEmpty(nextProps.currentShortcut.staging.metastasis) && (this.state.previousShortcut.staging.metastasis !== nextProps.currentShortcut.staging.metastasis)) { 
             const currentState = this.state.state;
             const state = currentState
                 .transform()
                 .moveToRangeOf(mNode)
                 .moveEnd(-1)
                 .deleteForward()
-                .insertText(nextProps.stagingShortcut.staging.metastasis)
+                .insertText(nextProps.currentShortcut.staging.metastasis)
                 .apply();
-            this.setState({ state: state })
+            this.setState({ 
+              state: state,
+              previousShortcut: new StagingShortcut(() => {}, nextProps.currentShortcut.staging)
+            });
           }
         }
-      } else if (progressionNode) {  
+      } else if (progressionNode  && isProgressionShortcut) {  
         for(const parentNode of this.state.state.document.nodes) {
           const progressionStatusNode = getNodeById(parentNode.nodes, 'progression-value');
           const progressionReasonNode = getNodeById(parentNode.nodes, 'progression-cause');
-          console.log(nextProps.progressionShortcut === this.state.previousProgressionShortcut)
-          console.log(nextProps.progressionShortcut)
-          console.log(this.state.previousProgressionShortcut)
-          if (progressionStatusNode && !Lang.isEmpty(nextProps.progressionShortcut.progression.status) && (this.state.previousProgressionShortcut.progression.status !== nextProps.progressionShortcut.progression.status)) { 
+          
+          if (progressionStatusNode && !Lang.isEmpty(nextProps.currentShortcut.progression.status) && (this.state.previousShortcut.progression.status !== nextProps.currentShortcut.progression.status)) { 
             console.log('changed the Progression status')
             const currentState = this.state.state;
             const state = currentState
                 .transform()
                 .moveToRangeOf(progressionStatusNode)
-                .insertText(nextProps.progressionShortcut.progression.status)
+                .insertText(nextProps.currentShortcut.progression.status)
                 .moveToRangeOf(progressionReasonNode)
                 .apply();
             this.setState(
               { 
                 state: state, 
-                previousProgressionShortcut: new ProgressionShortcut(() => {}, nextProps.progressionShortcut.progression)
+                previousShortcut: new ProgressionShortcut(() => {}, nextProps.currentShortcut.progression)
               }
             );
-          } else if (progressionReasonNode && !this.arrayEquality(this.state.previousProgressionShortcut.progression.reason, nextProps.progressionShortcut.progression.reason)) {  
+          } else if (progressionReasonNode && !this.arrayEquality(this.state.previousShortcut.progression.reason, nextProps.currentShortcut.progression.reason)) {  
             console.log(`changing progression node`)
             // Process reason text into proper format
             let reasonText = "";
-            const reasonLength = nextProps.progressionShortcut.progression.reason.length;
+            const reasonLength = nextProps.currentShortcut.progression.reason.length;
             if (reasonLength > 0) { 
               for (let i = 0; i < reasonLength - 1; i++) {
-                 reasonText += nextProps.progressionShortcut.progression.reason[i];
+                 reasonText += nextProps.currentShortcut.progression.reason[i];
                  reasonText += ', ';
                } 
-              reasonText += nextProps.progressionShortcut.progression.reason[reasonLength - 1];
+              reasonText += nextProps.currentShortcut.progression.reason[reasonLength - 1];
             } else { 
               reasonText = "__ "
             }
@@ -1000,7 +1030,7 @@ class ClinicalNotes extends Component {
             this.setState(
               { 
                 state: state, 
-                previousProgressionShortcut: new ProgressionShortcut(() => {}, nextProps.progressionShortcut.progression)
+                previousShortcut: new ProgressionShortcut(() => {}, nextProps.currentShortcut.progression)
               }
             );
           } 

--- a/src/shortcuts/ProgressionShortcut.jsx
+++ b/src/shortcuts/ProgressionShortcut.jsx
@@ -24,7 +24,12 @@ class ProgressionShortcut extends Shortcut {
         this.onUpdate = onUpdate;
         console.log(`constructor for a new Progression shortcut object`)
     }
-
+    /* 
+     * Returns "progression"
+     */
+    getShortcutType() { 
+        return "progression";
+    }
     /* 
      * Translate progression status into a string 
      */

--- a/src/shortcuts/Shortcut.jsx
+++ b/src/shortcuts/Shortcut.jsx
@@ -12,6 +12,10 @@ class Shortcut {
         return "#null"; 
     }
 
+    getShortcutType() { 
+        throw new TypeError("Primitive shortcut has no type")
+    }
+
     getForm () { 
         return (<h2>No additional values for current shortcut</h2>);
     }

--- a/src/shortcuts/StagingShortcut.jsx
+++ b/src/shortcuts/StagingShortcut.jsx
@@ -24,9 +24,14 @@ class StagingShortcut extends Shortcut {
         this.handleStagingUpdate = this.handleStagingUpdate.bind(this);
         console.log(`constructor for a new Staging object`)
     }
-
     /* 
-     * Translate staging tumor size into a string 
+     * Returns "staging"
+     */
+    getShortcutType() { 
+        return "staging";
+    }
+    /* 
+     * Translate staging Staging information into a string 
      */
     getTumorSizeString(curStaging) { 
         let tString = ``;

--- a/src/shortcuts/ToxicityShortcut.jsx
+++ b/src/shortcuts/ToxicityShortcut.jsx
@@ -23,7 +23,12 @@ class ToxicityShortcut extends Shortcut {
         this.onUpdate = onUpdate;
         console.log(`constructor for a new Toxicity object`)
     }
-
+    /* 
+     * Returns "toxicity"
+     */
+    getShortcutType() { 
+        return "toxicity";
+    }
     /* 
      * Get grade string for given toxicity
      */

--- a/src/summary/DataSummaryPanel.jsx
+++ b/src/summary/DataSummaryPanel.jsx
@@ -29,21 +29,25 @@ class DataSummaryPanel extends Component {
 
         // Format Progression
         //
-        // If there is a progression shortcut to include 
-        const progressionShortcut = this.props.progressionShortcut
-        if (!Lang.isNull(progressionShortcut)) { 
+        // If there is a progression shortcut to include, parse it's values
+        const isCurrentShortcut = (!Lang.isNull(this.props.currentShortcut));
+        let isProgressionShortcut = false;
+        if (isCurrentShortcut) {
+            isProgressionShortcut = (this.props.currentShortcut.getShortcutType() === "progression");
+        }
+        if (isProgressionShortcut) { 
             currentProgressionArray = [
                 {
                     name: "Progression Value",
-                    display: progressionShortcut.progression.status,
-                    value: progressionShortcut.progression.status,
-                    startDate: progressionShortcut.progression.startDate
+                    display: this.props.currentShortcut.progression.status,
+                    value: this.props.currentShortcut.progression.status,
+                    startDate: this.props.currentShortcut.progression.startDate
                 },
                 {
                     name: "Reasons",
-                    display: progressionShortcut.progression.reason.join(", "),
-                    value: progressionShortcut.progression.reason,
-                    startDate: progressionShortcut.progression.startDate
+                    display: this.props.currentShortcut.progression.reason.join(", "),
+                    value: this.props.currentShortcut.progression.reason,
+                    startDate: this.props.currentShortcut.progression.startDate
                 }
             ];
         } else { 
@@ -63,12 +67,15 @@ class DataSummaryPanel extends Component {
             ];
         }
         // Check if start date is longer than 6 months from today's date and set the progression header accordingly
-        if (Lang.isNull(progressionShortcut) || progressionShortcut.progression.startDate < sixMonthsAgoDate) {
-            progressionHeader = "Current Progression";
-        } else {
-            progressionHeader = "Current Progression as of " + progressionShortcut.progression.startDate.format('MM/DD/YYYY') + ":";
+        if (isProgressionShortcut) { 
+            if (this.props.currentShortcut.progression.startDate < sixMonthsAgoDate) {
+                progressionHeader = "Current Progression";
+            } else {
+                progressionHeader = "Progression as of " + this.props.currentShortcut.progression.startDate.format('MM/DD/YYYY') + ":";
+            }
+        } else { 
+            progressionHeader = "Progression";
         }
-
 
         return (
             <div className="dashboard-panel">

--- a/src/views/FullApp.jsx
+++ b/src/views/FullApp.jsx
@@ -36,9 +36,11 @@ class FullApp extends Component {
             withinStructuredField: null,
             selectedText: null,
             // Current shortcutting: 
+            currentShortcut: null,
+            // Old Shortcutting
             progressionShortcut: new ProgressionShortcut(this.handleProgressionShortcutUpdate, {
                     id: Math.floor(Math.random() * Date.now()),
-                    status: 'Progressing Disease',
+                    status: 'Progressing',
                     reason: [
                         "Pathology",
                         "Imaging",
@@ -309,25 +311,25 @@ class FullApp extends Component {
     changeCurrentShortcut = (shortcutType) => {
         if (Lang.isNull(shortcutType)) {   
             this.setState({
-                progressionShortcut: null
+                currentShortcut: null
             });
         } else { 
             switch (shortcutType.toLowerCase()) { 
                 case "progression": 
                     this.setState({
-                        progressionShortcut: new ProgressionShortcut(this.handleProgressionShortcutUpdate)
+                        currentShortcut: new ProgressionShortcut(this.handleProgressionShortcutUpdate)
                     });
                     break;
 
                 case "toxicity": 
                     this.setState({
-                        progressionShortcut: new ToxicityShortcut(this.handleProgressionShortcutUpdate)
+                        currentShortcut: new ToxicityShortcut(this.handleProgressionShortcutUpdate)
                     });
                     break;
 
                 case "staging": 
                     this.setState({
-                        stagingShortcut: new StagingShortcut(this.handleStagingShortcutUpdate)
+                        currentShortcut: new StagingShortcut(this.handleStagingShortcutUpdate)
                     });
                     break;
                 default: 
@@ -387,14 +389,14 @@ class FullApp extends Component {
     handleStructuredFieldEntered = (field) => {
         console.log("structured field entered: " + field);
         this.setState({
-            withinStructuredField: field
+            currentShortcut: field
         })
     }
 
     handleStructuredFieldExited = (field) => {
         // console.log("structured field exited: " + field);
         this.setState({
-            withinStructuredField: null
+            currentShortcut: null
         })
     }
     
@@ -456,7 +458,13 @@ class FullApp extends Component {
         let diagnosis = this.state.diagnosis;
 
         /* update staging if captured */
-        const currentStaging = Lang.isNull(this.state.stagingShortcut) ? {} : this.state.stagingShortcut.staging;
+        const isCurrentShortcut = (!Lang.isNull(this.state.currentShortcut));
+        let isStagingShortcut = false;
+        if (isCurrentShortcut) {
+            isStagingShortcut = (this.state.currentShortcut.getShortcutType() === "staging");
+        }
+
+        const currentStaging = (!isStagingShortcut) ? {} : this.state.currentShortcut.staging;
         const t = currentStaging.tumorSize;
         const n = currentStaging.nodeSize;
         const m = currentStaging.metastasis;
@@ -473,10 +481,7 @@ class FullApp extends Component {
         return (
             <MuiThemeProvider muiTheme={getMuiTheme(lightBaseTheme)}>
                 <div className="FullApp">
-                    <NavBar
-                        onStructuredFieldEntered={this.handleStructuredFieldEntered}
-                        onStructuredFieldExited={this.handleStructuredFieldExited}
-                    />
+                    <NavBar />
                     <Grid className="FullApp-content" fluid>
                         <Row center="xs">
                             <Col sm={4}>
@@ -485,8 +490,7 @@ class FullApp extends Component {
                                     onItemClicked={this.handleSummaryItemSelected}
                                     changeCurrentShortcut={this.changeCurrentShortcut}
                                     // Properties
-                                    progressionShortcut={this.state.progressionShortcut}
-                                    stagingShortcut={this.state.stagingShortcut}
+                                    currentShortcut={this.state.currentShortcut}
 
                                     patient={this.state.patient}
                                     conditions={this.state.conditions}
@@ -506,8 +510,7 @@ class FullApp extends Component {
                                     // New Prog
                                     changeCurrentShortcut={this.changeCurrentShortcut}
                                     // Properties
-                                    progressionShortcut={this.state.progressionShortcut}
-                                    stagingShortcut={this.state.stagingShortcut}
+                                    currentShortcut={this.state.currentShortcut}
 
                                     itemToBeInserted={this.state.SummaryItemToInsert}
                                     patient={this.state.patient}
@@ -517,14 +520,13 @@ class FullApp extends Component {
                             <Col sm={3}>
                                 <FormTray
                                     // Update functions
-                                    changeCurrentShortcut={this.changeCurrentShortcut}
+                                    changeShortcut={this.changeCurrentShortcut}
                                     // Properties
                                     withinStructuredField={this.state.withinStructuredField}
                                     selectedText={this.state.selectedText}
                                     patient={this.state.patient}
 
-                                    progressionShortcut={this.state.progressionShortcut}
-                                    stagingShortcut={this.state.stagingShortcut}
+                                    currentShortcut={this.state.currentShortcut}
                                 />
                             </Col>
                         </Row>

--- a/src/views/FullApp.jsx
+++ b/src/views/FullApp.jsx
@@ -29,9 +29,6 @@ class FullApp extends Component {
 
         this.state = {
             /* staging */
-            tumorSize: '',
-            nodeSize: '',
-            metastasis: '',
             SummaryItemToInsert: '',
             withinStructuredField: null,
             selectedText: null,

--- a/src/views/FullApp.jsx
+++ b/src/views/FullApp.jsx
@@ -37,23 +37,6 @@ class FullApp extends Component {
             selectedText: null,
             // Current shortcutting: 
             currentShortcut: null,
-            // Old Shortcutting
-            progressionShortcut: new ProgressionShortcut(this.handleProgressionShortcutUpdate, {
-                    id: Math.floor(Math.random() * Date.now()),
-                    status: 'Progressing',
-                    reason: [
-                        "Pathology",
-                        "Imaging",
-                        "Symptoms"
-                    ],
-                    startDate: moment('2017-05-15')
-                }),
-            // Patient data
-            stagingShortcut: new StagingShortcut(this.handleStagingShortcutUpdate, { 
-                tumorSize: '',
-                nodeSize: '',
-                metastasis: '',
-            }),
             patient: {
                 photo: "./DebraHernandez672.jpg",
                 name: "Debra Hernandez672",
@@ -315,25 +298,23 @@ class FullApp extends Component {
             });
         } else { 
             switch (shortcutType.toLowerCase()) { 
-                case "progression": 
-                    this.setState({
-                        currentShortcut: new ProgressionShortcut(this.handleProgressionShortcutUpdate)
-                    });
-                    break;
-
-                case "toxicity": 
-                    this.setState({
-                        currentShortcut: new ToxicityShortcut(this.handleProgressionShortcutUpdate)
-                    });
-                    break;
-
-                case "staging": 
-                    this.setState({
-                        currentShortcut: new StagingShortcut(this.handleStagingShortcutUpdate)
-                    });
-                    break;
-                default: 
-                    console.error(`Error: Trying to change shortcut to ${shortcutType.toLowerCase()}, which is an invalid shortcut type`);
+            case "progression":
+                this.setState({
+                    currentShortcut: new ProgressionShortcut(this.handleProgressionShortcutUpdate)
+                });
+                break;
+            case "toxicity":
+                this.setState({
+                    currentShortcut: new ToxicityShortcut(this.handleProgressionShortcutUpdate)
+                });
+                break;
+            case "staging":
+                this.setState({
+                    currentShortcut: new StagingShortcut(this.handleStagingShortcutUpdate)
+                });
+                break;
+            default:
+                console.error(`Error: Trying to change shortcut to ${shortcutType.toLowerCase()}, which is an invalid shortcut type`);
             }
         }
     }
@@ -353,50 +334,17 @@ class FullApp extends Component {
         (s !== "") && this.setState({stagingShortcut: s});
     }
 
-    /* 
-     * Add a progression event to the current array of progression events
-     */ 
-    addProgressionEvent = (progressionEvent) => { 
-        // Make sure this event doesn't already exist in the app
-        if (! this.state.progression.some((event) => event.id === progressionEvent.id)) { 
-            console.log(`in addProgressionEvent; this is a new event; adding to array`);
-            const newProgression = this.state.progression;
-            newProgression.push(progressionEvent);
-            newProgression.sort(this._timeSorter);
-            this.setState({
-                progression: newProgression
-            });
-        } 
-        // else do nothing
-    }
-
-    /* 
-     * update a progression event if it's in the current array of progression events
-     */ 
-    updateProgressionEvent = (id, progressionEvent) => { 
-        // If we can find an event that shares the current id, update it
-        const oldEventIndex = this.state.progression.findIndex((event) => event.id === id)
-        if (oldEventIndex !== -1) {
-            console.log('in updateProgressionEvent; we found an equiv event; updating');
-            let newProgression = [...this.state.progression];
-            newProgression[oldEventIndex] = progressionEvent;
-            this.setState({
-                progression: newProgression
-            });
-        }
-    }
-
     handleStructuredFieldEntered = (field) => {
         console.log("structured field entered: " + field);
         this.setState({
-            currentShortcut: field
+            withinStructuredField: field
         })
     }
 
     handleStructuredFieldExited = (field) => {
-        // console.log("structured field exited: " + field);
+        console.log("structured field exited: " + field);
         this.setState({
-            currentShortcut: null
+            withinStructuredField: null
         })
     }
     
@@ -407,50 +355,9 @@ class FullApp extends Component {
         })
     }
 
-    componentDidUpdate = (a, b) => {
-        // Nothing right now
-    }
-
     handleSummaryItemSelected = (itemText) =>{
         if (itemText) {
             this.setState({SummaryItemToInsert: itemText});
-        }
-    }
-
-    handleStagingTUpdate = (t) => {
-        console.log(`Updated: ${t}`);
-        (t !== "") && this.setState({tumorSize: t});
-    }
-
-    handleStagingNUpdate = (n) => {
-        console.log(`Updated: ${n}`);
-        (n !== "") && this.setState({nodeSize: n});
-    }
-
-    handleStagingMUpdate = (m) => {
-        console.log(`Updated: ${m}`);
-        (m !== "") && this.setState({metastasis: m});
-    }
-
-
-    handleProgressionUpdate = (p) => { 
-        console.log(`Updated progression:`);
-        console.log(p);
-        if (p !== "" && this.state.progression.some(existingProgression => existingProgression.id === p.id)) {
-            console.log("this is an updated event");
-            this.updateProgressionEvent(p.id, p);
-        } else if (p !== "") { 
-            console.log("this is a new progression event");
-            this.addProgressionEvent(p)
-        }
-        // else do nothing
-    }
-
-    handleNewProgression = (p) => { 
-        console.log(`This is a new progression`);
-        if (p !== "") {
-            this.addProgressionEvent(p)
-
         }
     }
 
@@ -491,14 +398,13 @@ class FullApp extends Component {
                                     changeCurrentShortcut={this.changeCurrentShortcut}
                                     // Properties
                                     currentShortcut={this.state.currentShortcut}
-
-                                    patient={this.state.patient}
                                     conditions={this.state.conditions}
                                     diagnosis={diagnosis}
-                                    keyDates={this.state.keyDates}
-                                    procedures={this.state.procedures}
-                                    pathology={this.state.pathology}
                                     genetics={this.state.genetics}
+                                    keyDates={this.state.keyDates}
+                                    patient={this.state.patient}
+                                    pathology={this.state.pathology}
+                                    procedures={this.state.procedures}
                                 />
                             </Col>
                             <Col sm={5}>
@@ -507,14 +413,12 @@ class FullApp extends Component {
                                     onStructuredFieldEntered={this.handleStructuredFieldEntered}
                                     onStructuredFieldExited={this.handleStructuredFieldExited}
                                     onSelectionChange={this.handleSelectionChange}
-                                    // New Prog
                                     changeCurrentShortcut={this.changeCurrentShortcut}
                                     // Properties
                                     currentShortcut={this.state.currentShortcut}
-
+                                    data={{patient: {name: 'Debra Hernandez672', age: '51 years old', gender: 'female'}}}
                                     itemToBeInserted={this.state.SummaryItemToInsert}
                                     patient={this.state.patient}
-                                    data={{patient: {name: 'Debra Hernandez672', age: '51 years old', gender: 'female'}}}
                                 />
                             </Col>
                             <Col sm={3}>
@@ -522,20 +426,19 @@ class FullApp extends Component {
                                     // Update functions
                                     changeShortcut={this.changeCurrentShortcut}
                                     // Properties
-                                    withinStructuredField={this.state.withinStructuredField}
-                                    selectedText={this.state.selectedText}
-                                    patient={this.state.patient}
-
                                     currentShortcut={this.state.currentShortcut}
+                                    patient={this.state.patient}
+                                    selectedText={this.state.selectedText}
+                                    withinStructuredField={this.state.withinStructuredField}
                                 />
                             </Col>
                         </Row>
                         <Row center="xs">
                             <Col sm={12}>
                                 <TimelinePanel
+                                    events={timelineEvents}
                                     medications={this.state.medications}
                                     procedures={this.state.procedures}
-                                    events={timelineEvents}
                                 />
                             </Col>
                         </Row>


### PR DESCRIPTION
Based on task 326: Modify patient mode to use currentShortcut.

Glaring differences: The inputs for the shortcut are not persistent, and dissapear the moment a new shortcut is generated. This is due to the lack of unified patient model. We could try to patch together some kind of read/write architecture based on what we talked about yesterday, but I thought we might want to wait until we started using the SHR models. This is up for discussion. 

Changes: 
- Removed several old functions/values used in updating TMN values, progression values, etc... 
- Removed any traces of two different shortcuts. 
- Change currentShortcut by typing into clinical notes, entering data into that shortcut as per usual.
- TMN values now no longer require a double click to input data. 
- Progression reasons are now trimmed for leading and tailing whitespace before validation. 
- Suppressed some logging.
- Data Summary Panel now displays based on currentShortcut, not the patient model passed. When we decide to publish data from currentShortcut to patient, this needs addressing. 

I think that sums up most of what's new. Let me know if you see anything else worth mentioning, any feedback on what's described above, and any suggestions regarding the patient data publishing. 

Thanks,
- Dylan 
