### PR TITLE
Create copy component

### DIFF
--- a/src/forms/FormList.css
+++ b/src/forms/FormList.css
@@ -4,6 +4,8 @@
     /*height: calc(100vh - 64px - 80px);*/
     height: calc(100vh - 64px);
     text-align: left;
+    overflow-y: scroll;
+    overflow: overlay;
 }
 
 #list-panel .list-element.unselected{ 

--- a/src/forms/FormList.jsx
+++ b/src/forms/FormList.jsx
@@ -1,7 +1,6 @@
 // React imports
 import React, {Component} from 'react';
 // material-ui
-import Paper from 'material-ui/Paper';
 import {List, ListItem} from 'material-ui/List';
 // Styling
 import './FormList.css';

--- a/src/forms/FormList.jsx
+++ b/src/forms/FormList.jsx
@@ -1,6 +1,7 @@
 // React imports
 import React, {Component} from 'react';
 // material-ui
+import Paper from 'material-ui/Paper';
 import {List, ListItem} from 'material-ui/List';
 // Styling
 import './FormList.css';
@@ -10,7 +11,7 @@ class FormList extends Component {
     constructor(props) {
         super(props);
         this._newShortcut = this._newShortcut.bind(this);
-        this.state = { 
+        this.state = {
             disabledElement: null
         }
     }
@@ -20,7 +21,7 @@ class FormList extends Component {
         this.props.changeShortcut(this.props.shortcuts[index]);
     }
 
-    _onTouchTap(event, shortcutName) { 
+    _onTouchTap(event, shortcutName) {
         this.setState({
             disabledElement: shortcutName
         });
@@ -35,7 +36,7 @@ class FormList extends Component {
                         let primaryText = shortcutName;
                         if (this.state.disabledElement === shortcutName) {
                             classValue += " selected";
-                        } else { 
+                        } else {
                             classValue += " unselected";
                         }
                         return (

--- a/src/viewer/ShortcutViewer.css
+++ b/src/viewer/ShortcutViewer.css
@@ -14,4 +14,14 @@
     margin-left: 5px;
     margin-top:  100px;
 }
-
+.row.vdivide [class*='col-']:not(:last-child):after {
+    background: red;
+    width: 1px;
+    content: "";
+    display:block;
+    position: absolute;
+    top:0;
+    bottom: 0;
+    right: 0;
+    min-height: 70px;
+}

--- a/src/viewer/ShortcutViewer.css
+++ b/src/viewer/ShortcutViewer.css
@@ -1,10 +1,12 @@
 
 #shortcut-viewer {
     background: white;
-    height: calc(100vh - 64px - 40px);
+
+    /* 64 fo navbar; 60px for top/bottom padding */
+    height: calc(100vh - 64px - 60px);
     text-align: left;
     z-index: 2;
-    padding: 20px;
+    padding: 30px 60px;
     -webkit-box-shadow: -3px 0px 5px -2px rgba(125,125,125,0.7);
     -moz-box-shadow: -3px 0px 5px -2px rgba(125,125,125,0.7);
     box-shadow: -3px 0px 5px -2px rgba(125,125,125,0.7);
@@ -13,9 +15,9 @@
 
 .btn_copy {
     display: inline-block;
-    margin-left: 5px;
     margin-top:  50px;
-}
+/*    width: 100%;
+*/}
 
 #copy-keyword:after {
     background: #b1b1b1;
@@ -26,7 +28,7 @@
     bottom: 0;
     right: 0;
     min-height: 20px;
-    margin: -5px 10px;
+    margin: -5px 20px -5px 20px; 
 }
 
 #copy-keyword {
@@ -35,7 +37,7 @@
 }
 
 #copy-content {
-    margin: 0 20px;
+    margin: 0 20px 0 0;
     display: inline-block;
 }
 

--- a/src/viewer/ShortcutViewer.css
+++ b/src/viewer/ShortcutViewer.css
@@ -1,5 +1,5 @@
 
-#shortcut-viewer { 
+#shortcut-viewer {
     background: white;
     height: calc(100vh - 64px - 40px);
     text-align: left;
@@ -13,3 +13,4 @@
 .btn_viewer {
     margin-left: 5px;
 }
+

--- a/src/viewer/ShortcutViewer.css
+++ b/src/viewer/ShortcutViewer.css
@@ -8,6 +8,7 @@
     -webkit-box-shadow: -3px 0px 5px -2px rgba(125,125,125,0.7);
     -moz-box-shadow: -3px 0px 5px -2px rgba(125,125,125,0.7);
     box-shadow: -3px 0px 5px -2px rgba(125,125,125,0.7);
+    overflow-y: scroll;
 }
 
 .btn_copy {

--- a/src/viewer/ShortcutViewer.css
+++ b/src/viewer/ShortcutViewer.css
@@ -10,7 +10,8 @@
     box-shadow: -3px 0px 5px -2px rgba(125,125,125,0.7);
 }
 
