### PR TITLE
Enter click within dropdown now moves selection forward

### DIFF
--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -358,13 +358,13 @@ function onUpDown(event, data, state, opts) {
 	//console.log('onUpDown DONE');
 }
 
-function onEnter(event, data, state, opts) {
-	//console.log('onEnter START');
-/*    event.preventDefault();
 
-    return insertRow(opts, state.transform())
-        .apply();*/
-	//console.log('onEnter DONE')
+function onEnter(event, data, state, opts) {
+	console.log('onEnter START');
+	event.preventDefault();
+	let result = moveField(state, opts, 1);
+	return result;
+	console.log('onEnter DONE')
 }
 
 function moveField(state, opts, fieldDelta) {


### PR DESCRIPTION
Clicking enter when focused on a dropdown moves you over to the next structured field. I haven't implemented a shift-enter functionality because it feels somewhat foreign to me, but if someone feels passionately that shift-enter should move you backwards, I'm happy to implement that feature!