### PR TITLE
Fix returning to structured field after leaving it (388)

### DIFF
--- a/src/structuredfieldcomponents/DropdownStructuredComponent.jsx
+++ b/src/structuredfieldcomponents/DropdownStructuredComponent.jsx
@@ -9,10 +9,11 @@ class DropdownStructuredComponent extends Component {
 		
 	}
 
-	render = () => { 
+	render = () => {
+		let datakey = this.props.else['data-key'] + "-0";
 		return (        
-		    <span defaultValue='Select' className='sf-subfield' {...this.props.else}>
-				<select defaultValue='Select' onFocus={this.props.handleDropdownFocus} onChange={this.createSelectionHandler(this.props.name)}>
+		    <span className='sf-subfield' {...this.props.else}>
+				<select data-offset-key={datakey} defaultValue='Select' onFocus={this.props.handleDropdownFocus} onChange={this.createSelectionHandler(this.props.name)}>
 					<option disabled hidden>Select</option>
 			        {this.props.items.map(function(item, index) {
 			            return <option key={item} value={item}>{item}</option>;


### PR DESCRIPTION
suppress onBlur event caused by giving focus to dropdown within structured field. added onOutsideStructuredFieldDropDownTab for handling tab key outside of dropdown. added data-offset-key attribute to select dropdowns to suppress many of the TypeErrors for cannot read property 'firstChild' of null resulting from content.js (slate) calling findDeepestNode based on a lookup of the above key. I left a lot of console.log messages in code for now. we will be debugging key behavior for a number of additional jira issues. It works to right arrow or tab from left side of structured field. It also works to just click on a drop down. not all keys that could return are implemented still and there are jira issues for them (e.g., shift-F2 or shift-tab when to right of structured field not implemented)