-.btn_viewer {
+.btn_copy {
     margin-left: 5px;
+    margin-top:  100px;
 }
 

--- a/src/viewer/ShortcutViewer.css
+++ b/src/viewer/ShortcutViewer.css
@@ -11,26 +11,41 @@
 }
 
 .btn_copy {
+    display: inline-block;
     margin-left: 5px;
     margin-top:  100px;
 }
 
-/*.btn-copy {*/
-    /*margin-left: 5px;*/
-    /*margin-top:  100px;*/
-    /*background-color: #7f7f7f;*/
-    /*cursor: hand;*/
-    /*border: solid lightgrey;*/
-/*}*/
+#copy-keyword:after {
+    background: #b1b1b1;
+    width: 1px;
+    content: "";
+    display:inline-block;
+    top:0;
+    bottom: 0;
+    right: 0;
+    min-height: 20px;
+    margin: -5px 10px;
+}
 
-/*.btn-copy .inline {*/
-    /*float:left;*/
-/*}*/
+#copy-keyword {
+    margin: 0 0 0 20px;
+    display: inline-block;
+}
 
-/*.btn-copy .btn-copy-start {*/
-    /*border-right: solid #9197a3;*/
-    /*border-width: 1px;*/
-    /*padding-right: 20px;*/
-/*}*/
+#copy-keyword-disabled {
+    margin: 0 0 0 20px;
+    display: inline-block;
+    color:#b1b1b1;
+}
 
+#copy-content {
+    margin: 0 20px;
+    display: inline-block;
+}
 
+#copy-content-disabled {
+    margin: 0 20px;
+    display: inline-block;
+    color: #b1b1b1;
+}

--- a/src/viewer/ShortcutViewer.css
+++ b/src/viewer/ShortcutViewer.css
@@ -13,7 +13,7 @@
 .btn_copy {
     display: inline-block;
     margin-left: 5px;
-    margin-top:  100px;
+    margin-top:  50px;
 }
 
 #copy-keyword:after {
@@ -33,19 +33,8 @@
     display: inline-block;
 }
 
-#copy-keyword-disabled {
-    margin: 0 0 0 20px;
-    display: inline-block;
-    color:#b1b1b1;
-}
-
 #copy-content {
     margin: 0 20px;
     display: inline-block;
 }
 
-#copy-content-disabled {
-    margin: 0 20px;
-    display: inline-block;
-    color: #b1b1b1;
-}

--- a/src/viewer/ShortcutViewer.css
+++ b/src/viewer/ShortcutViewer.css
@@ -14,14 +14,23 @@
     margin-left: 5px;
     margin-top:  100px;
 }
