### PR TITLE
Landing page no patient mode

### DIFF
--- a/src/forms/FormList.css
+++ b/src/forms/FormList.css
@@ -11,6 +11,9 @@
 #list-panel .list-element.unselected{ 
     border-bottom: 1px solid #d9d9d9 !important;
 }
+#list-panel .list-element.unselected.overview{
+    color: steelblue !important;
+}
 
 #list-panel .list-element.selected{ 
     background-color: white !important;
@@ -18,4 +21,7 @@
     -webkit-box-shadow: 0px 4px 5px -4px rgba(125,125,125,0.7);
     -moz-box-shadow: 0px 4px 5px -4px rgba(125,125,125,0.7);
     box-shadow: 0px 4px 5px -4px rgba(125,125,125,0.7);
+}
+#list-panel .list-element.selected.overview{
+    color: steelblue !important;
 }

--- a/src/forms/FormList.jsx
+++ b/src/forms/FormList.jsx
@@ -8,14 +8,14 @@ class FormList extends Component {
         super(props);
         this._newShortcut = this._newShortcut.bind(this);
         this.state = {
-            disabledElement: "Overview"
+            disabledElement: "About Flux Notes Lite"
         }
     }
 
     _newShortcut(e, index, shortcutName) {
         e.preventDefault();
 
-        if (shortcutName !== "Overview") {
+        if (shortcutName !== "About Flux Notes Lite") {
             this.props.changeShortcut(this.props.shortcuts[index]);
         }
         else {
@@ -37,7 +37,7 @@ class FormList extends Component {
                         let classValue = "list-element";
                         let primaryText = shortcutName;
 
-                        if (shortcutName === "Overview") {
+                        if (shortcutName === "About Flux Notes Lite") {
                             classValue += " overview";
                         }
                         if (this.state.disabledElement === shortcutName) {

--- a/src/forms/FormList.jsx
+++ b/src/forms/FormList.jsx
@@ -17,7 +17,14 @@ class FormList extends Component {
 
     _newShortcut(e, index, shortcutName) {
         e.preventDefault();
-        this.props.changeShortcut(this.props.shortcuts[index]);
+
+        if (shortcutName !== "Welcome") {
+            this.props.changeShortcut(this.props.shortcuts[index]);
+        }
+        else {
+            console.log("selected 'Welcome'");
+            this.props.changeShortcut(null);
+        }
     }
 
     _onTouchTap(event, shortcutName) {

--- a/src/forms/FormList.jsx
+++ b/src/forms/FormList.jsx
@@ -18,11 +18,11 @@ class FormList extends Component {
     _newShortcut(e, index, shortcutName) {
         e.preventDefault();
 
-        if (shortcutName !== "Welcome") {
+        if (shortcutName !== "Overview") {
             this.props.changeShortcut(this.props.shortcuts[index]);
         }
         else {
-            console.log("selected 'Welcome'");
+            console.log("selected 'Overview'");
             this.props.changeShortcut(null);
         }
     }
@@ -40,8 +40,13 @@ class FormList extends Component {
                     {this.props.shortcuts.map((shortcutName, i) => {
                         let classValue = "list-element";
                         let primaryText = shortcutName;
+
+                        if (shortcutName === "Overview") {
+                            classValue += " overview";
+                        }
                         if (this.state.disabledElement === shortcutName) {
                             classValue += " selected";
+
                         } else {
                             classValue += " unselected";
                         }

--- a/src/forms/FormList.jsx
+++ b/src/forms/FormList.jsx
@@ -1,8 +1,5 @@
-// React imports
 import React, {Component} from 'react';
-// material-ui
 import {List, ListItem} from 'material-ui/List';
-// Styling
 import './FormList.css';
 
 class FormList extends Component {
@@ -11,7 +8,7 @@ class FormList extends Component {
         super(props);
         this._newShortcut = this._newShortcut.bind(this);
         this.state = {
-            disabledElement: null
+            disabledElement: "Overview"
         }
     }
 
@@ -22,7 +19,6 @@ class FormList extends Component {
             this.props.changeShortcut(this.props.shortcuts[index]);
         }
         else {
-            console.log("selected 'Overview'");
             this.props.changeShortcut(null);
         }
     }
@@ -58,7 +54,8 @@ class FormList extends Component {
                                 className={classValue}
                                 onTouchTap={ (e) => {
                                     this._onTouchTap(e, shortcutName)
-                                    this._newShortcut(e, i, shortcutName)}
+                                    this._newShortcut(e, i, shortcutName)
+                                }
                                 }
                             />
                         );

--- a/src/forms/LandingPageForm.css
+++ b/src/forms/LandingPageForm.css
@@ -1,0 +1,21 @@
+#list-panel {
+    background-color: #F3F3F3;
+    /*Minus 64 for nav, minus 80 for search*/
+    /*height: calc(100vh - 64px - 80px);*/
+    height: calc(100vh - 64px);
+    text-align: left;
+    overflow-y: scroll;
+    overflow: overlay;
+}
+
+#list-panel .list-element.unselected{ 
+    border-bottom: 1px solid #d9d9d9 !important;
+}
+
+#list-panel .list-element.selected{ 
+    background-color: white !important;
+    font-weight: bold!important;
+    -webkit-box-shadow: 0px 4px 5px -4px rgba(125,125,125,0.7);
+    -moz-box-shadow: 0px 4px 5px -4px rgba(125,125,125,0.7);
+    box-shadow: 0px 4px 5px -4px rgba(125,125,125,0.7);
+}

--- a/src/forms/LandingPageForm.css
+++ b/src/forms/LandingPageForm.css
@@ -1,21 +1,3 @@
-#list-panel {
-    background-color: #F3F3F3;
-    /*Minus 64 for nav, minus 80 for search*/
-    /*height: calc(100vh - 64px - 80px);*/
-    height: calc(100vh - 64px);
-    text-align: left;
-    overflow-y: scroll;
-    overflow: overlay;
-}
-
-#list-panel .list-element.unselected{ 
-    border-bottom: 1px solid #d9d9d9 !important;
-}
-
-#list-panel .list-element.selected{ 
-    background-color: white !important;
-    font-weight: bold!important;
-    -webkit-box-shadow: 0px 4px 5px -4px rgba(125,125,125,0.7);
-    -moz-box-shadow: 0px 4px 5px -4px rgba(125,125,125,0.7);
-    box-shadow: 0px 4px 5px -4px rgba(125,125,125,0.7);
+.landing-page-title {
+    color: steelblue;
 }

--- a/src/forms/LandingPageForm.jsx
+++ b/src/forms/LandingPageForm.jsx
@@ -26,7 +26,7 @@ class LandingPageForm extends Component {
                 </p>
                 <p>
                     This application leverages the SHR (Standard Health Record) format for capturing data. For more
-                    information about the SHR, please go to the <a href="https://shr.mitre.org/#home">website</a>
+                    information about the SHR, please go to the <a href="https://shr.mitre.org/#home" target="_blank">website</a>
                 </p>
 
                 <h4>Using Flux Notes Lite</h4>

--- a/src/forms/LandingPageForm.jsx
+++ b/src/forms/LandingPageForm.jsx
@@ -4,15 +4,52 @@ import './LandingPageForm.css';
 
 class LandingPageForm extends Component {
 
-    constructor(props) {
-        super(props);
-
-    }
-
     render() {
         return (
-            <div id="test">
-                <span>Welcome page here</span>
+            <div id="landing-page-container">
+                <h1 className="landing-page-title">Flux Notes Lite Overview</h1>
+                <h4>Overview</h4>
+                <p>
+                    Flux Notes Lite supports the ICARE data study capture of progression and toxicity for the PATINA
+                    clinical trial. The purpose of Flux Notes Lite is to help clinicians capture disease progression and
+                    toxicity information in a structured data format that can be easily analyzed and shared across
+                    multiple clinical care sites.
+                </p>
+                <p>
+                    This application provides an easy mechanism for clinicians to  generate progression and toxicity
+                    information via an interface and allow them to copy the resulting structured shorthand phrase and paste it
+                    into their EHR notes entry.
+                </p>
+                <p>
+                    This tool is one of multiple prototypes in development by MITRE with the end goal of providing
+                    complete, accurate, and computable records to inform the best care for each individual.
+                </p>
+                <p>
+                    This application leverages the SHR (Standard Health Record) format for capturing data. For more
+                    information about the SHR, please go to the <a href="https://shr.mitre.org/#home">website</a>
+                </p>
+
+
+                <h4>Using Flux Notes Lite</h4>
+                <ol>
+                    <li>
+                        From the left panel, select the type of data that you would like to capture
+                    </li>
+                    <br/>
+                    <li>
+                        A form will be displayed on the right for the selected data type. On this form, choose values
+                        related to the data. As values are selected, the copy button on the bottom of the form will show
+                        the structured shorthand phrase as it is being built
+                    </li>
+                    <br/>
+                    <li>
+                        Once you finish entering data, click the copy button to copy the shorthand phrase
+                    </li>
+                    <br/>
+                    <li>
+                        Paste the phrase into your EHR notes entry
+                    </li>
+                </ol>
             </div>
         )
     }

--- a/src/forms/LandingPageForm.jsx
+++ b/src/forms/LandingPageForm.jsx
@@ -25,8 +25,7 @@ class LandingPageForm extends Component {
                     complete, accurate, and computable records to inform the best care for each individual.
                 </p>
                 <p>
-                    This application leverages the SHR (Standard Health Record) format for capturing data. For more
-                    information about the SHR, please go to the <a href="https://shr.mitre.org/#home" target="_blank">website</a>
+                    This application leverages the <a href="https://shr.mitre.org/#home" target="_blank">SHR (Standard Health Record)</a> format for capturing data.
                 </p>
 
                 <h4>Using Flux Notes Lite</h4>

--- a/src/forms/LandingPageForm.jsx
+++ b/src/forms/LandingPageForm.jsx
@@ -1,0 +1,21 @@
+import React, {Component} from 'react';
+// Styling
+import './LandingPageForm.css';
+
+class LandingPageForm extends Component {
+
+    constructor(props) {
+        super(props);
+
+    }
+
+    render() {
+        return (
+            <div id="test">
+                <span>Welcome page here</span>
+            </div>
+        )
+    }
+}
+
+export default LandingPageForm;

--- a/src/forms/LandingPageForm.jsx
+++ b/src/forms/LandingPageForm.jsx
@@ -1,5 +1,4 @@
 import React, {Component} from 'react';
-// Styling
 import './LandingPageForm.css';
 
 class LandingPageForm extends Component {
@@ -16,8 +15,9 @@ class LandingPageForm extends Component {
                     multiple clinical care sites.
                 </p>
                 <p>
-                    This application provides an easy mechanism for clinicians to  generate progression and toxicity
-                    information via an interface and allow them to copy the resulting structured shorthand phrase and paste it
+                    This application provides an easy mechanism for clinicians to generate progression and toxicity
+                    information via an interface and allow them to copy the resulting structured shorthand phrase and
+                    paste it
                     into their EHR notes entry.
                 </p>
                 <p>
@@ -28,7 +28,6 @@ class LandingPageForm extends Component {
                     This application leverages the SHR (Standard Health Record) format for capturing data. For more
                     information about the SHR, please go to the <a href="https://shr.mitre.org/#home">website</a>
                 </p>
-
 
                 <h4>Using Flux Notes Lite</h4>
                 <ol>

--- a/src/forms/LandingPageForm.jsx
+++ b/src/forms/LandingPageForm.jsx
@@ -6,11 +6,11 @@ class LandingPageForm extends Component {
     render() {
         return (
             <div id="landing-page-container">
-                <h1 className="landing-page-title">Flux Notes Lite Overview</h1>
-                <h4>Overview</h4>
+                <h1 className="landing-page-title">About Flux Notes Lite</h1>
                 <p>
-                    Flux Notes Lite supports the ICARE data study capture of progression and toxicity for the PATINA
-                    clinical trial. The purpose of Flux Notes Lite is to help clinicians capture disease progression and
+                    Flux Notes Lite supports the ICARE data study capture of progression and toxicity during the
+                    authoring of clinical notes. The purpose of Flux Notes Lite is to help clinicians capture disease
+                    progression and
                     toxicity information in a structured data format that can be easily analyzed and shared across
                     multiple clinical care sites.
                 </p>

--- a/src/forms/ProgressionForm.css
+++ b/src/forms/ProgressionForm.css
@@ -47,10 +47,6 @@
     transition-delay: 0.5s;
 }
 
-.btn-group-status-progression {
-    /*background-color: #001A33;*/
+.helper-text {
+    color: #b1b1b1;
 }
-
-/*.btn-progression {*/
-    /*margin: 15px;*/
-/*}*/

--- a/src/forms/ProgressionForm.jsx
+++ b/src/forms/ProgressionForm.jsx
@@ -48,7 +48,7 @@ class ProgressionForm extends Component {
                 this.props.onProgressionUpdate(newProgression);
             } else {
                 // Nothing -- the element is already in there
-                console.log(`[WARNING] Cornercase; the element ${reason.name} shouldnt have been in our current reasons, but it was`);
+                console.warn(`Warning: Cornercase; the element ${reason.name} shouldnt have been in our current reasons, but it was`);
             }
         } else {
             // Index shouldn't be -1; if it is, don't remove it again;
@@ -60,7 +60,7 @@ class ProgressionForm extends Component {
                 this.props.onProgressionUpdate(newProgression);
             } else {
                 // Nothing -- the element is already removed from the array;
-                console.log(`[WARNING] Cornercase: the element ${reason.name} should be in our current reasons, but it isn't`);
+                console.warn(`Warning: Cornercase: the element ${reason.name} should be in our current reasons, but it isn't`);
             }
         }
 

--- a/src/forms/ProgressionForm.jsx
+++ b/src/forms/ProgressionForm.jsx
@@ -63,7 +63,6 @@ class ProgressionForm extends Component {
                 console.warn(`Warning: Cornercase: the element ${reason.name} should be in our current reasons, but it isn't`);
             }
         }
-
     }
 
     renderReasonButtonGroup = (reason, i) => {

--- a/src/forms/ProgressionForm.jsx
+++ b/src/forms/ProgressionForm.jsx
@@ -123,6 +123,7 @@ class ProgressionForm extends Component {
                 <h4>Status of progression</h4>
                 <p id="data-element-description">
                     {progressionLookup.getDescription("status")}
+                    <span className="helper-text"> Choose one</span>
                 </p>
 
                 <div className="btn-group-status-progression">
@@ -161,6 +162,7 @@ class ProgressionForm extends Component {
                 <h4>Rationale for status</h4>
                 <p id="data-element-description">
                     {progressionLookup.getDescription("reason")}
+                    <span className="helper-text"> Choose one or more</span>
                 </p>
 
                 <div className="btn-group-reason-progression">

--- a/src/forms/ToxicityForm.css
+++ b/src/forms/ToxicityForm.css
@@ -154,3 +154,7 @@
 .react-autosuggest__suggestion--highlighted {
     background-color: rgba(0,0,0,0.08);
 }
+
+.helper-text {
+    color: #b1b1b1;
+}

--- a/src/forms/ToxicityForm.jsx
+++ b/src/forms/ToxicityForm.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, {Component} from 'react';
 import Autosuggest from 'react-autosuggest';
 import {Row, Col} from 'react-flexbox-grid';
 import Divider from 'material-ui/Divider';
@@ -10,26 +10,26 @@ import './ToxicityForm.css';
 class ToxicityForm extends Component {
     constructor(props) {
         super(props);
-  
+
         this.state = {
             gradeOptions: toxicityLookup.getGradeOptions(),
             adverseEventOptions: toxicityLookup.getAdverseEventOptions(),
             suggestions: [],
             searchText: '',
-        }; 
+        };
     }
 
     /* 
      * Update potential toxicity value
      */
-    updatePotentialToxicity = (newToxicity) => { 
+    updatePotentialToxicity = (newToxicity) => {
         this.props.onToxicityUpdate(newToxicity);
     }
 
     /* 
      * Reset potential toxicity 
      */
-    resetPotentialToxicity = () => { 
+    resetPotentialToxicity = () => {
         this.setState({
             searchText: ""
         })
@@ -38,8 +38,8 @@ class ToxicityForm extends Component {
     /* 
      * Changes the potential toxicity to the provided value
      */
-    changePotentialToxicity = ({newValue}) => { 
-        this.setState({ 
+    changePotentialToxicity = ({newValue}) => {
+        this.setState({
             searchText: newValue
         });
     }
@@ -49,32 +49,32 @@ class ToxicityForm extends Component {
      */
     handleGradeSelecion = (e, grade, isSelected) => {
         e.preventDefault();
-        if (isSelected) { 
-            const newToxicity = (Lang.isNull(this.props.toxicity)) ? {} : { ...this.props.toxicity}; 
+        if (isSelected) {
+            const newToxicity = (Lang.isNull(this.props.toxicity)) ? {} : {...this.props.toxicity};
             delete newToxicity.grade;
             this.updatePotentialToxicity(newToxicity);
-        } else { 
-            const newGrade = grade; 
-            const newToxicity = (Lang.isNull(this.props.toxicity)) ? {} : { ...this.props.toxicity}; 
+        } else {
+            const newGrade = grade;
+            const newToxicity = (Lang.isNull(this.props.toxicity)) ? {} : {...this.props.toxicity};
             newToxicity["grade"] = newGrade;
             this.updatePotentialToxicity(newToxicity);
         }
     }
-  
+
     /* 
      * When a valid adverse event is selected, update potential toxicity 
      */
     handleAdverseEventSelection = (newAdverseEvent) => {
-        const newToxicity = (Lang.isNull(this.props.toxicity)) ? {} : { ...this.props.toxicity};
+        const newToxicity = (Lang.isNull(this.props.toxicity)) ? {} : {...this.props.toxicity};
         // A null or undefined value for newAdverseEvent should trigger the deletion of the current adverseEvent
-        if (Lang.isUndefined(newAdverseEvent) || Lang.isNull(newAdverseEvent)){ 
+        if (Lang.isUndefined(newAdverseEvent) || Lang.isNull(newAdverseEvent)) {
             delete newToxicity.adverseEvent;
-        } else { 
+        } else {
             newToxicity["adverseEvent"] = titlecase(newAdverseEvent);
             // Make sure grade is possible with given new tox
         }
         const potentialGrade = (toxicityLookup.isValidGradeForAdverseEvent(newToxicity.grade, newAdverseEvent)) ? newToxicity.grade : null;
-        if(Lang.isNull(potentialGrade)) { 
+        if (Lang.isNull(potentialGrade)) {
             delete newToxicity.grade;
         }
         this.updatePotentialToxicity(newToxicity);
@@ -88,25 +88,25 @@ class ToxicityForm extends Component {
         this.setState({
             searchText: newValue,
         });
-        if(toxicityLookup.isValidAdverseEvent(newValue)) { 
+        if (toxicityLookup.isValidAdverseEvent(newValue)) {
             this.handleAdverseEventSelection(newValue)
-        } else if (!toxicityLookup.isValidAdverseEvent(newValue) && toxicityLookup.isValidAdverseEvent(this.props.toxicity.adverseEvent)) { 
+        } else if (!toxicityLookup.isValidAdverseEvent(newValue) && toxicityLookup.isValidAdverseEvent(this.props.toxicity.adverseEvent)) {
             this.handleAdverseEventSelection(null)
         }
     }
 
     /* 
      * Render the adverse event  item for the adverse event suggestion
-     */    
+     */
     getSuggestions = (searchText) => {
         const inputValue = searchText.trim().toLowerCase();
         const inputLength = inputValue.length;
 
-        return inputLength === 0  ? [] : this.state.adverseEventOptions.filter((event) => {
+        return inputLength === 0 ? [] : this.state.adverseEventOptions.filter((event) => {
             const name = (Lang.isEmpty(event.name)) ? "" : event.name;
             const description = (Lang.isEmpty(event.description)) ? "" : event.description;
             return (name.toLowerCase().indexOf(inputValue) >= 0 || description.toLowerCase().indexOf(inputValue) >= 0)
-        }).slice(0,7);
+        }).slice(0, 7);
     };
 
     /* 
@@ -122,19 +122,19 @@ class ToxicityForm extends Component {
      * Autosuggest will call this function every time you need to update suggestions.
      * You already implemented this logic above, so just use it.
      */
-    onSuggestionsFetchRequested = ({ value }) => {
-      this.setState({
-        suggestions: this.getSuggestions(value)
-      });
+    onSuggestionsFetchRequested = ({value}) => {
+        this.setState({
+            suggestions: this.getSuggestions(value)
+        });
     };
 
     /* 
      * Autosuggest will call this function every time you need to clear suggestions.
      */
     onSuggestionsClearRequested = () => {
-      this.setState({
-        suggestions: []
-      });
+        this.setState({
+            suggestions: []
+        });
     };
 
     /* 
@@ -146,9 +146,9 @@ class ToxicityForm extends Component {
                 <Col xs={3} className="adverse-event-suggestion-name">
                     {suggestion.name}
                 </Col>
-                <Col xs={9} className="adverse-event-suggestion-description"> 
+                <Col xs={9} className="adverse-event-suggestion-description">
                     {suggestion.description}
-                </Col> 
+                </Col>
             </Row>
         );
     }
@@ -157,56 +157,60 @@ class ToxicityForm extends Component {
      * Render the grade menu item for the given grade object, 
      *  Update grade description if there is a current adverse event 
      */
-    renderGradeMenuItem = (grade, adverseEventName) => { 
+    renderGradeMenuItem = (grade, adverseEventName) => {
         const currentGradeLevel = grade.name;
         const isDisabled = !toxicityLookup.isValidGradeForAdverseEvent(grade.name, adverseEventName);
 
         const isSelected = !Lang.isEmpty(this.props.toxicity) && !Lang.isEmpty(this.props.toxicity.grade) && this.props.toxicity.grade === grade.name
         let gradeMenuClass = "grade-menu-item";
-        if (isDisabled) { 
+        if (isDisabled) {
             gradeMenuClass += " disabled"
-        } else if (isSelected) { 
+        } else if (isSelected) {
             gradeMenuClass += " selected"
         }
         let gradeDescription = "";
 
-        if (Lang.isUndefined(adverseEventName)) { 
+        if (Lang.isUndefined(adverseEventName)) {
             gradeDescription = grade.description;
-        } else if (isDisabled) { 
+        } else if (isDisabled) {
             gradeDescription = "";
-        } else { 
+        } else {
             const adverseEventNameLowerCase = adverseEventName.toLowerCase();
-            const adverseEventOptionsLowerCase = this.state.adverseEventOptions.map(function(elem) { const elemCopy = Lang.clone(elem); elemCopy.name = elemCopy.name.toLowerCase(); return elemCopy; });
+            const adverseEventOptionsLowerCase = this.state.adverseEventOptions.map(function (elem) {
+                const elemCopy = Lang.clone(elem);
+                elemCopy.name = elemCopy.name.toLowerCase();
+                return elemCopy;
+            });
             const currentAdverseEvent = Array.find(adverseEventOptionsLowerCase, {name: adverseEventNameLowerCase})
             gradeDescription = currentAdverseEvent[currentGradeLevel];
-        }        
+        }
         return (
-            <div 
+            <div
                 className={gradeMenuClass}
                 key={grade.name}
                 // onHover
                 onClick={(e) => {
-                    if (!isDisabled) { 
+                    if (!isDisabled) {
                         return this.handleGradeSelecion(e, grade.name, isSelected)
-                    } 
+                    }
                 }}
             >
                 <div className="grade-menu-item-name">
                     {currentGradeLevel}
                 </div>
-                <div className="grade-menu-item-description"> 
+                <div className="grade-menu-item-description">
                     {gradeDescription}
-                </div> 
+                </div>
             </div>
-        ) 
+        )
     }
-  
+
     render() {
-        let potentialToxicity = Lang.isNull(this.props.toxicity) ? {} : {...this.props.toxicity};        
+        let potentialToxicity = Lang.isNull(this.props.toxicity) ? {} : {...this.props.toxicity};
         const inputProps = {
-          placeholder: 'Enter symptom',
-          value: this.state.searchText,
-          onChange: this.handleUpdateAdverseEventInput
+            placeholder: 'Enter symptom',
+            value: this.state.searchText,
+            onChange: this.handleUpdateAdverseEventInput
         };
 
         return (
@@ -215,8 +219,8 @@ class ToxicityForm extends Component {
                 <p id="data-element-description">
                     {toxicityLookup.getDescription("toxicity")}
                 </p>
-                <Divider className="divider" />
-    
+                <Divider className="divider"/>
+
                 <h4>Adverse Event</h4>
                 <p id="data-element-description">
                     {toxicityLookup.getDescription("adverseEvent")}
@@ -231,7 +235,7 @@ class ToxicityForm extends Component {
                     renderSuggestion={this.renderSuggestion}
                     inputProps={inputProps}
                 />
-    
+
                 <h4>Grade</h4>
                 <p id="data-element-description">
                     {toxicityLookup.getDescription("grade")}
@@ -239,9 +243,9 @@ class ToxicityForm extends Component {
                 </p>
                 <div id="grade-menu">
                     {this.state.gradeOptions.map((grade, i) => {
-                        if(Lang.isUndefined(potentialToxicity.adverseEvent)) { 
-                            return this.renderGradeMenuItem(grade)                      
-                        } else { 
+                        if (Lang.isUndefined(potentialToxicity.adverseEvent)) {
+                            return this.renderGradeMenuItem(grade)
+                        } else {
                             return this.renderGradeMenuItem(grade, potentialToxicity.adverseEvent);
                         }
                     })}
@@ -255,7 +259,7 @@ export default ToxicityForm;
 
 
 function titlecase(label) {
-  return label.toLowerCase().split(' ').map(function(word) {
-    return word.replace(word[0], word[0].toUpperCase());
-  }).join(' ');
+    return label.toLowerCase().split(' ').map(function (word) {
+        return word.replace(word[0], word[0].toUpperCase());
+    }).join(' ');
 }

--- a/src/forms/ToxicityForm.jsx
+++ b/src/forms/ToxicityForm.jsx
@@ -204,7 +204,7 @@ class ToxicityForm extends Component {
     render() {
         let potentialToxicity = Lang.isNull(this.props.toxicity) ? {} : {...this.props.toxicity};        
         const inputProps = {
-          placeholder: 'Search through adverse events',
+          placeholder: 'Enter symptom',
           value: this.state.searchText,
           onChange: this.handleUpdateAdverseEventInput
         };
@@ -235,6 +235,7 @@ class ToxicityForm extends Component {
                 <h4>Grade</h4>
                 <p id="data-element-description">
                     {toxicityLookup.getDescription("grade")}
+                    <span className="helper-text"> Choose one</span>
                 </p>
                 <div id="grade-menu">
                     {this.state.gradeOptions.map((grade, i) => {

--- a/src/viewer/ShortcutViewer.css
+++ b/src/viewer/ShortcutViewer.css
@@ -16,6 +16,7 @@
 .btn_copy {
     display: inline-block;
     margin-top:  90px;
+    margin-bottom: 10px;
 }
 
 #copy-keyword:after {
@@ -40,3 +41,6 @@
     display: inline-block;
 }
 
+.helper-text {
+    color: #b1b1b1;
+}

--- a/src/viewer/ShortcutViewer.jsx
+++ b/src/viewer/ShortcutViewer.jsx
@@ -24,30 +24,34 @@ class ShortcutViewer extends Component {
     _getCopyComponent(string) {
         return (
             <CopyToClipboard text={string}>
-                <RaisedButton
-                    className="btn_copy"
-                    labelStyle={{
-                        textTransform: "none",
-                    }}
-                    buttonStyle={{
-                        textAlign: "left",
-                        height: "45px",
-                    }}
-                    overlayStyle={{
-                        padding: "5px 0 4px 0"
-                    }}
-                    style={{
-                        minWidth: "99.8%"
-                    }}
-                    fullWidth={true}
-                >
-                    <div id="copy-keyword">
-                        Copy
-                    </div>
-                    <div id="copy-content">
-                        {string}
-                    </div>
-                </RaisedButton>
+                <div>
+
+                    <RaisedButton
+                        className="btn_copy"
+                        labelStyle={{
+                            textTransform: "none",
+                        }}
+                        buttonStyle={{
+                            textAlign: "left",
+                            height: "45px",
+                        }}
+                        overlayStyle={{
+                            padding: "5px 0 4px 0"
+                        }}
+                        style={{
+                            minWidth: "99.8%"
+                        }}
+                        fullWidth={true}
+                    >
+                        <div id="copy-keyword">
+                            Copy
+                        </div>
+                        <div id="copy-content">
+                            {string}
+                        </div>
+                    </RaisedButton>
+                    <span className="helper-text">Click copy button to copy string</span>
+                </div>
             </CopyToClipboard>
         );
     }

--- a/src/viewer/ShortcutViewer.jsx
+++ b/src/viewer/ShortcutViewer.jsx
@@ -13,7 +13,6 @@ class ShortcutViewer extends Component {
     _getInitialState(initialString) {
         return (
             <div>
-                <span>Choose a template from the left panel</span>
                 <LandingPageForm/>
             </div>
         );

--- a/src/viewer/ShortcutViewer.jsx
+++ b/src/viewer/ShortcutViewer.jsx
@@ -1,22 +1,27 @@
 import React, {Component} from 'react';
 import CopyToClipboard from 'react-copy-to-clipboard';
 import RaisedButton from 'material-ui/RaisedButton';
+import LandingPageForm from '../forms/LandingPageForm';
+// Lodash component
 import Lang from 'lodash'
 import './ShortcutViewer.css';
 
 class ShortcutViewer extends Component {
-    /* 
+    /*
      * Returns JSX element for the initial, no-shorcut state
-     */ 
+     */
     _getInitialState(initialString) {
         return (
-            <span>Choose a template from the left panel</span>
+            <div>
+                <span>Choose a template from the left panel</span>
+                <LandingPageForm/>
+            </div>
         );
     }
 
-    /* 
+    /*
      * Returns JSX element for the copy component
-     */ 
+     */
     _getCopyComponent(string) {
         return (
             <CopyToClipboard text={string}>
@@ -33,7 +38,7 @@ class ShortcutViewer extends Component {
                         padding: "5px 0 4px 0"
                     }}
                     style={{
-                        minWidth: "99.8%"                        
+                        minWidth: "99.8%"
                     }}
                     fullWidth={true}
                 >
@@ -75,7 +80,7 @@ class ShortcutViewer extends Component {
         )
     }
 
-    
+
 }
 
 export default ShortcutViewer;

--- a/src/views/SlimApp.jsx
+++ b/src/views/SlimApp.jsx
@@ -51,7 +51,7 @@ class SlimApp extends Component {
                                     {/*No need for formsearch right now*/}
                                     {/*<FormSearch />*/}
                                     <FormList
-                                        shortcuts={['Overview', 'Progression', 'Toxicity']}
+                                        shortcuts={['About Flux Notes Lite', 'Progression', 'Toxicity']}
                                         currentShortcut={this.state.currentShortcut}
                                         changeShortcut={this.changeShortcut}
                                     />

--- a/src/views/SlimApp.jsx
+++ b/src/views/SlimApp.jsx
@@ -14,7 +14,7 @@ class SlimApp extends Component {
     constructor(props) {
         super(props);
 
-        this.shortcuts = [ "progression", "staging", "toxicity" ];
+        this.shortcuts = ["progression", "staging", "toxicity"];
         this.shortcutManager = new ShortcutManager(this.shortcuts);
 
         this.state = {
@@ -46,23 +46,23 @@ class SlimApp extends Component {
                     <NavBar title="Flux Notes Lite"/>
                     <Grid className="SlimApp-content" fluid>
                         <div id="forms-panel">
-                                <Row center="xs">
-                                    <Col className="no-padding" xs={3} >
-                                        {/*No need for formsearch right now*/}
-                                        {/*<FormSearch />*/}
-                                        <FormList
-                                            shortcuts={['Overview', 'Progression', 'Toxicity']}
-                                            currentShortcut={this.state.currentShortcut}
-                                            changeShortcut={this.changeShortcut}
-                                        />
-                                    </Col>
-                                    <Col className="no-padding" xs={9}>
-                                        <ShortcutViewer
-                                            currentShortcut={this.state.currentShortcut}
-                                            onShortcutUpdate={this.handleShortcutUpdate}
-                                        />
-                                    </Col>
-                                </Row>
+                            <Row center="xs">
+                                <Col className="no-padding" xs={3}>
+                                    {/*No need for formsearch right now*/}
+                                    {/*<FormSearch />*/}
+                                    <FormList
+                                        shortcuts={['Overview', 'Progression', 'Toxicity']}
+                                        currentShortcut={this.state.currentShortcut}
+                                        changeShortcut={this.changeShortcut}
+                                    />
+                                </Col>
+                                <Col className="no-padding" xs={9}>
+                                    <ShortcutViewer
+                                        currentShortcut={this.state.currentShortcut}
+                                        onShortcutUpdate={this.handleShortcutUpdate}
+                                    />
+                                </Col>
+                            </Row>
                         </div>
                     </Grid>
                 </div>

--- a/src/views/SlimApp.jsx
+++ b/src/views/SlimApp.jsx
@@ -51,7 +51,7 @@ class SlimApp extends Component {
                                         {/*No need for formsearch right now*/}
                                         {/*<FormSearch />*/}
                                         <FormList
-                                            shortcuts={['Progression', 'Toxicity']}
+                                            shortcuts={['Welcome', 'Progression', 'Toxicity']}
                                             currentShortcut={this.state.currentShortcut}
                                             changeShortcut={this.changeShortcut}
                                         />

--- a/src/views/SlimApp.jsx
+++ b/src/views/SlimApp.jsx
@@ -51,7 +51,7 @@ class SlimApp extends Component {
                                         {/*No need for formsearch right now*/}
                                         {/*<FormSearch />*/}
                                         <FormList
-                                            shortcuts={['Welcome', 'Progression', 'Toxicity']}
+                                            shortcuts={['Overview', 'Progression', 'Toxicity']}
                                             currentShortcut={this.state.currentShortcut}
                                             changeShortcut={this.changeShortcut}
                                         />


### PR DESCRIPTION
Created a landing page for Flux Lite: 

Front end:
- On app start, "Overview" page (the landing page) is shown is shown
- Users can always click to view the "Overview" page even if they click to a shortcut form
- landing page includes background information on the goal of Flux Notes Lite, information on SHR and a link to the SHR, as well as instructions for how to use the app
- Added helper text to the forms (modeling the mockups)

Back end: 
- Created a new form for the landing page that gets called when currentShortcut is set to null
