### PR TITLE
Update progression form

### DIFF
--- a/src/forms/ProgressionForm.css
+++ b/src/forms/ProgressionForm.css
@@ -19,7 +19,7 @@
     position: absolute;
     z-index: 1;
     bottom: 125%;
-    margin-left: -60px;
+    margin-left: 18px !important;
     opacity: 0;
     transition: opacity 1s;
     font-size: .8rem;

--- a/src/forms/ProgressionForm.css
+++ b/src/forms/ProgressionForm.css
@@ -48,7 +48,7 @@
 }
 
 .btn-group-status-progression {
-
+    /*background-color: #001A33;*/
 }
 
 /*.btn-progression {*/

--- a/src/forms/ProgressionForm.css
+++ b/src/forms/ProgressionForm.css
@@ -46,3 +46,11 @@
     opacity: 1;
     transition-delay: 0.5s;
 }
+
+.btn-group-status-progression {
+
+}
+
+/*.btn-progression {*/
+    /*margin: 15px;*/
+/*}*/

--- a/src/forms/ProgressionForm.jsx
+++ b/src/forms/ProgressionForm.jsx
@@ -18,6 +18,7 @@ class ProgressionForm extends Component {
         this.state = {
             statusOptions: progressionLookup.getStatusOptions(),
             reasonOptions: progressionLookup.getReasonOptions(),
+            reasonButtonsActiveState: []
         };
     }
 
@@ -34,9 +35,13 @@ class ProgressionForm extends Component {
         this.props.onProgressionUpdate(newProgression);
     }
 