-.row.vdivide [class*='col-']:not(:last-child):after {
-    background: red;
-    width: 1px;
-    content: "";
-    display:block;
-    position: absolute;
-    top:0;
-    bottom: 0;
-    right: 0;
-    min-height: 70px;
-}
+
+/*.btn-copy {*/
+    /*margin-left: 5px;*/
+    /*margin-top:  100px;*/
+    /*background-color: #7f7f7f;*/
+    /*cursor: hand;*/
+    /*border: solid lightgrey;*/
+/*}*/
+
+/*.btn-copy .inline {*/
+    /*float:left;*/
+/*}*/
+
+/*.btn-copy .btn-copy-start {*/
+    /*border-right: solid #9197a3;*/
+    /*border-width: 1px;*/
+    /*padding-right: 20px;*/
+/*}*/
+
+

--- a/src/viewer/ShortcutViewer.jsx
+++ b/src/viewer/ShortcutViewer.jsx
@@ -20,6 +20,8 @@ class ShortcutViewer extends Component {
         let copyString = "COPY | ";
         let copyComponent = null;
         let disableCopyButton = true;
+        let copyKeywordClass = "copy-keyword-disabled";
+        let copyContentClass = "copy-content-disabled";
 
         if (this.props.currentShortcut == null) {
             copyComponent = null;
@@ -32,11 +34,15 @@ class ShortcutViewer extends Component {
 
                 if (copyString.indexOf('[') > -1) {
                     disableCopyButton = false;
+                    copyKeywordClass = "copy-keyword";
+                    copyContentClass = "copy-content";
 
                 } else {
                     disableCopyButton = true;
+                    copyKeywordClass = "copy-keyword-disabled";
+                    copyContentClass = "copy-content-disabled";
                 }
-                copyComponent = this._getCopyComponent(string, copyString, disableCopyButton);
+                copyComponent = this._getCopyComponent(string, disableCopyButton, copyKeywordClass, copyContentClass);
             }
         }
 
@@ -61,27 +67,24 @@ class ShortcutViewer extends Component {
             <span>{initialString}</span>
         );
     }
-    _getCopyComponent(string, copyString, disableCopyButton) {
+
+    _getCopyComponent(string, disableCopyButton, copyKeywordClass, copyContentClass) {
         return (
             <CopyToClipboard text={string}>
                 <RaisedButton
                     className="btn_copy"
                     labelStyle={{textTransform: "none"}}
-                    label={copyString}
+                    containerElement="copy-container"
                     disabled={disableCopyButton}
-                    onClick={(e) => this._handleClick(e)}
-                />
+                >
+                    <div id={copyKeywordClass}>
+                        Copy
+                    </div>
+                    <div id={copyContentClass}>
+                        {string}
+                    </div>
+                </RaisedButton>
             </CopyToClipboard>
-
-            // Playing around with making my own div button to cutomize styling
-            // <CopyToClipboard text={string}>
-            //     <div className="btn-copy">
-            //             <div className="inline btn-copy-start">Copy</div>
-            //             <div className="text-center inline">Two</div>
-            //     </div>
-            // </CopyToClipboard>
-
-
         );
     }
 }

