### PR TITLE
Style lite-mode shortcut formList 

### DIFF
--- a/src/forms/FormList.css
+++ b/src/forms/FormList.css
@@ -1,7 +1,8 @@
 #list-panel {
     background-color: #F3F3F3;
     /*Minus 64 for nav, minus 80 for search*/
-    height: calc(100vh - 64px - 80px);
+    /*height: calc(100vh - 64px - 80px);*/
+    height: calc(100vh - 64px);
     text-align: left;
 }
 

--- a/src/forms/FormList.css
+++ b/src/forms/FormList.css
@@ -1,7 +1,7 @@
 #list-panel {
     background-color: #F3F3F3;
     /*Minus 64 for nav, minus 80 for search*/
-    height: calc(100vh - 64px- 80px);
+    height: calc(100vh - 64px - 80px);
     text-align: left;
 }
 

--- a/src/forms/FormList.css
+++ b/src/forms/FormList.css
@@ -1,4 +1,18 @@
 #list-panel {
-    border-right: 1px solid #d9d9d9;
-    height: 70vh;
+    background-color: #F3F3F3;
+    /*Minus 64 for nav, minus 80 for search*/
+    height: calc(100vh - 64px- 80px);
+    text-align: left;
+}
+
+#list-panel .list-element.unselected{ 
+    border-bottom: 1px solid #d9d9d9 !important;
+}
+
+#list-panel .list-element.selected{ 
+    background-color: white !important;
+    font-weight: bold!important;
+    -webkit-box-shadow: 0px 4px 5px -4px rgba(125,125,125,0.7);
+    -moz-box-shadow: 0px 4px 5px -4px rgba(125,125,125,0.7);
+    box-shadow: 0px 4px 5px -4px rgba(125,125,125,0.7);
 }

--- a/src/forms/FormList.jsx
+++ b/src/forms/FormList.jsx
@@ -16,7 +16,6 @@ class FormList extends Component {
     }
 
     _newShortcut(e, index, shortcutName) {
-        console.log(`new shortcut ${index}`);
         e.preventDefault();
         this.props.changeShortcut(this.props.shortcuts[index]);
     }