-    handleReasonSelection = (reason, isChecked) => {
+    handleReasonSelection = (reason, i) => {
+
+        // set active button state array
+        this.state.reasonButtonsActiveState[i] =! this.state.reasonButtonsActiveState[i];
+
         const reasonIndex = this.props.progression.reason.findIndex((r) => r === reason.name);
-        if (isChecked) {
+        if (this.state.reasonButtonsActiveState[i]) {
             // Index should be -1; if it isn't don't add to array
             if (reasonIndex === -1) {
                 console.log(`about to add reason ${reason.name} to list of progression reasons`);
@@ -62,6 +67,7 @@ class ProgressionForm extends Component {
                 console.log(`Cornercase: the element ${reason.name} should be in our current reasons, but it isn't`);
             }
         }
+
     }
 
     renderStatusMenuItem = (status) => {
@@ -86,10 +92,52 @@ class ProgressionForm extends Component {
         )
     }
 
+    renderReasonButtonGroup = (reason, i) => {
+
+        let reasonName = reason.name;
+        let reasonDescription = reason.description;
+        let backgroundColor = "";
+        let labelColor = "";
+
+        if (this.state.reasonButtonsActiveState[i]) {
+            backgroundColor="#1a75ff";
+            labelColor="#fff";
+        } else {
+            backgroundColor="";
+            labelColor="";
+        }
+
+        const buttonClass = (reasonDescription.length > 100) ? "tooltiptext large" : "tooltiptext";
+
+        return (
+            <div key={reasonName} className="tooltip">
+                <span id={reasonName} className={buttonClass}>{reasonDescription}</span>
+                <RaisedButton
+                    key={i}
+                    label={reasonName}
+                    labelStyle={{
+                        textTransform: "none",
+                    }}
+                    buttonStyle={{
+                        height: "75px",
+                        width: "200px"
+                    }}
+                    overlayStyle={{
+                        padding: "20px 0 20px 0"
+                    }}
+                    style={{margin: 0.5}}
+
+                    onClick={(e, isChecked) => this.handleReasonSelection(reason, i)}
+
+                    backgroundColor={backgroundColor}
+                    labelColor={labelColor}
+                >
+                </RaisedButton>
+            </div>
+        )
+    }
+
     render() {
-        const style = {
-            margin: 0.5,
-        };
         return (
             <div>
                 <h1>Disease Progression</h1>
@@ -133,7 +181,7 @@ class ProgressionForm extends Component {
                                     overlayStyle={{
                                         padding: "20px 0 20px 0"
                                     }}
-                                    style={style}
+                                    style={{margin: 0.5}}
                                     onClick={(e) => this.handleStatusSelection(e, i)}
                                     disabled={this.currentlySelected(this.props.progression.status, this.state.statusOptions[i].name)}
                                 >
@@ -147,9 +195,16 @@ class ProgressionForm extends Component {
                 <p id="data-element-description">
                     {progressionLookup.getDescription("reason")}
                 </p>
+
                 {this.state.reasonOptions.map((reason, i) => {
                     return this.renderReasonCheckbox(reason, i)
                 })}
+
+                <div className="btn-group-reason-progression">
+                    {this.state.reasonOptions.map((reason, i) => {
+                        return this.renderReasonButtonGroup(reason, i)
+                    })}
+                </div>
             </div>
         );
     }

--- a/src/forms/ProgressionForm.jsx
+++ b/src/forms/ProgressionForm.jsx
@@ -5,6 +5,7 @@ import Divider from 'material-ui/Divider';
 import SelectField from 'material-ui/SelectField';
 import MenuItem from 'material-ui/MenuItem';
 import Checkbox from 'material-ui/Checkbox';
+import RaisedButton from 'material-ui/RaisedButton';
 // Libraries
 import progressionLookup from '../lib/progression_lookup';
 // Styling
@@ -84,6 +85,9 @@ class ProgressionForm extends Component {
   }
 
   render() {
+      const style = {
+          margin: 0.5,
+      };
     return (
         <div>
             <h1>Disease Progression</h1>
@@ -105,6 +109,37 @@ class ProgressionForm extends Component {
                   return this.renderStatusMenuItem(status)
               })}
             </SelectField>
+
+            <div className="btn-group-status-progression">
+                <RaisedButton
+                    className="btn_progression"
+                    label="Test"
+                    labelStyle={{
+                        textTransform: "none",
+                    }}
+                    style={style}
+
+                >
+                </RaisedButton>
+                <RaisedButton
+                    label="Test2"
+                    labelStyle={{
+                        textTransform: "none",
+                    }}
+                    buttonStyle={{
+                        height: "45px",
+                    }}
+                    overlayStyle={{
+                        padding: "5px 0 4px 0"
+                    }}
+                    style={style}
+
+                >
+                </RaisedButton>
+                <RaisedButton label="Primary" style={style} />
+                <RaisedButton label="Primary" style={style}/>
+            </div>
+
 
             <h4>Progression Reasons</h4>
             <p id="data-element-description">

--- a/src/forms/ProgressionForm.jsx
+++ b/src/forms/ProgressionForm.jsx
@@ -2,13 +2,8 @@
 import React, {Component} from 'react';
 // material-ui
 import Divider from 'material-ui/Divider';
-import SelectField from 'material-ui/SelectField';
-import MenuItem from 'material-ui/MenuItem';
-import Checkbox from 'material-ui/Checkbox';
 import RaisedButton from 'material-ui/RaisedButton';
-// Libraries
 import progressionLookup from '../lib/progression_lookup';
-// Styling
 import './ProgressionForm.css';
 
 class ProgressionForm extends Component {
@@ -29,7 +24,6 @@ class ProgressionForm extends Component {
     handleStatusSelection = (e, i) => {
         e.preventDefault();
         const newStatus = this.state.statusOptions[i].name;
-        console.log(`ProgressionForm.handleStatusSelection Status #${i} ${newStatus}`);
         const newProgression = {...this.props.progression};
         newProgression["status"] = newStatus;
         this.props.onProgressionUpdate(newProgression);
@@ -38,13 +32,17 @@ class ProgressionForm extends Component {
     handleReasonSelection = (reason, i) => {
 
         // set active button state array
-        this.state.reasonButtonsActiveState[i] =! this.state.reasonButtonsActiveState[i];
+        let newArray = this.state.reasonButtonsActiveState;
+        newArray[i] =! this.state.reasonButtonsActiveState[i];
+
+        this.setState({
+            reasonButtonsActiveState: newArray
+        });
 
         const reasonIndex = this.props.progression.reason.findIndex((r) => r === reason.name);
         if (this.state.reasonButtonsActiveState[i]) {
             // Index should be -1; if it isn't don't add to array
             if (reasonIndex === -1) {
-                console.log(`about to add reason ${reason.name} to list of progression reasons`);
                 const newReasons = [...this.props.progression.reason];
                 newReasons.push(reason.name);
                 const newProgression = {...this.props.progression};
@@ -52,44 +50,22 @@ class ProgressionForm extends Component {
                 this.props.onProgressionUpdate(newProgression);
             } else {
                 // Nothing -- the element is already in there
-                console.log(`Cornercase; the element ${reason.name} shouldnt have been in our current reasons, but it was`);
+                console.log(`[WARNING] Cornercase; the element ${reason.name} shouldnt have been in our current reasons, but it was`);
             }
         } else {
             // Index shouldn't be -1; if it is, don't remove it again;
             if (reasonIndex !== -1) {
-                console.log(`about to remove element ${reason.name} from progression reasons`);
+
                 const filteredReasons = this.props.progression.reason.filter((r) => r !== reason.name);
                 const newProgression = {...this.props.progression};
                 newProgression["reason"] = filteredReasons;
                 this.props.onProgressionUpdate(newProgression);
             } else {
                 // Nothing -- the element is already removed from the array;
-                console.log(`Cornercase: the element ${reason.name} should be in our current reasons, but it isn't`);
+                console.log(`[WARNING] Cornercase: the element ${reason.name} should be in our current reasons, but it isn't`);
             }
         }
 
-    }
-
-    renderStatusMenuItem = (status) => {
-        return (
-            <MenuItem
-                key={status.name}
-                value={status.name}
-                primaryText={status.name}
-            />
-        )
-    }
-
-    renderReasonCheckbox = (reason, i) => {
-        const isChecked = this.props.progression.reason.some((curReason) => curReason.toLowerCase() === reason.name.toLowerCase());
-        return (
-            <Checkbox
-                key={i}
-                checked={isChecked}
-                onCheck={(e, isChecked) => this.handleReasonSelection(reason, isChecked)}
-                label={reason.name}
-            />
-        )
     }
 
     renderReasonButtonGroup = (reason, i) => {
@@ -100,7 +76,7 @@ class ProgressionForm extends Component {
         let labelColor = "";
 
         if (this.state.reasonButtonsActiveState[i]) {
-            backgroundColor="#1a75ff";
+            backgroundColor="#6666ff";
             labelColor="#fff";
         } else {
             backgroundColor="";
@@ -150,15 +126,6 @@ class ProgressionForm extends Component {
                 <p id="data-element-description">
                     {progressionLookup.getDescription("status")}
                 </p>
-                <SelectField
-                    value={this.props.progression.status}
-                    hintText="Status"
-                    onChange={this.handleStatusSelection}
-                >
-                    {this.state.statusOptions.map((status, i) => {
-                        return this.renderStatusMenuItem(status)
-                    })}
-                </SelectField>
 
                 <div className="btn-group-status-progression">
                     {this.state.statusOptions.map((status, i) => {
@@ -184,6 +151,8 @@ class ProgressionForm extends Component {
                                     style={{margin: 0.5}}
                                     onClick={(e) => this.handleStatusSelection(e, i)}
                                     disabled={this.currentlySelected(this.props.progression.status, this.state.statusOptions[i].name)}
+                                    disabledBackgroundColor="#6666ff"
+                                    disabledLabelColor="#fff"
                                 >
                                 </RaisedButton>
                             </div>
@@ -195,10 +164,6 @@ class ProgressionForm extends Component {
                 <p id="data-element-description">
                     {progressionLookup.getDescription("reason")}
                 </p>
-
-                {this.state.reasonOptions.map((reason, i) => {
-                    return this.renderReasonCheckbox(reason, i)
-                })}
 
                 <div className="btn-group-reason-progression">
                     {this.state.reasonOptions.map((reason, i) => {

--- a/src/forms/ProgressionForm.jsx
+++ b/src/forms/ProgressionForm.jsx
@@ -98,7 +98,7 @@ class ProgressionForm extends Component {
                 </p>
                 <Divider className="divider"/>
 
-                <h4>Progression Status</h4>
+                <h4>Status of progression</h4>
                 <p id="data-element-description">
                     {progressionLookup.getDescription("status")}
                 </p>
@@ -138,7 +138,7 @@ class ProgressionForm extends Component {
                     })}
                 </div>
 
-                <h4>Progression Reasons</h4>
+                <h4>Rationale for status</h4>
                 <p id="data-element-description">
                     {progressionLookup.getDescription("reason")}
                 </p>

--- a/src/forms/ProgressionForm.jsx
+++ b/src/forms/ProgressionForm.jsx
@@ -74,7 +74,7 @@ class ProgressionForm extends Component {
         let labelColor = "";
 
         if (this.state.reasonButtonsActiveState[i]) {
-            backgroundColor = "#6666ff";
+            backgroundColor = "#297DA2";
             labelColor = "#fff";
         } else {
             backgroundColor = "";
@@ -94,7 +94,7 @@ class ProgressionForm extends Component {
                     }}
                     buttonStyle={{
                         height: "75px",
-                        width: "200px"
+                        width: "180px"
                     }}
                     overlayStyle={{
                         padding: "20px 0 20px 0"
@@ -141,7 +141,7 @@ class ProgressionForm extends Component {
                                     }}
                                     buttonStyle={{
                                         height: "75px",
-                                        width: "200px"
+                                        width: "180px"
                                     }}
                                     overlayStyle={{
                                         padding: "20px 0 20px 0"
@@ -149,7 +149,7 @@ class ProgressionForm extends Component {
                                     style={{margin: 0.5}}
                                     onClick={(e) => this.handleStatusSelection(e, i)}
                                     disabled={this.currentlySelected(this.props.progression.status, this.state.statusOptions[i].name)}
-                                    disabledBackgroundColor="#6666ff"
+                                    disabledBackgroundColor="#297DA2"
                                     disabledLabelColor="#fff"
                                 >
                                 </RaisedButton>

--- a/src/forms/ProgressionForm.jsx
+++ b/src/forms/ProgressionForm.jsx
@@ -115,25 +115,30 @@ class ProgressionForm extends Component {
                 <div className="btn-group-status-progression">
                     {this.state.statusOptions.map((status, i) => {
                         let statusName = status.name;
+                        let statusDescription = status.description;
+                        const buttonClass = (statusDescription.length > 100) ? "tooltiptext large" : "tooltiptext";
                         return (
-                            <RaisedButton
-                                key={i}
-                                label={statusName}
-                                labelStyle={{
-                                    textTransform: "none",
-                                }}
-                                buttonStyle={{
-                                    height: "75px",
-                                    width: "200px"
-                                }}
-                                overlayStyle={{
-                                    padding: "20px 0 20px 0"
-                                }}
-                                style={style}
-                                onClick={(e) => this.handleStatusSelection(e, i)}
-                                disabled={this.currentlySelected(this.props.progression.status, this.state.statusOptions[i].name)}
-                            >
-                            </RaisedButton>
+                            <div key={statusName} className="tooltip">
+                                <span id={statusName} className={buttonClass}>{statusDescription}</span>
+                                <RaisedButton
+                                    key={i}
+                                    label={statusName}
+                                    labelStyle={{
+                                        textTransform: "none",
+                                    }}
+                                    buttonStyle={{
+                                        height: "75px",
+                                        width: "200px"
+                                    }}
+                                    overlayStyle={{
+                                        padding: "20px 0 20px 0"
+                                    }}
+                                    style={style}
+                                    onClick={(e) => this.handleStatusSelection(e, i)}
+                                    disabled={this.currentlySelected(this.props.progression.status, this.state.statusOptions[i].name)}
+                                >
+                                </RaisedButton>
+                            </div>
                         );
                     })}
                 </div>

--- a/src/forms/ProgressionForm.jsx
+++ b/src/forms/ProgressionForm.jsx
@@ -113,9 +113,7 @@ class ProgressionForm extends Component {
             <div className="btn-group-status-progression">
                 {this.state.statusOptions.map((status, i) => {
                     let statusName = status.name;
-                    console.log(statusName);
                     return (
-
                         <RaisedButton
                             key={i}
                             label={statusName}
@@ -130,16 +128,12 @@ class ProgressionForm extends Component {
                                 padding: "20px 0 20px 0"
                             }}
                             style={style}
+                            onClick={(e) => this.handleStatusSelection(e, i)}
                         >
                         </RaisedButton>
-
                     );
                 })}
-
-
-
             </div>
-
 
             <h4>Progression Reasons</h4>
             <p id="data-element-description">

--- a/src/forms/ProgressionForm.jsx
+++ b/src/forms/ProgressionForm.jsx
@@ -21,10 +21,10 @@ class ProgressionForm extends Component {
       };
   }
 
-  handleStatusSelecion = (e, i) => {
+  handleStatusSelection = (e, i) => {
     e.preventDefault();
     const newStatus = this.state.statusOptions[i].name; 
-    console.log(`ProgressionForm.handleStatusSelecion Status #${i} ${newStatus}`);
+    console.log(`ProgressionForm.handleStatusSelection Status #${i} ${newStatus}`);
     const newProgression = { ...this.props.progression}; 
     newProgression["status"] = newStatus;
     this.props.onProgressionUpdate(newProgression);
@@ -103,7 +103,7 @@ class ProgressionForm extends Component {
             <SelectField
               value={this.props.progression.status}
               hintText="Status"
-              onChange={this.handleStatusSelecion}
+              onChange={this.handleStatusSelection}
             >
               {this.state.statusOptions.map((status, i) => {
                   return this.renderStatusMenuItem(status)
@@ -111,33 +111,33 @@ class ProgressionForm extends Component {
             </SelectField>
 
             <div className="btn-group-status-progression">
-                <RaisedButton
-                    className="btn_progression"
-                    label="Test"
-                    labelStyle={{
-                        textTransform: "none",
-                    }}
-                    style={style}
+                {this.state.statusOptions.map((status, i) => {
+                    let statusName = status.name;
+                    console.log(statusName);
+                    return (
 
-                >
-                </RaisedButton>
-                <RaisedButton
-                    label="Test2"
-                    labelStyle={{
-                        textTransform: "none",
-                    }}
-                    buttonStyle={{
-                        height: "45px",
-                    }}
-                    overlayStyle={{
-                        padding: "5px 0 4px 0"
-                    }}
-                    style={style}
+                        <RaisedButton
+                            key={i}
+                            label={statusName}
+                            labelStyle={{
+                                textTransform: "none",
+                            }}
+                            buttonStyle={{
+                                height: "75px",
+                                width: "200px"
+                            }}
+                            overlayStyle={{
+                                padding: "20px 0 20px 0"
+                            }}
+                            style={style}
+                        >
+                        </RaisedButton>
 
-                >
-                </RaisedButton>
-                <RaisedButton label="Primary" style={style} />
-                <RaisedButton label="Primary" style={style}/>
+                    );
+                })}
+
+
+
             </div>
 
 

--- a/src/forms/ProgressionForm.jsx
+++ b/src/forms/ProgressionForm.jsx
@@ -1,6 +1,4 @@
-// React imports
 import React, {Component} from 'react';
-// material-ui
 import Divider from 'material-ui/Divider';
 import RaisedButton from 'material-ui/RaisedButton';
 import progressionLookup from '../lib/progression_lookup';
@@ -33,7 +31,7 @@ class ProgressionForm extends Component {
 
         // set active button state array
         let newArray = this.state.reasonButtonsActiveState;
-        newArray[i] =! this.state.reasonButtonsActiveState[i];
+        newArray[i] = !this.state.reasonButtonsActiveState[i];
 
         this.setState({
             reasonButtonsActiveState: newArray
@@ -76,11 +74,11 @@ class ProgressionForm extends Component {
         let labelColor = "";
 
         if (this.state.reasonButtonsActiveState[i]) {
-            backgroundColor="#6666ff";
-            labelColor="#fff";
+            backgroundColor = "#6666ff";
+            labelColor = "#fff";
         } else {
-            backgroundColor="";
-            labelColor="";
+            backgroundColor = "";
+            labelColor = "";
         }
 
         const buttonClass = (reasonDescription.length > 100) ? "tooltiptext large" : "tooltiptext";

--- a/src/forms/ProgressionForm.jsx
+++ b/src/forms/ProgressionForm.jsx
@@ -1,5 +1,5 @@
 // React imports
-import React, { Component } from 'react';
+import React, {Component} from 'react';
 // material-ui
 import Divider from 'material-ui/Divider';
 import SelectField from 'material-ui/SelectField';
@@ -12,146 +12,142 @@ import progressionLookup from '../lib/progression_lookup';
 import './ProgressionForm.css';
 
 class ProgressionForm extends Component {
-  constructor(props) {
-      super(props);
+    constructor(props) {
+        super(props);
 
-      this.state = {
-        statusOptions: progressionLookup.getStatusOptions(),
-        reasonOptions: progressionLookup.getReasonOptions(),
-      };
-  }
-
-  handleStatusSelection = (e, i) => {
-    e.preventDefault();
-    const newStatus = this.state.statusOptions[i].name; 
-    console.log(`ProgressionForm.handleStatusSelection Status #${i} ${newStatus}`);
-    const newProgression = { ...this.props.progression}; 
-    newProgression["status"] = newStatus;
-    this.props.onProgressionUpdate(newProgression);
-  }
-
-  handleReasonSelection = (reason, isChecked) => {
-    const reasonIndex = this.props.progression.reason.findIndex((r) => r === reason.name);
-    if (isChecked) {
-      // Index should be -1; if it isn't don't add to array
-      if (reasonIndex === -1) {
-        console.log(`about to add reason ${reason.name} to list of progression reasons`);
-        const newReasons = [...this.props.progression.reason];
-        newReasons.push(reason.name);
-        const newProgression = { ...this.props.progression}; 
-        newProgression["reason"] = newReasons;
-        this.props.onProgressionUpdate(newProgression);
-      } else { 
-        // Nothing -- the element is already in there
-        console.log(`Cornercase; the element ${reason.name} shouldnt have been in our current reasons, but it was`);
-      }
-    } else { 
-      // Index shouldn't be -1; if it is, don't remove it again;
-      if(reasonIndex !== -1) { 
-        console.log(`about to remove element ${reason.name} from progression reasons`);
-        const filteredReasons = this.props.progression.reason.filter((r) => r !== reason.name);
-        const newProgression = { ...this.props.progression}; 
-        newProgression["reason"] = filteredReasons;
-        this.props.onProgressionUpdate(newProgression);
-      } else { 
-        // Nothing -- the element is already removed from the array;
-        console.log(`Cornercase: the element ${reason.name} should be in our current reasons, but it isn't`);
-      }
+        this.state = {
+            statusOptions: progressionLookup.getStatusOptions(),
+            reasonOptions: progressionLookup.getReasonOptions(),
+        };
     }
-  }
 
-  renderStatusMenuItem = (status) => { 
-    return (
-      <MenuItem 
-        key={status.name} 
-        value={status.name} 
-        primaryText={status.name} 
-      />
-    ) 
-  }
+    currentlySelected(item, i) {
+        return (item === i ? true : false);
+    }
 
-  renderReasonCheckbox = (reason, i) => {
-    
+    handleStatusSelection = (e, i) => {
+        e.preventDefault();
+        const newStatus = this.state.statusOptions[i].name;
+        console.log(`ProgressionForm.handleStatusSelection Status #${i} ${newStatus}`);
+        const newProgression = {...this.props.progression};
+        newProgression["status"] = newStatus;
+        this.props.onProgressionUpdate(newProgression);
+    }
 
-    const isChecked = this.props.progression.reason.some((curReason) => curReason.toLowerCase() === reason.name.toLowerCase());
-    return (
-      <Checkbox
-        key={i}
-        checked={isChecked}
-        onCheck={(e, isChecked) => this.handleReasonSelection(reason, isChecked)}
-        label={reason.name}
-      />
-    )
-  }
+    handleReasonSelection = (reason, isChecked) => {
+        const reasonIndex = this.props.progression.reason.findIndex((r) => r === reason.name);
+        if (isChecked) {
+            // Index should be -1; if it isn't don't add to array
+            if (reasonIndex === -1) {
+                console.log(`about to add reason ${reason.name} to list of progression reasons`);
+                const newReasons = [...this.props.progression.reason];
+                newReasons.push(reason.name);
+                const newProgression = {...this.props.progression};
+                newProgression["reason"] = newReasons;
+                this.props.onProgressionUpdate(newProgression);
+            } else {
+                // Nothing -- the element is already in there
+                console.log(`Cornercase; the element ${reason.name} shouldnt have been in our current reasons, but it was`);
+            }
+        } else {
+            // Index shouldn't be -1; if it is, don't remove it again;
+            if (reasonIndex !== -1) {
+                console.log(`about to remove element ${reason.name} from progression reasons`);
+                const filteredReasons = this.props.progression.reason.filter((r) => r !== reason.name);
+                const newProgression = {...this.props.progression};
+                newProgression["reason"] = filteredReasons;
+                this.props.onProgressionUpdate(newProgression);
+            } else {
+                // Nothing -- the element is already removed from the array;
+                console.log(`Cornercase: the element ${reason.name} should be in our current reasons, but it isn't`);
+            }
+        }
+    }
 
-  render() {
-      const style = {
-          margin: 0.5,
-      };
-    return (
-        <div>
-            <h1>Disease Progression</h1>
-            <p id="data-element-description">
-              {progressionLookup.getDescription("progression")}
-            </p>
-            <Divider className="divider" />
+    renderStatusMenuItem = (status) => {
+        return (
+            <MenuItem
+                key={status.name}
+                value={status.name}
+                primaryText={status.name}
+            />
+        )
+    }
 
-            <h4>Progression Status</h4>
-            <p id="data-element-description">
-              {progressionLookup.getDescription("status")}
-            </p>
-            <SelectField
-              value={this.props.progression.status}
-              hintText="Status"
-              onChange={this.handleStatusSelection}
-            >
-              {this.state.statusOptions.map((status, i) => {
-                  return this.renderStatusMenuItem(status)
-              })}
-            </SelectField>
+    renderReasonCheckbox = (reason, i) => {
+        const isChecked = this.props.progression.reason.some((curReason) => curReason.toLowerCase() === reason.name.toLowerCase());
+        return (
+            <Checkbox
+                key={i}
+                checked={isChecked}
+                onCheck={(e, isChecked) => this.handleReasonSelection(reason, isChecked)}
+                label={reason.name}
+            />
+        )
+    }
 
-            <div className="btn-group-status-progression">
-                {this.state.statusOptions.map((status, i) => {
-                    let statusName = status.name;
-                    return (
-                        <RaisedButton
-                            key={i}
-                            label={statusName}
-                            labelStyle={{
-                                textTransform: "none",
-                            }}
-                            buttonStyle={{
-                                height: "75px",
-                                width: "200px"
-                            }}
-                            overlayStyle={{
-                                padding: "20px 0 20px 0"
-                            }}
-                            style={style}
-                            onClick={(e) => this.handleStatusSelection(e, i)}
-                        >
-                        </RaisedButton>
-                    );
+    render() {
+        const style = {
+            margin: 0.5,
+        };
+        return (
+            <div>
+                <h1>Disease Progression</h1>
+                <p id="data-element-description">
+                    {progressionLookup.getDescription("progression")}
+                </p>
+                <Divider className="divider"/>
+
+                <h4>Progression Status</h4>
+                <p id="data-element-description">
+                    {progressionLookup.getDescription("status")}
+                </p>
+                <SelectField
+                    value={this.props.progression.status}
+                    hintText="Status"
+                    onChange={this.handleStatusSelection}
+                >
+                    {this.state.statusOptions.map((status, i) => {
+                        return this.renderStatusMenuItem(status)
+                    })}
+                </SelectField>
+
+                <div className="btn-group-status-progression">
+                    {this.state.statusOptions.map((status, i) => {
+                        let statusName = status.name;
+                        return (
+                            <RaisedButton
+                                key={i}
+                                label={statusName}
+                                labelStyle={{
+                                    textTransform: "none",
+                                }}
+                                buttonStyle={{
+                                    height: "75px",
+                                    width: "200px"
+                                }}
+                                overlayStyle={{
+                                    padding: "20px 0 20px 0"
+                                }}
+                                style={style}
+                                onClick={(e) => this.handleStatusSelection(e, i)}
+                                disabled={this.currentlySelected(this.props.progression.status, this.state.statusOptions[i].name)}
+                            >
+                            </RaisedButton>
+                        );
+                    })}
+                </div>
+
+                <h4>Progression Reasons</h4>
+                <p id="data-element-description">
+                    {progressionLookup.getDescription("reason")}
+                </p>
+                {this.state.reasonOptions.map((reason, i) => {
+                    return this.renderReasonCheckbox(reason, i)
                 })}
             </div>
-
-            <h4>Progression Reasons</h4>
-            <p id="data-element-description">
-              {progressionLookup.getDescription("reason")}
-            </p>
-            {this.state.reasonOptions.map((reason, i) => { 
-              return this.renderReasonCheckbox(reason, i)
-            })}
-        </div>
-    );
-  }
+        );
+    }
 }
 
 export default ProgressionForm;
-
-/*
-function titlecase(label) {
-  return label.toLowerCase().split(' ').map(function(word) {
-    return word.replace(word[0], word[0].toUpperCase());
-  }).join(' ');
-}*/

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -364,7 +364,6 @@ function onEnter(event, data, state, opts) {
 	event.preventDefault();
 	let result = moveField(state, opts, 1);
 	return result;
-	console.log('onEnter DONE')
 }
 
 function moveField(state, opts, fieldDelta) {

--- a/src/shortcuts/ProgressionShortcut.jsx
+++ b/src/shortcuts/ProgressionShortcut.jsx
@@ -22,7 +22,6 @@ class ProgressionShortcut extends Shortcut {
         }
         this.progression = Lang.clone(progression);
         this.onUpdate = onUpdate;
-        console.log(`constructor for a new Progression shortcut object`)
     }
     /* 
      * Returns "progression"
@@ -118,9 +117,7 @@ class ProgressionShortcut extends Shortcut {
         );      
     }
     
-    handleProgressionUpdate = (p) => { 
-        console.log(`Updated progression:`);
-        console.log(p);
+    handleProgressionUpdate = (p) => {
         this.progression.status = p.status;
         this.progression.reason = p.reason;
         this.progression.startDate = p.startDate;

--- a/src/views/SlimApp.jsx
+++ b/src/views/SlimApp.jsx
@@ -60,7 +60,6 @@ class SlimApp extends Component {
      * Change the current shortcut to be the new type of shortcut  
      */
     handleShortcutUpdate = (s) => {
-        console.log(`Updated: ${s}`);
         (s !== "") && this.setState({currentShortcut: s});
     }
 


### PR DESCRIPTION
Progression form now looks like the mockups. 

Front End:
- Users can select progression status via buttons
- Only one button can be selected at a time for status
- For reasons, multiple buttons can be selected and selecting on a button again turns the button from active to inactive
- All buttons, when selected, turn blue (modelling the mockups)
- Shortcut string in copy button gets updated based on buttons pressed
- Copy function still works
- Tooltips are on all buttons (displays the option's description)
- Updated headers in progression form to match mockups

Back End: 
- Removed code for drop down selections
- Buttons are generated dynamically from list of progression of statuses and reasons
- Deleted console logs and renamed important warning messages to warning
- Removed unused imports
- Fixed spacing in progression form related files to 4 spaces
- Created an array in progression form state to keep track of active/inactive buttons

Note:
- Buttons do not span the full width of the form. The mockups have the buttons spanning the full width. Created a jira issue for this (issue 443)