--- a/src/viewer/ShortcutViewer.jsx
+++ b/src/viewer/ShortcutViewer.jsx
@@ -50,9 +50,18 @@ class ShortcutViewer extends Component {
             <CopyToClipboard text={string}>
                 <RaisedButton
                     className="btn_copy"
-                    labelStyle={{textTransform: "none"}}
-                    containerElement="copy-container"
-
+                    labelStyle={{
+                        textTransform: "none",
+                    }}
+                    buttonStyle={{
+                        textAlign: "left",
+                        height: "45px",
+                        // padding: "5px 0"
+                    }}
+                    overlayStyle={{
+                        padding: "5px 0 4px 0"
+                    }}
+                    fullWidth={true}
                 >
                     <div id="copy-keyword">
                         Copy

--- a/src/viewer/ShortcutViewer.jsx
+++ b/src/viewer/ShortcutViewer.jsx
@@ -17,11 +17,7 @@ class ShortcutViewer extends Component {
 
         let string = "";
         let initialString = "Choose a template from the left panel";
-        let copyString = "COPY | ";
         let copyComponent = null;
-        let disableCopyButton = true;
-        let copyKeywordClass = "copy-keyword-disabled";
-        let copyContentClass = "copy-content-disabled";
 
         if (this.props.currentShortcut == null) {
             copyComponent = null;
@@ -30,19 +26,7 @@ class ShortcutViewer extends Component {
         else {
             if (this.props.currentShortcut) {
                 string = this.props.currentShortcut.getAsString();
-                copyString += string;
-
-                if (copyString.indexOf('[') > -1) {
-                    disableCopyButton = false;
-                    copyKeywordClass = "copy-keyword";
-                    copyContentClass = "copy-content";
-
-                } else {
-                    disableCopyButton = true;
-                    copyKeywordClass = "copy-keyword-disabled";
-                    copyContentClass = "copy-content-disabled";
-                }
-                copyComponent = this._getCopyComponent(string, disableCopyButton, copyKeywordClass, copyContentClass);
+                copyComponent = this._getCopyComponent(string);
             }
         }
 
@@ -68,19 +52,19 @@ class ShortcutViewer extends Component {
         );
     }
 
-    _getCopyComponent(string, disableCopyButton, copyKeywordClass, copyContentClass) {
+    _getCopyComponent(string) {
         return (
             <CopyToClipboard text={string}>
                 <RaisedButton
                     className="btn_copy"
                     labelStyle={{textTransform: "none"}}
                     containerElement="copy-container"
-                    disabled={disableCopyButton}
+
                 >
-                    <div id={copyKeywordClass}>
+                    <div id="copy-keyword">
                         Copy
                     </div>
-                    <div id={copyContentClass}>
+                    <div id="copy-content">
                         {string}
                     </div>
                 </RaisedButton>

--- a/src/viewer/ShortcutViewer.jsx
+++ b/src/viewer/ShortcutViewer.jsx
@@ -72,25 +72,23 @@ class ShortcutViewer extends Component {
     }
     _getCopyComponent(string, copyString, disableCopyButton) {
         return (
-            // <CopyToClipboard text={string}>
-            //     <RaisedButton
-            //         className="btn_copy"
-            //         labelStyle={{textTransform: "none"}}
-            //         label={copyString}
-            //         disabled={disableCopyButton}
-            //         onClick={(e) => this._handleClick(e)}
-            //     />
-            // </CopyToClipboard>
-
             <CopyToClipboard text={string}>
-                <div className="container">
-                    <div className="row vdivide">
-                        <div className="col-sm-4 text-center"><h1>One</h1></div>
-                        <div className="col-sm-4 text-center"><h1>Two</h1></div>
-                        <div className="col-sm-4 text-center"><h1>Three</h1></div>
-                    </div>
-                </div>
+                <RaisedButton
+                    className="btn_copy"
+                    labelStyle={{textTransform: "none"}}
+                    label={copyString}
+                    disabled={disableCopyButton}
+                    onClick={(e) => this._handleClick(e)}
+                />
             </CopyToClipboard>
+
+            // Playing around with making my own div button to cutomize styling
+            // <CopyToClipboard text={string}>
+            //     <div className="btn-copy">
+            //             <div className="inline btn-copy-start">Copy</div>
+            //             <div className="text-center inline">Two</div>
+            //     </div>
+            // </CopyToClipboard>
 
 
         );

--- a/src/viewer/ShortcutViewer.jsx
+++ b/src/viewer/ShortcutViewer.jsx
@@ -49,15 +49,6 @@ class ShortcutViewer extends Component {
 
         return (
             <div id="shortcut-viewer">
-                <RaisedButton
-                    className="btn_viewer"
-                    label="Reset"
-                    onClick={(e) => this._handleResetClick(e)}
-                />
-
-
-                <Divider className="divider"/>
-
                 {panelContent}
                 <br/>
                 {copyComponent}

--- a/src/viewer/ShortcutViewer.jsx
+++ b/src/viewer/ShortcutViewer.jsx
@@ -19,13 +19,10 @@ class ShortcutViewer extends Component {
     render() {
 
         let string = "";
-
         let initialString = "Choose a template from the left panel";
-
         let copyString = "COPY | ";
-
         let copyComponent = null;
-
+        let disableCopyButton = true;
 
         if (this.props.currentShortcut == null) {
             string = initialString;
@@ -36,11 +33,20 @@ class ShortcutViewer extends Component {
             if (this.props.currentShortcut) {
                 string = this.props.currentShortcut.getAsString();
                 copyString += string;
-                copyComponent = this._getCopyComponent(string, copyString);
+
+                console.log("string: " + string);
+                console.log("copyString: " + copyString);
+
+                // TODO: check if string is more than "COPY | #<shortcut>" and if yes enable button
+                if (copyString === string) {
+                   console.log("nothing input yet");
+
+                } else {
+                    console.log("something was input");
+                }
+                copyComponent = this._getCopyComponent(string, copyString, disableCopyButton);
             }
         }
-
-
 
         let panelContent = null;
         if (!Lang.isNull(this.props.currentShortcut)) {
@@ -60,9 +66,9 @@ class ShortcutViewer extends Component {
                 {/*</CopyToClipboard>*/}
 
                 <RaisedButton
-                className="btn_viewer"
-                label="Reset"
-                onClick={(e) => this._handleResetClick(e)}
+                    className="btn_viewer"
+                    label="Reset"
+                    onClick={(e) => this._handleResetClick(e)}
                 />
 
 
@@ -70,10 +76,7 @@ class ShortcutViewer extends Component {
 
                 {panelContent}
                 <br/>
-                <div>
-                    {string}
-                </div>
-                <br/>
+
                 {copyComponent}
 
 
@@ -90,13 +93,14 @@ class ShortcutViewer extends Component {
         this.props.onShortcutUpdate(null);
     }
 
-    _getCopyComponent(string, copyString) {
+    _getCopyComponent(string, copyString, disableCopyButton) {
         return (
             <CopyToClipboard text={string}>
                 <RaisedButton
                     className="btn_copy"
                     labelStyle={{textTransform: "none"}}
                     label={copyString}
+                    disabled={disableCopyButton}
                     onClick={(e) => this._handleClick(e)}
                 />
             </CopyToClipboard>

--- a/src/viewer/ShortcutViewer.jsx
+++ b/src/viewer/ShortcutViewer.jsx
@@ -2,10 +2,7 @@
 import React, {Component} from 'react';
 import CopyToClipboard from 'react-copy-to-clipboard';
 
-
 // material-ui
-// import Paper from 'material-ui/Paper';
-// import Divider from 'material-ui/Divider';
 import RaisedButton from 'material-ui/RaisedButton';
 
 // Lodash component
@@ -25,7 +22,6 @@ class ShortcutViewer extends Component {
         let disableCopyButton = true;
 
         if (this.props.currentShortcut == null) {
-            string = initialString;
             copyComponent = null;
 
         }
@@ -34,15 +30,13 @@ class ShortcutViewer extends Component {
                 string = this.props.currentShortcut.getAsString();
                 copyString += string;
 
-                console.log("string: " + string);
-                console.log("copyString: " + copyString);
-
-                // TODO: check if string is more than "COPY | #<shortcut>" and if yes enable button
-                if (copyString === string) {
-                   console.log("nothing input yet");
+                if (copyString.indexOf('[') > -1) {
+                    console.log("something was input");
+                    disableCopyButton = false;
 
                 } else {
-                    console.log("something was input");
+                    console.log("nothing input yet");
+                    disableCopyButton = true;
                 }
                 copyComponent = this._getCopyComponent(string, copyString, disableCopyButton);
             }
@@ -51,20 +45,12 @@ class ShortcutViewer extends Component {
         let panelContent = null;
         if (!Lang.isNull(this.props.currentShortcut)) {
             panelContent = this.props.currentShortcut.getForm();
+        } else {
+            panelContent = this._getInitialState(initialString);
         }
 
         return (
             <div id="shortcut-viewer">
-
-
-                {/*<CopyToClipboard text={string}>*/}
-                {/*<RaisedButton*/}
-                {/*className="btn_viewer"*/}
-                {/*label="Copy"*/}
-                {/*onClick={(e) => this._handleClick(e)}*/}
-                {/*/>*/}
-                {/*</CopyToClipboard>*/}
-
                 <RaisedButton
                     className="btn_viewer"
                     label="Reset"
@@ -76,23 +62,17 @@ class ShortcutViewer extends Component {
 
                 {panelContent}
                 <br/>
-
                 {copyComponent}
-
-
             </div>
         )
     }
 
-    _handleClick(e) {
-        console.log("clicked copy button")
-    }
 
-    _handleResetClick(e) {
-        e.preventDefault();
-        this.props.onShortcutUpdate(null);
+    _getInitialState(initialString) {
+        return (
+            <span>{initialString}</span>
+        );
     }
-
     _getCopyComponent(string, copyString, disableCopyButton) {
         return (
             <CopyToClipboard text={string}>

--- a/src/viewer/ShortcutViewer.jsx
+++ b/src/viewer/ShortcutViewer.jsx
@@ -16,25 +16,18 @@ class ShortcutViewer extends Component {
     render() {
 
         let string = "";
-        let initialString = "Choose a template from the left panel";
         let copyComponent = null;
-
-        if (this.props.currentShortcut == null) {
-            copyComponent = null;
-
-        }
-        else {
-            if (this.props.currentShortcut) {
-                string = this.props.currentShortcut.getAsString();
-                copyComponent = this._getCopyComponent(string);
-            }
-        }
-
         let panelContent = null;
+
+        if (this.props.currentShortcut) {
+            string = this.props.currentShortcut.getAsString();
+            copyComponent = this._getCopyComponent(string);
+        }
+
         if (!Lang.isNull(this.props.currentShortcut)) {
             panelContent = this.props.currentShortcut.getForm();
         } else {
-            panelContent = this._getInitialState(initialString);
+            panelContent = this._getInitialState();
         }
 
         return (
@@ -48,7 +41,7 @@ class ShortcutViewer extends Component {
 
     _getInitialState(initialString) {
         return (
-            <span>{initialString}</span>
+            <span>Choose a template from the left panel</span>
         );
     }
 

--- a/src/viewer/ShortcutViewer.jsx
+++ b/src/viewer/ShortcutViewer.jsx
@@ -1,11 +1,12 @@
 // React imports
 import React, {Component} from 'react';
-// import CopyToClipboard from 'react-copy-to-clipboard';
+import CopyToClipboard from 'react-copy-to-clipboard';
+
 
 // material-ui
 // import Paper from 'material-ui/Paper';
 // import Divider from 'material-ui/Divider';
-// import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from 'material-ui/RaisedButton';
 
 // Lodash component
 import Lang from 'lodash'
@@ -19,14 +20,26 @@ class ShortcutViewer extends Component {
 
         let string = "";
 
+        let initialString = "Choose a template from the left panel";
+
+        let copyString = "COPY | ";
+
+        let copyComponent = null;
+
+
         if (this.props.currentShortcut == null) {
-            string = "Choose a template from the left panel";
+            string = initialString;
+            copyComponent = null;
+
         }
         else {
             if (this.props.currentShortcut) {
                 string = this.props.currentShortcut.getAsString();
+                copyString += string;
+                copyComponent = this._getCopyComponent(string, copyString);
             }
         }
+
 
 
         let panelContent = null;
@@ -39,27 +52,30 @@ class ShortcutViewer extends Component {
 
 
                 {/*<CopyToClipboard text={string}>*/}
-                    {/*<RaisedButton*/}
-                        {/*className="btn_viewer"*/}
-                        {/*label="Copy"*/}
-                        {/*onClick={(e) => this._handleClick(e)}*/}
-                    {/*/>*/}
+                {/*<RaisedButton*/}
+                {/*className="btn_viewer"*/}
+                {/*label="Copy"*/}
+                {/*onClick={(e) => this._handleClick(e)}*/}
+                {/*/>*/}
                 {/*</CopyToClipboard>*/}
 
-                {/*<RaisedButton*/}
-                    {/*className="btn_viewer"*/}
-                    {/*label="Reset"*/}
-                    {/*onClick={(e) => this._handleResetClick(e)}*/}
-                {/*/>*/}
+                <RaisedButton
+                className="btn_viewer"
+                label="Reset"
+                onClick={(e) => this._handleResetClick(e)}
+                />
 
 
-                {/*<Divider className="divider"/>*/}
-              
+                <Divider className="divider"/>
+
                 {panelContent}
                 <br/>
                 <div>
                     {string}
                 </div>
+                <br/>
+                {copyComponent}
+
 
             </div>
         )
@@ -73,6 +89,20 @@ class ShortcutViewer extends Component {
         e.preventDefault();
         this.props.onShortcutUpdate(null);
     }
+
+    _getCopyComponent(string, copyString) {
+        return (
+            <CopyToClipboard text={string}>
+                <RaisedButton
+                    className="btn_copy"
+                    labelStyle={{textTransform: "none"}}
+                    label={copyString}
+                    onClick={(e) => this._handleClick(e)}
+                />
+            </CopyToClipboard>
+        );
+    }
+
 }
 
 export default ShortcutViewer;

--- a/src/viewer/ShortcutViewer.jsx
+++ b/src/viewer/ShortcutViewer.jsx
@@ -31,11 +31,9 @@ class ShortcutViewer extends Component {
                 copyString += string;
 
                 if (copyString.indexOf('[') > -1) {
-                    console.log("something was input");
                     disableCopyButton = false;
 
                 } else {
-                    console.log("nothing input yet");
                     disableCopyButton = true;
                 }
                 copyComponent = this._getCopyComponent(string, copyString, disableCopyButton);
@@ -67,7 +65,6 @@ class ShortcutViewer extends Component {
         )
     }
 
-
     _getInitialState(initialString) {
         return (
             <span>{initialString}</span>
@@ -75,18 +72,29 @@ class ShortcutViewer extends Component {
     }
     _getCopyComponent(string, copyString, disableCopyButton) {
         return (
+            // <CopyToClipboard text={string}>
+            //     <RaisedButton
+            //         className="btn_copy"
+            //         labelStyle={{textTransform: "none"}}
+            //         label={copyString}
+            //         disabled={disableCopyButton}
+            //         onClick={(e) => this._handleClick(e)}
+            //     />
+            // </CopyToClipboard>
+
             <CopyToClipboard text={string}>
-                <RaisedButton
-                    className="btn_copy"
-                    labelStyle={{textTransform: "none"}}
-                    label={copyString}
-                    disabled={disableCopyButton}
-                    onClick={(e) => this._handleClick(e)}
-                />
+                <div className="container">
+                    <div className="row vdivide">
+                        <div className="col-sm-4 text-center"><h1>One</h1></div>
+                        <div className="col-sm-4 text-center"><h1>Two</h1></div>
+                        <div className="col-sm-4 text-center"><h1>Three</h1></div>
+                    </div>
+                </div>
             </CopyToClipboard>
+
+
         );
     }
-
 }
 
 export default ShortcutViewer;


### PR DESCRIPTION
Created a new copy button that models the mockup. Copy button is initially disabled until user selects values from the shortcut template. The copy button text updates as the user builds the shortcut string (following the mockup design). Clicking on the copy button copies the shortcut string to the clip board. With Dylan's help, styled material-ui's raised button component to more closely match the mockups