@@ -28,7 +27,6 @@ class FormList extends Component {
     }
 
     render() {
-        console.log(`This is the disabled element: ${this.state.disabledElement}`)
         return (
             <div id="list-panel">
                 <List style={{padding: "0px"}}>
@@ -40,7 +38,6 @@ class FormList extends Component {
                         } else { 
                             classValue += " unselected";
                         }
-                        console.log(shortcutName)
                         return (
                             <ListItem
                                 key={i}

--- a/src/forms/FormList.jsx
+++ b/src/forms/FormList.jsx
@@ -1,13 +1,7 @@
 // React imports
 import React, {Component} from 'react';
-// Our components
-import TemplateForm from './TemplateForm';
-import DataCaptureForm from './DataCaptureForm';
 // material-ui
-import Paper from 'material-ui/Paper';
 import {List, ListItem} from 'material-ui/List';
-// Lodash component
-import Lang from 'lodash'
 // Styling
 import './FormList.css';
 
@@ -16,25 +10,47 @@ class FormList extends Component {
     constructor(props) {
         super(props);
         this._newShortcut = this._newShortcut.bind(this);
+        this.state = { 
+            disabledElement: null
+        }
     }
 
-    _newShortcut(e, i) {
-        console.log(`new shortcut ${i}`);
+    _newShortcut(e, index, shortcutName) {
+        console.log(`new shortcut ${index}`);
         e.preventDefault();
-        this.props.changeShortcut(this.props.shortcuts[i]);
+        this.props.changeShortcut(this.props.shortcuts[index]);
+    }
+
+    _onTouchTap(event, shortcutName) { 
+        this.setState({
+            disabledElement: shortcutName
+        });
     }
 
     render() {
+        console.log(`This is the disabled element: ${this.state.disabledElement}`)
         return (
-            <div id="list-panel" className="dashboard-panel">
-                <List>
-                    {this.props.shortcuts.map((t, i) => {
+            <div id="list-panel">
+                <List style={{padding: "0px"}}>
+                    {this.props.shortcuts.map((shortcutName, i) => {
+                        let classValue = "list-element";
+                        let primaryText = shortcutName;
+                        if (this.state.disabledElement === shortcutName) {
+                            classValue += " selected";
+                        } else { 
+                            classValue += " unselected";
+                        }
+                        console.log(shortcutName)
                         return (
                             <ListItem
                                 key={i}
-                                id={t}
-                                primaryText={t}
-                                onClick={(e) => this._newShortcut(e, i)}
+                                id={shortcutName}
+                                primaryText={primaryText}
+                                className={classValue}
+                                onTouchTap={ (e) => {
+                                    this._onTouchTap(e, shortcutName)
+                                    this._newShortcut(e, i, shortcutName)}
+                                }
                             />
                         );
                     })}

--- a/src/forms/FormSearch.css
+++ b/src/forms/FormSearch.css
@@ -1,0 +1,8 @@
+
+#form-search {
+    padding: 15px 0;
+    background-color: #fbfbfb;
+    text-align: left;
+    height: 50px;
+    border-bottom: 1px solid #d9d9d9 !important;
+}

--- a/src/forms/FormSearch.jsx
+++ b/src/forms/FormSearch.jsx
@@ -1,0 +1,43 @@
+// React imports
+import React, {Component} from 'react';
+// material-ui
+import TextField from 'material-ui/TextField';
+import FontIcon from 'material-ui/FontIcon';
+// Styling
+import './FormSearch.css';
+
+class FormSearch extends Component {
+
+    constructor(props) {
+        super(props);
+        // this._newShortcut = this._newShortcut.bind(this);
+        this.underlineStyle = {
+            borderColor: "#17263f",
+        }
+    }
+
+    handleSearch(searchValue) { 
+        console.log()
+    }
+
+    render() {
+        return (
+            <div id="form-search">
+                <div style={{position: 'relative', display: 'inline-block'}}>
+                    <FontIcon 
+                        className="fa fa-search"
+                        style={{position: 'absolute', left: "15%", top: 15, fontSize: "16px", color: "#17263f"}}/>
+                    <TextField
+                        style={{textIndent: 25, left: "15%", textAlign: "left", minWidth: "80%", width: "100%"}}
+                        hintText="Search for a shortcut"
+                        onChange={(event, value) => this.handleSearch(value)}
+                        underlineFocusStyle={this.underlineStyle}
+
+                    />
+                </div>
+            </div>
+        )
+    }
+}
+
+export default FormSearch;

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,7 @@
 body {
   margin: 0;
   padding: 0;
+  height:100%;
+
   font-family: 'Roboto', sans-serif;
-  background-color: #F3F3F3;
 }

--- a/src/viewer/ShortcutViewer.css
+++ b/src/viewer/ShortcutViewer.css
@@ -1,7 +1,7 @@
 
 #shortcut-viewer { 
     background: white;
-    height: calc(100vh - 64px);
+    height: calc(100vh - 64px - 40px);
     text-align: left;
     z-index: 2;
     padding: 20px;

--- a/src/viewer/ShortcutViewer.css
+++ b/src/viewer/ShortcutViewer.css
@@ -1,3 +1,15 @@
+
+#shortcut-viewer { 
+    background: white;
+    height: calc(100vh - 64px);
+    text-align: left;
+    z-index: 2;
+    padding: 20px;
+    -webkit-box-shadow: -3px 0px 5px -2px rgba(125,125,125,0.7);
+    -moz-box-shadow: -3px 0px 5px -2px rgba(125,125,125,0.7);
+    box-shadow: -3px 0px 5px -2px rgba(125,125,125,0.7);
+}
+
 .btn_viewer {
     margin-left: 5px;
 }

--- a/src/viewer/ShortcutViewer.jsx
+++ b/src/viewer/ShortcutViewer.jsx
@@ -1,12 +1,11 @@
 // React imports
 import React, {Component} from 'react';
-import CopyToClipboard from 'react-copy-to-clipboard';
-
+// import CopyToClipboard from 'react-copy-to-clipboard';
 
 // material-ui
-import Paper from 'material-ui/Paper';
-import Divider from 'material-ui/Divider';
-import RaisedButton from 'material-ui/RaisedButton';
+// import Paper from 'material-ui/Paper';
+// import Divider from 'material-ui/Divider';
+// import RaisedButton from 'material-ui/RaisedButton';
 
 // Lodash component
 import Lang from 'lodash'
@@ -36,7 +35,7 @@ class ShortcutViewer extends Component {
         }
 
         return (
-            <div id="shortcut-viewer" className="dashboard-panel">
+            <div id="shortcut-viewer">
 
 
                 {/*<CopyToClipboard text={string}>*/}

--- a/src/views/FullApp.css
+++ b/src/views/FullApp.css
@@ -1,5 +1,6 @@
 .FullApp {
     height: 100vh;
+    background-color: #F3F3F3;
 }
 
 /* Restricts app to max fixed width for very wide screens. */

--- a/src/views/FullApp.css
+++ b/src/views/FullApp.css
@@ -5,43 +5,44 @@
 /* Restricts app to max fixed width for very wide screens. */
 .FullApp-content {
     max-width: 1600px;
+    background-color: #F3F3F3;
 }
 
-.container-fluid {
+.FullApp-content .container-fluid {
     padding-left: 12px;
     padding-right: 12px;
 }
 
-.dashboard-panel {
+.FullApp-content .dashboard-panel {
     margin-top: 16px;
     text-align: left;
 }
 
-.trio {
+.FullApp-content .trio {
     min-height: 810px !important;
 }
 
-.panel-content {
+.FullApp-content .panel-content {
     padding: 30px;
 }
 
-.divider {
+.FullApp-content .divider {
     margin: 20px 0px !important;
     clear: both;
 }
 
-h1 {
+.FullApp-content h1 {
     margin: 0px;
     font-size: 1.25rem;
 }
 
-h2 {
+.FullApp-content h2 {
     margin: 0px;
     font-size: 0.9rem;
     font-weight: lighter;
 }
 
-h3 {
+.FullApp-content h3 {
     margin: 0px;
     font-size: 0.8rem;
     font-weight: lighter;

--- a/src/views/SlimApp.css
+++ b/src/views/SlimApp.css
@@ -9,19 +9,9 @@
     padding: 0 0;
 }
 
-.SlimApp-content .dashboard-panel {
-    margin-top: 16px;
-    text-align: left;
+.SlimApp-content .row{
+    margin: 0!important;
 }
-
-.SlimApp-content .trio {
-    min-height: 810px !important;
-}
-
-.SlimApp-content .panel-content {
-    padding: 30px;
-}
-
 .SlimApp-content .divider {
     margin: 20px 0px !important;
     clear: both;

--- a/src/views/SlimApp.css
+++ b/src/views/SlimApp.css
@@ -1,49 +1,44 @@
 .SlimApp {
-    height: 100vh;
 }
 
 /* Restricts app to max fixed width for very wide screens. */
 .SlimApp-content {
-    max-width: 1200px;
+    background-color: white;
+    /*64 px is the height of the nav bar*/
+    height: calc(100vh - 64px);
+    padding: 0 0;
 }
 
-.container-fluid {
-    padding-left: 12px;
-    padding-right: 12px;
-}
-
-.dashboard-panel {
+.SlimApp-content .dashboard-panel {
     margin-top: 16px;
     text-align: left;
 }
 
-.trio {
+.SlimApp-content .trio {
     min-height: 810px !important;
 }
 
-.panel-content {
+.SlimApp-content .panel-content {
     padding: 30px;
 }
 
-
-
-.divider {
+.SlimApp-content .divider {
     margin: 20px 0px !important;
     clear: both;
 }
 
-h1 {
+.SlimApp-content h1 {
     margin: 0px;
     font-size: 1.25rem;
 }
 
-h2 {
+.SlimApp-content h2 {
     margin: 0px;
     font-size: 0.9rem;
     font-weight: lighter;
 }
 
-h3 {
+.SlimApp-content h3 {
     margin: 0px;
     font-size: 0.8rem;
     font-weight: lighter;
@@ -62,4 +57,8 @@ h3 {
 .SlimApp-content ::-webkit-scrollbar-thumb {
     border-radius: 10px;
     -webkit-box-shadow: inset 0 0 5px rgba(0,0,0,0.5);
+}
+
+.SlimApp-content .no-padding { 
+    padding: 0!important;
 }

--- a/src/views/SlimApp.jsx
+++ b/src/views/SlimApp.jsx
@@ -9,7 +9,7 @@ import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import NavBar from '../nav/NavBar';
 import ShortcutViewer from '../viewer/ShortcutViewer';
 import FormList from '../forms/FormList';
-import FormSearch from '../forms/FormSearch';
+// import FormSearch from '../forms/FormSearch';
 // Shortcut Classes
 import ProgressionShortcut from '../shortcuts/ProgressionShortcut';
 import ToxicityShortcut from '../shortcuts/ToxicityShortcut';
@@ -32,11 +32,6 @@ class SlimApp extends Component {
      * Change the current shortcut to be the new type of shortcut  
      */
     changeShortcut = (shortcutType) => {
-        // console.log("structured field entered: " + field);
-
-        console.log("shortcut type");
-        console.log(shortcutType);
-
         if (Lang.isNull(shortcutType)) {
             this.setState({
                 currentShortcut: null
@@ -79,7 +74,8 @@ class SlimApp extends Component {
                         <div id="forms-panel">
                                 <Row center="xs">
                                     <Col className="no-padding" xs={3} >
-                                        <FormSearch />
+                                        {/*No need for formsearch right now*/}
+                                        {/*<FormSearch />*/}
                                         <FormList
                                             shortcuts={['Progression', 'Toxicity']}
                                             currentShortcut={this.state.currentShortcut}

--- a/src/views/SlimApp.jsx
+++ b/src/views/SlimApp.jsx
@@ -4,13 +4,12 @@ import {Grid, Row, Col} from 'react-flexbox-grid';
 // Material UI components:
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import lightBaseTheme from 'material-ui/styles/baseThemes/lightBaseTheme';
-import Paper from 'material-ui/Paper';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
 // Application components:
 import NavBar from '../nav/NavBar';
 import ShortcutViewer from '../viewer/ShortcutViewer';
-import FormTray from '../forms/FormTray';
 import FormList from '../forms/FormList';
+import FormSearch from '../forms/FormSearch';
 // Shortcut Classes
 import ProgressionShortcut from '../shortcuts/ProgressionShortcut';
 import ToxicityShortcut from '../shortcuts/ToxicityShortcut';
@@ -77,30 +76,23 @@ class SlimApp extends Component {
                 <div className="SlimApp">
                     <NavBar title="Flux Notes Lite"/>
                     <Grid className="SlimApp-content" fluid>
-                        <div id="forms-panel" className="dashboard-panel">
-                            <Paper className="panel-content trio">
+                        <div id="forms-panel">
                                 <Row center="xs">
-                                    <Col sm={3}>
+                                    <Col className="no-padding" xs={3} >
+                                        <FormSearch />
                                         <FormList
                                             shortcuts={['Progression', 'Toxicity']}
                                             currentShortcut={this.state.currentShortcut}
                                             changeShortcut={this.changeShortcut}
                                         />
-
-                                        {/*<FormTray*/}
-                                        {/*shortcuts={['progression', 'toxicity']}*/}
-                                        {/*currentShortcut={this.state.currentShortcut}*/}
-                                        {/*changeShortcut={this.changeShortcut}*/}
-                                        {/*/>*/}
                                     </Col>
-                                    <Col sm={9}>
+                                    <Col className="no-padding" xs={9}>
                                         <ShortcutViewer
                                             currentShortcut={this.state.currentShortcut}
                                             onShortcutUpdate={this.handleShortcutUpdate}
                                         />
                                     </Col>
                                 </Row>
-                            </Paper>
                         </div>
                     </Grid>
                 </div>


### PR DESCRIPTION
The main purpose of this PR is to unify the styling of the lite-mode shortcuts dropdown with Edwin's mockups. This involved making some new css for slimApp, making FullApp's css more specific to impact just FullApp components and removing some unnecessary classNames. It also suppresses warnings from an earlier push.

Edit: Dropdown was a misnomer; the PR modifies the styling of lite-mode formList on the left hand side