### PR TITLE
generic shortcut support (350) and current shortcut null if not in struct field (383)

### DIFF
--- a/src/forms/FormTray.jsx
+++ b/src/forms/FormTray.jsx
@@ -52,21 +52,6 @@ class FormTray extends Component {
                 console.log(this.props);
                 panelContent = (
                         <DataCaptureForm
-                            // Staging Form data
-                            // Update functions
-                            onStagingTUpdate={this.props.onStagingTUpdate}
-                            onStagingNUpdate={this.props.onStagingNUpdate}
-                            onStagingMUpdate={this.props.onStagingMUpdate}
-                            onStageUpdate={this.props.onStageUpdate}
-                            // Helper functions
-                            calculateStage={this.props.calculateStage}
-                            // Properties
-                            tumorSize={this.props.tumorSize}
-                            nodeSize={this.props.nodeSize}
-                            metastasis={this.props.metastasis}
-                            stage={this.props.stage}
-                            
-                            // Progression data
                             // Update functions
                             changeCurrentShortcut={this.changeCurrentShortcut}
                             // Properties

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -24,7 +24,7 @@ const initialState = Slate.Raw.deserialize(
         nodes: [
             {
                 kind: 'block',
-                type: 'paragraph',
+                type: 'inline',
                 nodes: [
                     {
                         kind: 'text',
@@ -76,7 +76,8 @@ class FluxNotesEditor extends React.Component {
         // setup structured field plugin
         const structuredFieldPluginOptions = {
             updateEditorState: this.onEditorUpdate,
-            updateCurrentShortcutValues: this.onCurrentShortcutValuesUpdate
+            updateCurrentShortcutValues: this.onCurrentShortcutValuesUpdate,
+			changeCurrentShortcut: props.changeCurrentShortcut
         };
         structuredFieldTypes.forEach((type) => {
             const typeName = type.name;
@@ -93,28 +94,13 @@ class FluxNotesEditor extends React.Component {
     }
 
     onEditorUpdate = (newState) => {
-        console.log(`Plugin updating state`);
+        //console.log(`Plugin updating state`);
         this.setState({
             state: newState
         });
     }
-    onCurrentShortcutValuesUpdate = (value) => {
-
-        if (this.props.currentShortcut.getShortcutType() === "staging") {
-            if (value.startsWith("T")) {
-                this.handleStagingTUpdate(value);
-            } else if (value.startsWith("N")) {
-                this.handleStagingNUpdate(value);
-            } else if (value.startsWith("M")) {
-                this.handleStagingMUpdate(value);
-            } else {
-                console.log("Error: Unexpected value selected in staging dropdown");
-            }
-        }
-        else {
-            console.log("Error: Currently, no functionality to update shortcuts that are not staging");
-            // TODO: Add functionality to update values in other shortcuts (i.e progression, toxicity)
-        }
+    onCurrentShortcutValuesUpdate = (name, value) => {
+		this.props.currentShortcut.updateValue(name, value);
     }
 
     componentDidUpdate = (prevProps, prevState) => {
@@ -123,8 +109,7 @@ class FluxNotesEditor extends React.Component {
     }
 
     onChange = (state) => {
-        console.log("Editor onChange updating state.");
-
+        //console.log("Editor onChange updating state.");
         this.setState({
             state: state
         });
@@ -139,21 +124,33 @@ class FluxNotesEditor extends React.Component {
 		return state;
 	}
 
-    onInsertStructuredField = () => {
+	// for temporary toolbar buttons
+    onInsertStagingStructuredField = () => {
+		this.insertStructuredField("staging");
+	}
+    onInsertProgressionStructuredField = () => {
+		this.insertStructuredField("progression");
+	}
+    onInsertToxicityStructuredField = () => {
+		this.insertStructuredField("toxicity");
+	}
+	
+	
+	insertStructuredField = (shortcutType) => {
         let {state} = this.state;
 
-        let result = this.structuredFieldPlugin.transforms.insertStructuredField(state.transform());
+        // When structure field is inserted, change current shortcut
+        let shortcut = this.props.newCurrentShortcut(shortcutType);
+
+        let result = this.structuredFieldPlugin.transforms.insertStructuredField(state.transform(), shortcut);
 
         //let sf = result[0].state.document.getDescendant(result[1]);
         //let sf_firstChild = sf.nodes.get(0).key;
 
-        // When structure field is inserted, change current shortcut
-        this.props.changeCurrentShortcut("staging");
 
         // Attempt to delete remove structured field first child but this did not work. First child is the $#8202 unicode and for some reason
         // this gets added when structured field is created. When delete structured field, this character remains as part of the structured field
         // result[0].removeNodeByKey(sf_firstChild);
-
 
         let finalResult = result[0].apply();
 
@@ -165,32 +162,13 @@ class FluxNotesEditor extends React.Component {
         );
     }
 
-    handleStagingTUpdate = (newTValue) => {
-        const newStaging = Lang.clone(this.props.currentShortcut.staging);
-        newStaging['tumorSize'] = newTValue;
-        this.props.currentShortcut.handleStagingUpdate(newStaging);
-    }
-
-
-    handleStagingNUpdate = (newNValue) => {
-        const newStaging = Lang.clone(this.props.currentShortcut.staging);
-        newStaging['nodeSize'] = newNValue;
-        this.props.currentShortcut.handleStagingUpdate(newStaging);
-    }
-
-    handleStagingMUpdate = (newMValue) => {
-        const newStaging = Lang.clone(this.props.currentShortcut.staging);
-        newStaging['metastasis'] = newMValue;
-        this.props.currentShortcut.handleStagingUpdate(newStaging);
-    }
-
-
     renderTemporaryToolbar = () => {
-
         return (
             <div>
                 <div>
-                    <button onClick={this.onInsertStructuredField}>Insert Shortcut</button>
+                    <button onClick={this.onInsertStagingStructuredField}>Insert Staging Shortcut</button>
+                    <button onClick={this.onInsertProgressionStructuredField}>Insert Progression Shortcut</button>
+                    <button onClick={this.onInsertToxicityStructuredField}>Insert Toxicity Shortcut</button>
                 </div>
             </div>
         );

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -5,7 +5,7 @@ import Slate from 'slate';
 // when we change the selection and give focus in our key handlers, Slate changes the selection including
 // focus and then immediately takes focus away. Not an issue in 0.20.2 and older. package.json currently
 // forces a version less than 0.20.3.
-import Lang from 'lodash'
+//import Lang from 'lodash'
 //import { Set } from 'immutable'
 import {Row, Col} from 'react-flexbox-grid';
 import EditorToolbar from './EditorToolbar';

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -53,7 +53,7 @@ function StructuredFieldPlugin(opts) {
 
         switch (data.key) {
 		case KEY_F2:
-			return onTab(...args);
+			return onF2(...args);
         case KEY_ENTER:
             return onEnter(...args);
         case KEY_TAB:
@@ -246,6 +246,13 @@ function onTab(event, data, state, opts, editor) {
 	//console.log('onTab DONE (state change via moveField)');
 	return result;
 }
+
+/* 
+ * Pressing "F2" does the same thing as Tab
+ */
+ function onF2(event, data, state, opts, editor) { 
+ 	return onTab(event, data, state, opts, editor);
+ }
 
 function onBackspace(event, data, state, opts) {
 	console.log('onBackspace START');

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -72,7 +72,7 @@ function StructuredFieldPlugin(opts) {
 	}
 
     function onDropdownFocus(proxy, event)  {
-		console.log("onDropDownFocus START");
+		////console.log("onDropDownFocus START");
 		const state = this.getState(); // this is bound to editor. binding to state made it always have old state
 		//console.log(state.selection);
         // Get Slate Key of parent element
@@ -80,37 +80,37 @@ function StructuredFieldPlugin(opts) {
 		const selectedNode = state.document.getParent(state.selection.startKey);
         // If current selection is not identical, make it so
         if (dropdownKey !== selectedNode.key) {  // state.selection.startKey
-            console.log(`oddf: Drop down focus changed. Update slate selection to match`);
+            ////console.log(`oddf: Drop down focus changed. Update slate selection to match`);
 			//console.log(state);
-            console.log(`oddf: HTML focused component key: ${dropdownKey}`);
-            console.log(`oddf: Slate Selection start key : ${state.selection.startKey}`);
-			console.log(`oddf: Selected Node  key        : ${selectedNode.key}`);
+            ////console.log(`oddf: HTML focused component key: ${dropdownKey}`);
+            ////console.log(`oddf: Slate Selection start key : ${state.selection.startKey}`);
+			////console.log(`oddf: Selected Node  key        : ${selectedNode.key}`);
             const dropdownNode = state.document.getDescendant(dropdownKey);
             /*console.log(`oddf: DropdownNode:`);
             console.log(dropdownNode);*/
 
             //const newState = state.transform().moveToRangeOf(dropdownNode).apply();
 			const newState = state.transform().collapseToStartOf(dropdownNode).apply();
-            console.log(`oddf: New startKey: ${newState.selection.startKey}`);
+            ////console.log(`oddf: New startKey: ${newState.selection.startKey}`);
             opts.updateEditorState(newState);
-			console.log("onDropDownFocus DONE (state change)");
+			////console.log("onDropDownFocus DONE (state change)");
         } else { 
         /*    console.log(`No need to update state -- selections are in sync`)
             console.log(state)
 		 */
-			console.log("onDropDownFocus DONE (no state change)");
+			////console.log("onDropDownFocus DONE (no state change)");
         }
     }
 
-    function onDropdownSelection(e) {
+    function onDropdownSelection(name, e) {
         // console.log("[onDropdownSelection] - hit function");
         // console.log("selected value");
-        // console.log(e.target.value);
+		//console.log(name);
 
         // Pass selected value to FluxNotesEditor
-        opts.updateCurrentShortcutValues(e.target.value);
-        console.log("!!!!!! selected value: ");
-        console.log(e.target.value);
+        opts.updateCurrentShortcutValues(name, e.target.value);
+        //console.log("!!!!!! selected value: ");
+		//console.log(e.target.value);
     }
 
 
@@ -125,9 +125,11 @@ function StructuredFieldPlugin(opts) {
 			},
 			sf_subfield_dropdown:    props => {
 				let items = props.node.get('data').get('items');
+				let name = props.node.get('data').get('name');
 				//let value = props.node.get('data').get('value');
 				return (
 					<DropdownStructuredComponent
+						name={name}
 						handleDropdownFocus={onDropdownFocus.bind(props.editor)}
                         handleDropdownSelection={onDropdownSelection.bind(props.state)}
 						else={props.attributes}
@@ -235,13 +237,13 @@ function onOutsideStructuredFieldDropDownLeftRight(event, data, state, editor, o
  * and select the whole text
  */
 function onTab(event, data, state, opts, editor) {
-	console.log('onTab START');
+	//console.log('onTab START');
 	event.preventDefault();
 	//const { startBlock } = state;
     //console.log("startBlock. type=" + startBlock.type + " / key=" + startBlock.key);
     const direction = (data.isShift ? -1 : +1);
 	let result = moveField(state, opts, direction);
-	console.log('onTab DONE (state change via moveField)');
+	//console.log('onTab DONE (state change via moveField)');
 	return result;
 }
 
@@ -278,11 +280,11 @@ function onBackspace(event, data, state, opts) {
 
 
 function onLeftRight(event, data, state, opts) {
-	console.log('onLeftRight START');
+	//console.log('onLeftRight START');
 	const direction = data.key === 'left' ? -1 : +1;
 	event.preventDefault();
 	let result = moveField(state, opts, direction);
-	console.log('onLeftRight DONE (state change via moveField)');
+	//console.log('onLeftRight DONE (state change via moveField)');
 	return result;
 }
 
@@ -308,7 +310,7 @@ function onUpDown(event, data, state, opts) {
 
         return transform.apply();
     }*/
-	console.log('onUpDown DONE');
+	//console.log('onUpDown DONE');
 }
 
 function onEnter(event, data, state, opts) {
@@ -321,7 +323,7 @@ function onEnter(event, data, state, opts) {
 }
 
 function moveField(state, opts, fieldDelta) {
-	console.log("moveField START");
+	//console.log("moveField START");
 	let transform = state.transform();
 	const { startBlock } = state;
 	let block = startBlock;
@@ -366,7 +368,7 @@ function moveField(state, opts, fieldDelta) {
 	//console.log(block);
 	//if (block.kind !== 'text') console.log("block type: " + block.type);
 	//console.log("block key: " + block.key);
-	console.log("moveField DONE (state change)");
+	//console.log("moveField DONE (state change)");
 	if (fieldDelta < 0) {
 		return transform.collapseToEndOf(block).focus().apply();
 	} else {
@@ -403,7 +405,7 @@ function isSelectionLinkageBroken(selection, parentKey) {
 }
 
 function onBeforeInput(event, data, state, editor) {
-	console.log("onBeforeInput START");
+	////console.log("onBeforeInput START");
 	const { selection } = state;
 	const node = state.document.getDescendant(selection.startKey);
 	//console.log(selection);
@@ -416,7 +418,7 @@ function onBeforeInput(event, data, state, editor) {
 		const previousSiblingNode = state.document.getPreviousSibling(selection.startKey);
 		//console.log(previousSiblingNode);
 		if (!Lang.isUndefined(previousSiblingNode) && previousSiblingNode.kind === 'inline' && previousSiblingNode.isVoid && node.kind === 'text') {
-			console.log("bad selection will be fixed in onBeforeInput");
+			////console.log("bad selection will be fixed in onBeforeInput");
 			event.preventDefault();
 			let sf = parentNode;
 			let nextSibling = state.document.getNextSibling(sf.key);
@@ -428,7 +430,7 @@ function onBeforeInput(event, data, state, editor) {
 					.collapseToEndOf(nextSibling).focus()
 					.insertText(event.data)
 					.apply();
-				console.log("onBeforeInput DONE (with state change)");
+				////console.log("onBeforeInput DONE (with state change)");
 				return newState;
 			} else {
 				const newState = state
@@ -436,25 +438,25 @@ function onBeforeInput(event, data, state, editor) {
 					.collapseToStartOf(nextSibling).focus()
 					.insertText(event.data)
 					.apply();
-				console.log("onBeforeInput DONE (with state change)");
+				////console.log("onBeforeInput DONE (with state change)");
 				return newState;
 			}
 		}
 	}
-	console.log("onBeforeInput DONE (NO state change)");
+	////console.log("onBeforeInput DONE (NO state change)");
 }
 
 function onSelectionChange(opts, selection, state) {
-	const num = new Date().getTime();
-	console.log("onSelectionChange START " + num);
+	//const num = new Date().getTime();
+	////console.log("onSelectionChange START " + num);
 	//const node = state.document.getDescendant(selection.startKey);
 	//console.log(selection);
 	//console.log(state.selection);
 	const parentNode = state.document.getParent(selection.startKey);
 	if (isRelevantSelection(parentNode)) { 
-		console.log("osc: within structured field");
+		////console.log("osc: within structured field");
 		if (isSelectionLinkageBroken(selection, parentNode.key)) {
-			console.log("osc: Slate Selection change. html focus out of sync. fixing. " + num);
+			////console.log("osc: Slate Selection change. html focus out of sync. fixing. " + num);
 			/*console.log(selection.startKey);
 			console.log("osc: block with focus currently = " + node.key);
 			//console.log(node);
@@ -462,15 +464,20 @@ function onSelectionChange(opts, selection, state) {
 			//console.log(parentNode);
 			console.log("osc: " + parentNode.type);*/
 			if (parentNode.type === "sf_subfield_dropdown") {
-				console.log("osc: focus html component " + num);
+				////console.log("osc: focus html component " + num);
 				//console.log(parentNode);
 				const domElement = Slate.findDOMNode(parentNode);
-				console.log(domElement.childNodes[0]);
+				////console.log(domElement.childNodes[0]);
 				domElement.childNodes[0].focus();
 			}
 		}
+		const structuredFieldNode = state.document.getParent(parentNode.key);
+		let shortcut = structuredFieldNode.get('data').get('shortcut');
+		opts.changeCurrentShortcut(shortcut);
+	} else {
+		opts.changeCurrentShortcut(null);
 	}
-	console.log("onSelectionChange DONE " + num);
+	////console.log("onSelectionChange DONE " + num);
 }
 
 /**
@@ -480,13 +487,13 @@ function onSelectionChange(opts, selection, state) {
  * @param {Slate.Transform} transform
  * @return {Slate.Transform}
  */
-function insertStructuredField(opts, transform) {
+function insertStructuredField(opts, transform, shortcut) {
     const { state } = transform;
 	//console.log("insertStructuredField: " + state.selection.startKey);
     if (!state.selection.startKey) return false;
 
     // Create the structured-field node
-    const sf = createStructuredField(opts, 'staging');
+    const sf = createStructuredField(opts, shortcut);
 
 	//console.log("[insertStructuredField] sf");
 	//console.log(sf);
@@ -503,25 +510,27 @@ function insertStructuredField(opts, transform) {
  *
  * @param {Slate.State} state
  * @param {Object} opts
- * @param {String} type
+ * @param {Object} shortcut
  * @return {State.Block}
  */
-function createStructuredField(opts, type) {
-	const shortcut = {tumorSize: null, nodeSize: null, metastasis: null};
-    const nodes = [
-		createSubfield_StaticText(opts, '#staging['),
-		createSubfield_Dropdown(opts, { items: ['T0', 'T1', 'T2', 'T3'], value: shortcut.tumorSize }),
-		createSubfield_Dropdown(opts, { items: ['N0', 'N1', 'N2', 'N3'], value: shortcut.nodeSize }),
-		createSubfield_Dropdown(opts, { items: ['M0', 'M1'], value: shortcut.metastasis}),
-		createSubfield_StaticText(opts, ']')
-	];
+function createStructuredField(opts, shortcut) {
+	const nodeSpecs = shortcut.getStructuredFieldSpecification();
+	let nodes = nodeSpecs.map((spec, index) => {
+		if (spec.type === 'staticText') {
+			return createSubfield_StaticText(opts, spec.spec.text);
+		} else if (spec.type === 'dropDown') {
+			return createSubfield_Dropdown(opts, spec.spec);
+		} else {
+			throw new Error("Unsupported type in structured field spec: " + spec.type);
+		}
+	});
 
     let sf = Slate.Block.create({
         type:  opts.typeStructuredField,
         nodes: nodes,
-        data: {
-            shortcut
-        }
+		data: {
+			shortcut: shortcut
+		}
     });
 
 	return sf;
@@ -532,7 +541,8 @@ function createSubfield_Dropdown(opts, spec) {
 		type: opts.typeSubfieldDropdown,
 		data: {
 			value: spec.value,
-			items: spec.items
+			items: spec.items,
+			name: spec.name
 		}
 	});
 }

--- a/src/patient/Patient.jsx
+++ b/src/patient/Patient.jsx
@@ -539,6 +539,20 @@ class Patient {
 		});
 	}
 	
+	getMostRecentStagingForCondition(condition, sinceDate = null) {
+		let stagingList = this.getObservationsForCondition(condition, "http://standardhealthrecord.org/oncology/TNMStage");
+        const sortedStagingList = stagingList.sort(this._observationTimeSorter);
+        const length = sortedStagingList.length;
+        let s = (sortedStagingList[length - 1]);
+		if (Lang.isNull(sinceDate)) return s;
+		const startTime = new moment(s.occurrenceTime);
+		if (startTime < sinceDate) {
+			return null;
+		} else {
+			return s;
+		}
+    }
+	
 	getReceptorStatus(condition, receptorType) {
 		let listObs = this.getObservationsForCondition(condition, "http://standardhealthrecord.org/oncology/BreastCancerReceptorStatus");
 		let obs = listObs[0];
@@ -605,6 +619,13 @@ class Patient {
 	_progressionTimeSorter(a, b) {
 		const a_startTime = new moment(a.clinicallyRelevantTime);
 		const b_startTime = new moment(b.clinicallyRelevantTime);
+		if (a_startTime < b_startTime) { return -1; }
+		if (a_startTime > b_startTime) { return 1; }
+		return 0;
+	}
+	_observationTimeSorter(a, b) {
+		const a_startTime = new moment(a.occurrenceTime);
+		const b_startTime = new moment(b.occurrenceTime);
 		if (a_startTime < b_startTime) { return -1; }
 		if (a_startTime > b_startTime) { return 1; }
 		return 0;

--- a/src/shortcuts/ProgressionShortcut.jsx
+++ b/src/shortcuts/ProgressionShortcut.jsx
@@ -136,6 +136,18 @@ class ProgressionShortcut extends Shortcut {
         }*/
     }
 
+	getStructuredFieldSpecification() {
+		return [	{ type: 'staticText', 	spec: { text:'#progression['}},
+					{ type: 'dropDown',   	spec: { name: 'T', items: ['T0', 'T1', 'T2', 'T3'] }},
+					{ type: 'dropDown',   	spec: { name: 'N', items: ['N0', 'N1', 'N2', 'N3'] }},
+					{ type: 'dropDown', 	spec: { name: 'M', items: ['M0', 'M1'] }},
+					{ type: 'staticText',	spec: { text:']'}} ];
+	}
+
+	updateValue(name, value) {
+
+		this.onUpdate(this);
+	}
 }
 
 export default ProgressionShortcut;

--- a/src/shortcuts/Shortcut.jsx
+++ b/src/shortcuts/Shortcut.jsx
@@ -19,6 +19,14 @@ class Shortcut {
     getForm () { 
         return (<h2>No additional values for current shortcut</h2>);
     }
+	
+	getStructuredFieldSpecification() {
+		return null;
+	}
+	
+	updateValue(name, value) {
+		throw new Error("updateValue not implemented for current shortcut");
+	}
 }
 
 export default Shortcut;

--- a/src/shortcuts/ShortcutManager.js
+++ b/src/shortcuts/ShortcutManager.js
@@ -1,0 +1,34 @@
+import Lang from 'lodash'
+import ProgressionShortcut from './ProgressionShortcut';
+import StagingShortcut from './StagingShortcut';
+import ToxicityShortcut from './ToxicityShortcut';
+
+class ShortcutManager {
+	shortcuts = {
+		progression: ProgressionShortcut,
+		staging: StagingShortcut,
+		toxicity: ToxicityShortcut
+	};
+	
+	constructor(shortcutList) {
+		this.shortcutList = shortcutList;
+	}
+	
+	getSupportedShortcuts() {
+		return this.shortcutList;
+	}
+	
+	createShortcut(shortcutType, onUpdate, object) {
+		//let className = shortcutType.charAt(0).toUpperCase() + shortcutType.slice(1).toLowerCase() + "Shortcut";
+		//return instantiate(className, [onUpdate, object]);
+		//return new constructor(className, onUpdate, object);
+		//return new className(onUpdate, object);
+		if (!Lang.includes(this.shortcutList, shortcutType.toLowerCase())) {
+			throw new Error("Invalid shortcut type: " + shortcutType);
+		}
+		return new this.shortcuts[shortcutType.toLowerCase()](onUpdate, object);
+	}
+
+}
+
+export default ShortcutManager;

--- a/src/shortcuts/StagingShortcut.jsx
+++ b/src/shortcuts/StagingShortcut.jsx
@@ -113,6 +113,27 @@ class StagingShortcut extends Shortcut {
         //console.log(this.staging);
     }
 
+	getStructuredFieldSpecification() {
+		return [	{ type: 'staticText', 	spec: { text:'#staging['}},
+					{ type: 'dropDown',   	spec: { name: 'T', items: ['Tis', 'T0', 'T1', 'T2', 'T3','T4'] }},
+					{ type: 'dropDown',   	spec: { name: 'N', items: ['N0', 'N1mi', 'N1', 'N2', 'N3'] }},
+					{ type: 'dropDown', 	spec: { name: 'M', items: ['M0', 'M1'] }},
+					{ type: 'staticText',	spec: { text:']'}} ];
+	}
+	
+	updateValue(name, value) {
+		if (name === "T") {
+			this.staging.tumorSize = value.toUpperCase();
+		} else if (name === "N") {
+			this.staging.nodeSize = value.toUpperCase();
+		} else if (name === "M") {
+			this.staging.metastasis = value.toUpperCase();
+		} else {
+			console.log("Error: Unexpected value selected in staging dropdown: " + name);
+			return;
+		}
+		this.onUpdate(this);
+	}
 }
 
 export default StagingShortcut;

--- a/src/shortcuts/ToxicityShortcut.jsx
+++ b/src/shortcuts/ToxicityShortcut.jsx
@@ -117,6 +117,18 @@ class ToxicityShortcut extends Shortcut {
         );      
     }
 
+	getStructuredFieldSpecification() {
+		return [	{ type: 'staticText', 	spec: { text:'#toxicity['}},
+					{ type: 'dropDown',   	spec: { name: 'T', items: ['T0', 'T1', 'T2', 'T3'] }},
+					{ type: 'dropDown',   	spec: { name: 'N', items: ['N0', 'N1', 'N2', 'N3'] }},
+					{ type: 'dropDown', 	spec: { name: 'M', items: ['M0', 'M1'] }},
+					{ type: 'staticText',	spec: { text:']'}} ];
+	}
+
+	updateValue(name, value) {
+
+		this.onUpdate(this);
+	}
 }
 
 export default ToxicityShortcut;

--- a/src/structuredfieldcomponents/DropdownStructuredComponent.jsx
+++ b/src/structuredfieldcomponents/DropdownStructuredComponent.jsx
@@ -2,11 +2,18 @@ import React, { Component } from 'react';
 
 class DropdownStructuredComponent extends Component {
 
+	createSelectionHandler(name) {
+		return function(evt) {
+			this.props.handleDropdownSelection(name, evt);
+		}.bind(this);
+		
+	}
+
 	render = () => { 
 		return (        
-		    <span className='sf-subfield' {...this.props.else}>
-				<select onFocus={this.props.handleDropdownFocus} onChange={this.props.handleDropdownSelection}>
-					<option selected disabled hidden>Select</option>
+		    <span defaultValue='Select' className='sf-subfield' {...this.props.else}>
+				<select defaultValue='Select' onFocus={this.props.handleDropdownFocus} onChange={this.createSelectionHandler(this.props.name)}>
+					<option disabled hidden>Select</option>
 			        {this.props.items.map(function(item, index) {
 			            return <option key={item} value={item}>{item}</option>;
 			        })}

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -4,7 +4,7 @@ import moment from 'moment';
 class SummaryMetadata {
 	hardCodedMetadata = { "http://ncimeta.nci.nih.gov/C1334276" :	{ sections: [	{ 	name: "Current Diagnosis",
 																							items:	[	{ name: "Name", value: (patient, currentConditionEntry) => { return currentConditionEntry.specificType.coding.displayText; }},
-																										{ name: "Stage", value: (patient, currentConditionEntry) => { if (Lang.isUndefined(currentConditionEntry.staging)) { return null; } else { return "T" + currentConditionEntry.staging.tumorSize + "N" + currentConditionEntry.staging.nodeMetastasis + "M" + currentConditionEntry.staging.metastasis } }}
+																										{ name: "Stage", value: (patient, currentConditionEntry) => { let s = patient.getMostRecentStagingForCondition(currentConditionEntry); if (s) { return "T" + s.tStage.coding.value + "N" + s.nStage.coding.value + "M" + s.mStage.coding.value;  } else { return null; } } }
 																								    ]},
 																						{	name: "Progression",
 																							items:	[	{ name: "Current Progression", value: (patient, currentConditionEntry) => { let p = patient.getMostRecentProgressionForCondition(currentConditionEntry, moment().subtract(6, 'months')); if (Lang.isNull(p)) return null; else return p.value.coding.displayText; }},

--- a/src/views/TestApp.jsx
+++ b/src/views/TestApp.jsx
@@ -71,7 +71,7 @@ class TestApp extends Component {
 	}
 
     handleShortcutUpdate = (s) =>{
-        //console.log(`Updated shortcut`);
+        console.log(`Updated shortcut`);
         this.setState({currentShortcut: s});
     }
 

--- a/src/views/TestApp.jsx
+++ b/src/views/TestApp.jsx
@@ -11,18 +11,13 @@ import FluxNotesEditor from '../notes/FluxNotesEditor';
 import TestDataSummaryPanel from '../summary/TestDataSummaryPanel';
 import FormTray from '../forms/FormTray';
 import TestTimelinePanel from '../timeline/TestTimelinePanel';
-// Shortcut Classes
-import ProgressionShortcut from '../shortcuts/ProgressionShortcut';
-import ToxicityShortcut from '../shortcuts/ToxicityShortcut';
-import StagingShortcut from '../shortcuts/StagingShortcut';
+// Shortcuts
+import ShortcutManager from '../shortcuts/ShortcutManager';
 // Data model
 import Patient from '../patient/Patient';
 import SummaryMetadata from '../summary/SummaryMetadata';
 // Lodash component
 import Lang from 'lodash'
-
-//import staging from '../../lib/staging';
-//import moment from 'moment';
 
 import './TestApp.css';
 
@@ -32,6 +27,7 @@ class TestApp extends Component {
 
 		this.getItemListForProcedures = this.getItemListForProcedures.bind(this);
 		this.summaryMetadata = new SummaryMetadata();
+		this.shortcutManager = new ShortcutManager(this.shortcuts);
 
 	    this.state = {
             SummaryItemToInsert: '',
@@ -44,7 +40,9 @@ class TestApp extends Component {
             patient: new Patient()
         };
     }
-
+	
+	shortcuts = [ "progression", "staging", "toxicity" ];
+	
 	getItemListForProcedures = (patient, currentConditionEntry) => {
 		let procedures = patient.getProceduresForConditionChronologicalOrder(currentConditionEntry);
 		return procedures.map((p, i) => {
@@ -59,47 +57,22 @@ class TestApp extends Component {
     /* 
      * Change the current shortcut to be the new type of shortcut  
      */
-    changeCurrentShortcut = (shortcutType) => {
-        if (Lang.isNull(shortcutType)) {   
-            this.setState({
-                currentShortcut: null
-            });
-        } else { 
-            switch (shortcutType.toLowerCase()) { 
-            case "progression":
-                this.setState({
-                    currentShortcut: new ProgressionShortcut(this.handleProgressionShortcutUpdate)
-                });
-                break;
-            case "toxicity":
-                this.setState({
-                    currentShortcut: new ToxicityShortcut(this.handleProgressionShortcutUpdate)
-                });
-                break;
-            case "staging":
-                this.setState({
-                    currentShortcut: new StagingShortcut(this.handleStagingShortcutUpdate)
-                });
-                break;
-            default:
-                console.error(`Error: Trying to change shortcut to ${shortcutType.toLowerCase()}, which is an invalid shortcut type`);
-            }
+    newCurrentShortcut = (shortcutType, obj) => {
+		let newShortcut = null;
+        if (!Lang.isNull(shortcutType)) {
+			newShortcut = this.shortcutManager.createShortcut(shortcutType, this.handleShortcutUpdate, obj);
         }
+        this.setState({currentShortcut: newShortcut});
+		return newShortcut;
     }
+	
+	changeCurrentShortcut = (shortcut) => {
+		this.setState({currentShortcut: shortcut});
+	}
 
-    /* 
-     * Update the current Progression Shortcut
-     */
-    handleProgressionShortcutUpdate = (s) =>{
-        console.log(`Updated Progression: ${s}`);
-        (s !== "") && this.setState({progressionShortcut: s});
-    }
-    /* 
-     * Update the current Staging Shortcut  
-     */
-    handleStagingShortcutUpdate = (s) =>{
-        console.log(`Updated Staging: ${s}`);
-        (s !== "") && this.setState({stagingShortcut: s});
+    handleShortcutUpdate = (s) =>{
+        //console.log(`Updated shortcut`);
+        this.setState({currentShortcut: s});
     }
 
     handleStructuredFieldEntered = (field) => {
@@ -130,10 +103,6 @@ class TestApp extends Component {
     }
 
     render() {
-        // Timeline events are a mix of key dates and progression
-        //const timelineEvents = this.state.keyDates.concat(this.state.progression).sort(this._timeSorter);
-		//const timelineEvents = []; // TODO
-
         return (
             <MuiThemeProvider muiTheme={getMuiTheme(lightBaseTheme)}>
                 <div className="TestApp">
@@ -155,6 +124,7 @@ class TestApp extends Component {
                                     // Update functions
                                     onSelectionChange={this.handleSelectionChange}
                                     changeCurrentShortcut={this.changeCurrentShortcut}
+									newCurrentShortcut={this.newCurrentShortcut}
                                     // Properties
                                     currentShortcut={this.state.currentShortcut}
                                     itemToBeInserted={this.state.SummaryItemToInsert}


### PR DESCRIPTION
remove shortcut-specific code from everywhere except shortcuts, new shortcut manager, and a simple list of supported shortcuts in TestApp. also clear currentShortcut when not within a structured field in editor. also restore current shortcut to a structured field's corresponding shortcut when re-entering a structured field within editor. insert buttons in summary now correctly disable since currentShortcut is being set to null. Switches right panel to show form when in shortcut as it should. no update of drop downs in structured field from form changes yet. separate jira to cover that (368). added temporary button to insert each of the 3 supported shortcuts but the subfields aren't correct yet. other jiras to do those as well.