### PR TITLE
Context portal styling

### DIFF
--- a/src/context/ContextItem.css
+++ b/src/context/ContextItem.css
@@ -1,9 +1,10 @@
 
 .context-portal .context-menu-item { 
-    padding: 10px;
+    padding: 5px 10px;
     width: 300px;
 }
 
 .context-portal .context-menu-item[data-active="true"] {
-    background-color: rgba(0,0,0,0.1);
+    background-color: #297DA2;
+    color: #fff;
 }

--- a/src/context/ContextItem.css
+++ b/src/context/ContextItem.css
@@ -1,0 +1,9 @@
+
+.context-portal .context-menu-item { 
+    padding: 10px;
+    width: 300px;
+}
+
+.context-portal .context-menu-item[data-active="true"] {
+    background-color: rgba(0,0,0,0.1);
+}

--- a/src/context/ContextItem.jsx
+++ b/src/context/ContextItem.jsx
@@ -1,28 +1,37 @@
 import React from 'react'
+import './ContextItem.css';
 
 class ContextItem extends React.Component {
-
-  onClick = (e) => {
-    this.props.closePortal()
-
-    const { onChange, context, onSelected } = this.props
-
-    const state = onSelected(this.props.state, context)
-
-    onChange(state)
-  }
-
-  onMouseEnter = () =>
-    this.props.setSelectedIndex(this.props.index)
-
-  render = () =>
-    <li
-  	  className={this.props.index === this.props.selectedIndex ? 'selected' : undefined}
-      onClick={this.onClick}
-      onMouseEnter={this.onMouseEnter}
-    >
-      {this.props.context.context}
-    </li>
+    /*
+     * When an item is clicked, close the portal and update contextPortal accordingly 
+     */
+    onClick = (e) => {
+        this.props.closePortal();
+        const { onChange, context, onSelected } = this.props;
+        const state = onSelected(this.props.state, context);
+        onChange(state);
+    }
+    /*
+     * When an item is hovered, update the selectedIndex
+     */
+    onMouseEnter = () => {
+        return this.props.setSelectedIndex(this.props.index);
+    }
+    /*
+     * Render the individual menu item
+     */
+    render = () => {
+        return (
+            <li
+              className="context-menu-item"
+              data-active={this.props.index === this.props.selectedIndex}
+              onClick={this.onClick}
+              onMouseEnter={this.onMouseEnter}
+            >
+                {this.props.context.context}
+            </li>
+        );
+    }
 }
 
 export default ContextItem

--- a/src/context/ContextPortal.css
+++ b/src/context/ContextPortal.css
@@ -11,10 +11,10 @@
 }
 
 .context-portal ul {
-  list-style-type: none;
-  padding: 0;
-  margin: 10px 0;
-  background-color: #fff;
+    list-style-type: none;
+    padding: 0;
+    margin: 10px 0;
+    background-color: #fff;
 }
 
 .context-portal > * {

--- a/src/context/ContextPortal.css
+++ b/src/context/ContextPortal.css
@@ -1,25 +1,22 @@
-.context-portal {
-  display: none;
-  position: absolute;
-  z-index: 10000;
-  margin-left: 20px;
-  margin-top: 30px;
-  width: 200px;
+.context-portal { 
+    position: absolute;
+    box-sizing: border-box;
+    border-radius: 2px;
+    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+    box-shadow: rgba(0, 0, 0, 0.12) 0px 1px 6px, rgba(0, 0, 0, 0.12) 0px 1px 4px;
+    transition: all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms;
+    background-color: rgb(255, 255, 255);
+    z-index: 1111;
 }
 
 .context-portal ul {
   list-style-type: none;
-  margin-top: 0;
-  position: relative;
-  padding-left: 0;
-  margin-left: 5px;
+  padding: 0;
+  margin: 10px 0;
   background-color: #fff;
 }
 
-.context-portal li {
-  padding: 5px 10px;
-}
-
-.context-portal li.selected {
-  background-color: #eee;
+.context-portal > * {
+    display: block;
+    padding: 7px 10px;
 }

--- a/src/context/ContextPortal.css
+++ b/src/context/ContextPortal.css
@@ -6,6 +6,7 @@
     box-shadow: rgba(0, 0, 0, 0.12) 0px 1px 6px, rgba(0, 0, 0, 0.12) 0px 1px 4px;
     transition: all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms;
     background-color: rgb(255, 255, 255);
+    margin-top: 30px;
     z-index: 1111;
 }
 

--- a/src/context/ContextPortal.jsx
+++ b/src/context/ContextPortal.jsx
@@ -115,9 +115,7 @@ class ContextPortal extends React.Component {
 
         menu.style.position = 'absolute';
         menu.style.width = 300;
-        menu.style.border = '1px solid gray';
         menu.style.background = '#fff';
-        menu.style.margin = 10;
         menu.style.padding = 10;
         menu.style.display = 'block';
         menu.style.opacity = 1;

--- a/src/context/ContextPortal.jsx
+++ b/src/context/ContextPortal.jsx
@@ -10,152 +10,150 @@ const ENTER_KEY = 13
 //const RESULT_SIZE = 5
 
 class ContextPortal extends React.Component {
-  componentDidMount = () => {
-    document.addEventListener('keydown', this.handleKeydownCP);
-	this.adjustPosition()
-  }
-  componentWillUnmount() {
-	document.removeEventListener('keydown', this.handleKeydownCP);
-  }
-  componentDidUpdate = () => {
-    this.adjustPosition()
-  }
+    
+    componentDidMount = () => {
+         document.addEventListener('keydown', this.handleKeydownCP);
+         this.adjustPosition()
+    }
+
+    componentWillUnmount = () => {
+        document.removeEventListener('keydown', this.handleKeydownCP);
+    }
+    
+    componentDidUpdate = () => {
+        this.adjustPosition();
+    }
   
-  componentWillReceiveProps = (props) => {
-	if (props.contexts !== this.state.contexts) {
-		this.setState({
-			contexts: props.contexts
-		});
-		this.selectedIndex = 0;
-	}
-  }
+    componentWillReceiveProps = (props) => {
+        if (props.contexts !== this.state.contexts) {
+            this.setState({
+                contexts: props.contexts
+            });
+            this.selectedIndex = 0;
+        }
+    }
 
-  constructor(props) {
-    super()
-	
-	//props.callback.onKeyDown = this.onKeyDown
-	this.handleKeydownCP = this.handleKeydownCP.bind(this);
-    props.callback.onSelected = props.onSelected
-    props.callback.closePortal = this.closePortal
-    props.callback.readOnly = false
-	this.state = {
-		contexts: props.contexts,
-		active: false,
-		justActive: false
-	}
-  }
-
-  onOpen = (portal) => {
-	//console.log("onOpen");
-    this.setState({ menu: portal.firstChild, active: true, justActive: true })
-	setTimeout(function(){ this.setState({ justActive: false }) }.bind(this), 100);
-  }
+    constructor(props) {
+        super()
   
-  // called when user hits esc or clicks outside of portal
-  // call onSelected with null context to indicate nothing selected and just clean up state
-  onClose = () => {
-	//console.log("onClose");
-    if (this.props.isOpened) {
-		this.props.onChange(this.props.onSelected(this.props.state, null));
-	}
-	this.setState({ active: false, justActive: false }); // TEST: menu: null, 
-  }
+        this.handleKeydownCP = this.handleKeydownCP.bind(this);
+        props.callback.onSelected = props.onSelected;
+        props.callback.closePortal = this.closePortal;
+        props.callback.readOnly = false;
+        this.state = {
+            contexts: props.contexts,
+            active: false,
+            justActive: false
+        }
+    }
 
-  handleKeydownCP(e) {
-    //console.log("ContextPortal.handleKeyDownCP active=" + this.state.active + " " + e);
-    if (this.state.active) {
-		e.preventDefault();
-		e.stopPropagation();
-		if (this.state.justActive) { // eat key that made us become active
-			this.setState({ justActive: false });
-			return;
-		}
-		this.onKeyDown(e.keyCode);
-	}
-  }
+    onOpen = (portal) => {
+        this.setState({ menu: portal.firstChild, active: true, justActive: true })
+        setTimeout(function(){ this.setState({ justActive: false }) }.bind(this), 100);
+    }
   
-  onKeyDown(keyCode) {
-    //console.log("ContextPortal.onKeyDown " + keyCode);
-    if (keyCode === DOWN_ARROW_KEY) {
-      if (this.selectedIndex + 1 === this.state.contexts.length) {
-        this.selectedIndex = -1
-      }
-      this.selectedIndex += 1
-      this.forceUpdate()
-    } else if (keyCode === UP_ARROW_KEY) {
-      if (this.selectedIndex === 0) {
-        this.selectedIndex = this.state.contexts.length
-      }
-      this.selectedIndex -= 1
-      this.forceUpdate()
-    } else if (keyCode === ENTER_KEY) {
-		//console.log("ENTER. selected " + this.state.contexts[this.selectedIndex]);
-		this.setState({ active: false, justActive: false });
-		this.props.onChange(this.props.onSelected(this.props.state, this.state.contexts[this.selectedIndex]));
-	}
-  }
+    // called when user hits esc or clicks outside of portal
+    // call onSelected with null context to indicate nothing selected and just clean up state
+    onClose = () => {
+        if (this.props.isOpened) {
+            this.props.onChange(this.props.onSelected(this.props.state, null));
+        }
+        this.setState({ active: false, justActive: false }); // TEST: menu: null, 
+    }
 
-  adjustPosition = () => {
-    const { menu } = this.state
-    if (!menu || !menu.style) return
-	//console.log("!!!!!!!!!!!!!!!!!!!! in adjustPosition/state.menu set");
-	//console.log(menu);
+    handleKeydownCP(e) {
+        if (this.state.active) {
+            e.preventDefault();
+            e.stopPropagation();
+            if (this.state.justActive) { // eat key that made us become active
+                this.setState({ justActive: false });
+                return;
+            }
+            this.onKeyDown(e.keyCode);
+        }
+    }
+  
+    onKeyDown(keyCode) {
+        //console.log("ContextPortal.onKeyDown " + keyCode);
+        if (keyCode === DOWN_ARROW_KEY) {
+            if (this.selectedIndex + 1 === this.state.contexts.length) {
+                this.selectedIndex = -1;
+            }
+            this.selectedIndex += 1;
+            this.forceUpdate();
+        } else if (keyCode === UP_ARROW_KEY) {
+            if (this.selectedIndex === 0) {
+                this.selectedIndex = this.state.contexts.length;
+            }
+            this.selectedIndex -= 1;
+            this.forceUpdate();
+        } else if (keyCode === ENTER_KEY) {
+            this.setState({ active: false, justActive: false });
+            this.props.onChange(this.props.onSelected(this.props.state, this.state.contexts[this.selectedIndex]));
+        }
+    }
 
-	menu.style.position = 'absolute'
-	menu.style.width = 300
-	menu.style.border = '1px solid gray'
-	menu.style.background = '#fff'
-	menu.style.margin = 10
-	menu.style.padding = 10
-	menu.style.display = 'block'
-	menu.style.opacity = 1
-	menu.style.top = `${this.props.top}px`;
-	menu.style.left = `${this.props.left}px`;
-  }
+    adjustPosition = () => {
+        const { menu } = this.state
+        if (!menu || !menu.style) return;
 
-  closePortal = () => {
-    const { menu } = this.state
-    if (!menu) return
+        menu.style.position = 'absolute';
+        menu.style.width = 300;
+        menu.style.border = '1px solid gray';
+        menu.style.background = '#fff';
+        menu.style.margin = 10;
+        menu.style.padding = 10;
+        menu.style.display = 'block';
+        menu.style.opacity = 1;
+        menu.style.top = `${this.props.top}px`;
+        menu.style.left = `${this.props.left}px`;
+    }
 
-	//console.log("closePortal: remove style attribute.");
-	//menu.removeAttribute('style')
-	
-	return
-  }
+    closePortal = () => {
+        const { menu } = this.state
+        if (Lang.isEmpty(menu)) return;
+        //menu.removeAttribute('style');
+        return;
+    }
 
-  setSelectedIndex = (selectedIndex) => {
-    this.selectedIndex = selectedIndex
-    this.forceUpdate()
-  }
+    setSelectedIndex = (selectedIndex) => {
+        this.selectedIndex = selectedIndex;
+        this.forceUpdate();
+    }
 
-  render = () => {
-    const { contexts } = this.state
-
-	if (Lang.isNull(contexts)) return null; 
-	
-    return (
-      <Portal closeOnEsc closeOnOutsideClick isOpened={this.props.isOpened} onOpen={this.onOpen} onClose={this.onClose}>
-        <div className="context-portal">
-          <ul>
-            {contexts.map((context, index) => {
-              return <ContextItem
-                key={context.key}
-                index={index}
-                context={context}
-                selectedIndex={this.selectedIndex}
-                setSelectedIndex={this.setSelectedIndex}
-                onSelected={this.props.onSelected}
-				onChange={this.props.onChange}
-                closePortal={this.closePortal}
-				state={this.props.state}
-              />
-			  }
-            )}
-          </ul>
-        </div>
-      </Portal>
-    )
-  }
+    render = () => {
+        const { contexts } = this.state;
+  
+        if (Lang.isNull(contexts)) return null; 
+    
+        return (
+            <Portal 
+                closeOnEsc 
+                closeOnOutsideClick 
+                isOpened={this.props.isOpened} 
+                onOpen={this.onOpen} 
+                onClose={this.onClose}
+            >
+                <div className="context-portal">
+                    <ul>
+                        {contexts.map((context, index) => {
+                            return <ContextItem
+                                key={context.key}
+                                index={index}
+                                context={context}
+                                selectedIndex={this.selectedIndex}
+                                setSelectedIndex={this.setSelectedIndex}
+                                onSelected={this.props.onSelected}
+                                onChange={this.props.onChange}
+                                closePortal={this.closePortal}
+                                state={this.props.state}
+                            />
+                        })}
+                    </ul>
+                </div>
+            </Portal>
+        )
+    }
 }
 
 export default ContextPortal

--- a/src/notes/FluxNotesEditor.css
+++ b/src/notes/FluxNotesEditor.css
@@ -60,48 +60,6 @@
   color: black;
 }
 
-.MyEditor-root .autocomplete-menu { 
-    position: absolute;
-    box-sizing: border-box;
-    border-radius: 2px;
-    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-    box-shadow: rgba(0, 0, 0, 0.12) 0px 1px 6px, rgba(0, 0, 0, 0.12) 0px 1px 4px;
-    transition: all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms;
-    background-color: rgb(255, 255, 255);
-    z-index: 1111;
-}
-
-.MyEditor-root .autocomplete-menu > * {
-    display: block;
-    padding: 7px 10px;
-}
-
-.MyEditor-root .autocomplete-menu .menu-item[data-active="true"] {
-    background-color: rgba(0,0,0,0.1);
-}
-
-
-.MyEditor-root .shorthand-menu { 
-    position: absolute;
-    box-sizing: border-box;
-    border-radius: 2px;
-    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-    box-shadow: rgba(0, 0, 0, 0.12) 0px 1px 6px, rgba(0, 0, 0, 0.12) 0px 1px 4px;
-    transition: all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms;
-    background-color: rgb(255, 255, 255);
-    z-index: 1111;
-}
-
-.MyEditor-root .shorthand-menu > * {
-    display: block;
-    padding: 7px 10px;
-}
-
-.MyEditor-root .shorthand-menu .menu-item[data-active="true"] {
-    background-color: rgba(0,0,0,0.1);
-}
-
-
 .MyEditor-root p {
     display: inline;
     margin:0;
@@ -119,27 +77,38 @@
   width: 100%;  
 }
 
-.suggestion-portal {
-  display: none;
-  position: absolute;
-  z-index: 10000;
-  margin-top: 30px;
-  width: 200px;
+.suggestion-portal { 
+    position: absolute;
+    box-sizing: border-box;
+    border-radius: 2px;
+    margin-top: 30px;
+    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+    box-shadow: rgba(0, 0, 0, 0.12) 0px 1px 6px, rgba(0, 0, 0, 0.12) 0px 1px 4px;
+    transition: all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms;
+    background-color: rgb(255, 255, 255);
+    z-index: 1111;
 }
 
 .suggestion-portal ul {
   list-style-type: none;
-  margin-top: 0;
-  position: relative;
-  padding-left: 0;
-  margin-left: -8px;
+  padding: 0;
+  margin: 10px 0;
   background-color: #fff;
 }
 
-.suggestion-portal li {
-  padding: 5px 10px;
+.suggestion-portal > * {
+    display: block;
+    padding: 7px 10px;
+}
+
+
+.suggestion-portal li { 
+    padding: 5px 10px;
+    min-width: 75px;
+    max-width: 300px
 }
 
 .suggestion-portal li.selected {
-  background-color: #eee;
+  background-color: #297DA2;
+  color: #fff;
 }

--- a/src/notes/FluxNotesEditor.css
+++ b/src/notes/FluxNotesEditor.css
@@ -2,11 +2,11 @@
     width: 100%;
     max-width: 600px;
     margin: 20px auto;
-	text-align: left;
+    text-align: left;
 }
 
 .structured-field {
-	background-color: #d9ebf9;
+    background-color: #d9ebf9;
 }
 
 #clinical-notes #note-description p.note-description-detail-name {
@@ -57,7 +57,7 @@
 }
 
 .MyEditor-root .toolbar-menu .button[data-active="true"] {
-  color: black;
+    color: black;
 }
 
 .MyEditor-root p {
@@ -70,11 +70,11 @@
 }
 
 .clear{
-  clear: both;
-  display: block;  
-  content: "";
-  margin: 10px 0;
-  width: 100%;  
+    clear: both;
+    display: block;  
+    content: "";
+    margin: 10px 0;
+    width: 100%;  
 }
 
 .suggestion-portal { 
@@ -90,10 +90,10 @@
 }
 
 .suggestion-portal ul {
-  list-style-type: none;
-  padding: 0;
-  margin: 10px 0;
-  background-color: #fff;
+    list-style-type: none;
+    padding: 0;
+    margin: 10px 0;
+    background-color: #fff;
 }
 
 .suggestion-portal > * {
@@ -109,6 +109,6 @@
 }
 
 .suggestion-portal li.selected {
-  background-color: #297DA2;
-  color: #fff;
+    background-color: #297DA2;
+    color: #fff;
 }

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -44,7 +44,6 @@ class FluxNotesEditor extends React.Component {
         this.didFocusChange = false;
         
         this.selectingForShortcut = null;
-        this.onPortalSelection = this.onPortalSelection.bind(this);
         this.onChange = this.onChange.bind(this);
         
         // Set the initial state when the app is first constructed.
@@ -366,48 +365,111 @@ class FluxNotesEditor extends React.Component {
         );
     }
 }
-
-function getPos(el) {
+function getPos(domElement, node, state) {
     const offsetx = 0;
     const offsety = 0;
-    // This produces an offset relative to the current slate location
     var pos = { left: 0, top: 0 };
+    
+    const children = domElement.childNodes;
 
-    // Acquire from http://jsfiddle.net/gliheng/vbucs/12/
-    if (document.selection) {
-        var range = document.selection.createRange();
-        pos.left += range.offsetLeft + offsetx;
-        pos.top += range.offsetTop + offsety;
-    } else if (window.getSelection) {
-        var sel = window.getSelection();
-        if (sel.rangeCount === 0)  { 
-            console.log('for whatever reason the range count is zero')
-            return {};
+    console.log(domElement);
+    console.log(domElement.childNodes);
+
+    for(const child of children) { 
+        console.log(child);
+        if (child.getBoundingClientRect && child.getAttribute("data-key")) { 
+            const rect = child.getBoundingClientRect();
+            console.log(rect);
+            pos.left = rect.left + rect.width + offsetx;
+            pos.top = rect.top + offsety ;
         }
-        var _range = sel.getRangeAt(0).cloneRange();
+    }
+    return pos;
 
-        try {
-            _range.setStart(_range.startContainer, _range.startOffset - 1);
-        } catch (e) {console.log("error in setting range start")}
-
+/*    var sel = window.getSelection();
+    console.log(sel)
+    console.log(sel.rangeCount)
+    window.selectionOne = state.state.selection;
+    var _range = sel.getRangeAt(0).cloneRange();
+    console.log(_range);
+    try {
+        _range.setStart(_range.startContainer, _range.startOffset - 1);
+        console.log(_range)
         var rect = _range.getBoundingClientRect();
+        console.log(rect)
+        console.log(_range.endOffset)
+        console.log(_range.toString())
         if (_range.endOffset === 0 || _range.toString() === '') {
+            console.log("endoffset is 0 and the range is empty")
             pos.top += _range.startContainer.offsetTop;
             pos.left += _range.startContainer.offsetLeft;
         } else {
+            console.log("rect has content")
             pos.left += rect.left + rect.width + offsetx;
             pos.top += rect.top + offsety ;
         }
-    } else { 
-        console.error('Issues getting a proper position for the portal')
+    } catch(e) { 
+        console.log(e)
     }
-    return pos;
+    return pos;*/
+    // // Acquire from http://jsfiddle.net/gliheng/vbucs/12/
+    // if (document.selection) {
+    //     var range = document.selection.createRange();
+    //     pos.left += range.offsetLeft + offsetx;
+    //     pos.top += range.offsetTop + offsety;
+    // } else if (window.getSelection) {
+    //     var sel = window.getSelection();
+    //     console.log(sel)
+    //     console.log(sel.rangeCount)
+    //     if (sel.rangeCount === 0)  { 
+    //         console.log(domElement)
+    //         console.log("range is 0")
+    //         while (domElement != null) { 
+    //             pos.left += domElement.offsetLeft;
+    //             pos.top += domElement.offsetTop; 
+    //             domElement = domElement.offsetParent;    
+    //         }
+    //         return pos;
+    //     } else {
+    //         console.log("rangecount isn't 0")
+    //         var _range = sel.getRangeAt(0).cloneRange();
+
+    //         try {
+    //             _range.setStart(_range.startContainer, _range.startOffset - 1);
+    //             console.log("range setstart didn't fail")
+    //             var rect = _range.getBoundingClientRect();
+    //             if (_range.endOffset === 0 || _range.toString() === '') {
+    //                 console.log("endoffset is 0 and the range is empty")
+    //                 pos.top += _range.startContainer.offsetTop;
+    //                 pos.left += _range.startContainer.offsetLeft;
+    //             } else {
+    //                 console.log("rect has content")
+    //                 pos.left += rect.left + rect.width + offsetx;
+    //                 pos.top += rect.top + offsety ;
+    //             }
+    //         } catch (e) {
+    //             while (domElement != null) { 
+    //                 console.log(domElement)
+    //                 pos.left += domElement.offsetLeft;
+    //                 pos.top += domElement.offsetTop; 
+    //                 domElement = domElement.offsetParent;    
+    //             }
+    //         }            
+    //     }
+    // } else { 
+    //     while (domElement != null) { 
+    //         pos.left += domElement.offsetLeft;
+    //         pos.top += domElement.offsetTop; 
+    //         domElement = domElement.offsetParent;    
+    //     }
+    // }
 }
+
 
 function position(state) {
     const parentNode = state.state.document.getParent(state.state.selection.startKey);
     const el = Slate.findDOMNode(parentNode);
-    return getPos(el);
+    return getPos(el, parentNode, state);
 }
 
 function getIndexRangeForCurrentWord(text, index, initialIndex, initialChar) {

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -371,7 +371,7 @@ function getPos(el) {
     const offsetx = 0;
     const offsety = 0;
     // This produces an offset relative to the current slate location
-    var pos = { left: 0, top: 20 };
+    var pos = { left: 0, top: 0 };
 
     // Acquire from http://jsfiddle.net/gliheng/vbucs/12/
     if (document.selection) {

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -372,97 +372,14 @@ function getPos(domElement, node, state) {
     
     const children = domElement.childNodes;
 
-    console.log(domElement);
-    console.log(domElement.childNodes);
-
     for(const child of children) { 
-        console.log(child);
         if (child.getBoundingClientRect && child.getAttribute("data-key")) { 
             const rect = child.getBoundingClientRect();
-            console.log(rect);
             pos.left = rect.left + rect.width + offsetx;
             pos.top = rect.top + offsety ;
         }
     }
     return pos;
-
-/*    var sel = window.getSelection();
-    console.log(sel)
-    console.log(sel.rangeCount)
-    window.selectionOne = state.state.selection;
-    var _range = sel.getRangeAt(0).cloneRange();
-    console.log(_range);
-    try {
-        _range.setStart(_range.startContainer, _range.startOffset - 1);
-        console.log(_range)
-        var rect = _range.getBoundingClientRect();
-        console.log(rect)
-        console.log(_range.endOffset)
-        console.log(_range.toString())
-        if (_range.endOffset === 0 || _range.toString() === '') {
-            console.log("endoffset is 0 and the range is empty")
-            pos.top += _range.startContainer.offsetTop;
-            pos.left += _range.startContainer.offsetLeft;
-        } else {
-            console.log("rect has content")
-            pos.left += rect.left + rect.width + offsetx;
-            pos.top += rect.top + offsety ;
-        }
-    } catch(e) { 
-        console.log(e)
-    }
-    return pos;*/
-    // // Acquire from http://jsfiddle.net/gliheng/vbucs/12/
-    // if (document.selection) {
-    //     var range = document.selection.createRange();
-    //     pos.left += range.offsetLeft + offsetx;
-    //     pos.top += range.offsetTop + offsety;
-    // } else if (window.getSelection) {
-    //     var sel = window.getSelection();
-    //     console.log(sel)
-    //     console.log(sel.rangeCount)
-    //     if (sel.rangeCount === 0)  { 
-    //         console.log(domElement)
-    //         console.log("range is 0")
-    //         while (domElement != null) { 
-    //             pos.left += domElement.offsetLeft;
-    //             pos.top += domElement.offsetTop; 
-    //             domElement = domElement.offsetParent;    
-    //         }
-    //         return pos;
-    //     } else {
-    //         console.log("rangecount isn't 0")
-    //         var _range = sel.getRangeAt(0).cloneRange();
-
-    //         try {
-    //             _range.setStart(_range.startContainer, _range.startOffset - 1);
-    //             console.log("range setstart didn't fail")
-    //             var rect = _range.getBoundingClientRect();
-    //             if (_range.endOffset === 0 || _range.toString() === '') {
-    //                 console.log("endoffset is 0 and the range is empty")
-    //                 pos.top += _range.startContainer.offsetTop;
-    //                 pos.left += _range.startContainer.offsetLeft;
-    //             } else {
-    //                 console.log("rect has content")
-    //                 pos.left += rect.left + rect.width + offsetx;
-    //                 pos.top += rect.top + offsety ;
-    //             }
-    //         } catch (e) {
-    //             while (domElement != null) { 
-    //                 console.log(domElement)
-    //                 pos.left += domElement.offsetLeft;
-    //                 pos.top += domElement.offsetTop; 
-    //                 domElement = domElement.offsetParent;    
-    //             }
-    //         }            
-    //     }
-    // } else { 
-    //     while (domElement != null) { 
-    //         pos.left += domElement.offsetLeft;
-    //         pos.top += domElement.offsetTop; 
-    //         domElement = domElement.offsetParent;    
-    //     }
-    // }
 }
 
 

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -39,21 +39,21 @@ class FluxNotesEditor extends React.Component {
     constructor(props) {
         super(props);
 
-		this.contextManager = this.props.contextManager;
-		
-		this.didFocusChange = false;
-		
-		this.selectingForShortcut = null;
-		this.onPortalSelection = this.onPortalSelection.bind(this);
-		this.onChange = this.onChange.bind(this);
-		
+        this.contextManager = this.props.contextManager;
+        
+        this.didFocusChange = false;
+        
+        this.selectingForShortcut = null;
+        this.onPortalSelection = this.onPortalSelection.bind(this);
+        this.onChange = this.onChange.bind(this);
+        
         // Set the initial state when the app is first constructed.
         this.state = {
             state: initialState,
-			isPortalOpen: false,
-			portalOptions: null,
-			left: 0,
-			top: 0
+            isPortalOpen: false,
+            portalOptions: null,
+            left: 0,
+            top: 0
         }
 
         // setup structured field plugin
@@ -83,139 +83,139 @@ class FluxNotesEditor extends React.Component {
         });
         
         this.plugins = [
-			this.suggestionsPluginCreators,
-			this.suggestionsPluginInserters,
-			this.structuredFieldPlugin
-		];
-		
-		this.autoReplaceBeforeRegExp = undefined;
-		
-		let autoReplaceAfters = [];
-		let allShortcuts = this.props.shortcutManager.getAllShortcutClasses();
-		allShortcuts.forEach((shortcutC) => {
-			autoReplaceAfters = autoReplaceAfters.concat(shortcutC.getTriggers());			
-		});
-		this.autoReplaceBeforeRegExp = new RegExp("(" + autoReplaceAfters.join("|") + ")", 'i');
-		
-		// now add an AutoReplace plugin instance for each shortcut we're supporting as well
-		this.plugins.push(AutoReplace({
-			"trigger": 'space',
-			"before": this.autoReplaceBeforeRegExp,
-			"transform": this.autoReplaceTransform.bind(this)
-		}));
+            this.suggestionsPluginCreators,
+            this.suggestionsPluginInserters,
+            this.structuredFieldPlugin
+        ];
+        
+        this.autoReplaceBeforeRegExp = undefined;
+        
+        let autoReplaceAfters = [];
+        let allShortcuts = this.props.shortcutManager.getAllShortcutClasses();
+        allShortcuts.forEach((shortcutC) => {
+            autoReplaceAfters = autoReplaceAfters.concat(shortcutC.getTriggers());          
+        });
+        this.autoReplaceBeforeRegExp = new RegExp("(" + autoReplaceAfters.join("|") + ")", 'i');
+        
+        // now add an AutoReplace plugin instance for each shortcut we're supporting as well
+        this.plugins.push(AutoReplace({
+            "trigger": 'space',
+            "before": this.autoReplaceBeforeRegExp,
+            "transform": this.autoReplaceTransform.bind(this)
+        }));
     }
-		
-	suggestionFunction(initialChar, text) {
+        
+    suggestionFunction(initialChar, text) {
         if (Lang.isUndefined(text)) return [];
-		let shortcuts = this.contextManager.getCurrentlyValidShortcuts();
+        let shortcuts = this.contextManager.getCurrentlyValidShortcuts();
         let suggestionsShortcuts = [];
         const textLowercase = text.toLowerCase();
         shortcuts.forEach((shortcut) => {
-			const triggers = shortcut.getTriggers();
-			triggers.forEach((trigger) => {
-				const triggerNoPrefix = trigger.substring(1);
-				if (trigger.substring(0, 1) === initialChar && triggerNoPrefix.toLowerCase().includes(textLowercase)) {
-					suggestionsShortcuts.push({
-						"key": triggerNoPrefix,
-						"value": trigger,
-						"suggestion": triggerNoPrefix
-					});
-				}
-			});
+            const triggers = shortcut.getTriggers();
+            triggers.forEach((trigger) => {
+                const triggerNoPrefix = trigger.substring(1);
+                if (trigger.substring(0, 1) === initialChar && triggerNoPrefix.toLowerCase().includes(textLowercase)) {
+                    suggestionsShortcuts.push({
+                        "key": triggerNoPrefix,
+                        "value": trigger,
+                        "suggestion": triggerNoPrefix
+                    });
+                }
+            });
         });
-		return suggestionsShortcuts.slice(0, 10);
-	}
-	
-	choseSuggestedShortcut(suggestion) {
-		const { state } = this.state; 
+        return suggestionsShortcuts.slice(0, 10);
+    }
+    
+    choseSuggestedShortcut(suggestion) {
+        const { state } = this.state; 
         let shortcut = this.props.newCurrentShortcut(suggestion.value);
-		
-		if (!Lang.isNull(shortcut) && shortcut.needToSelectValueFromMultipleOptions()) {
-			return this.openPortalToSelectValueForShortcut(shortcut, true, state.transform()).apply();
-		} else {
+        
+        if (!Lang.isNull(shortcut) && shortcut.needToSelectValueFromMultipleOptions()) {
+            return this.openPortalToSelectValueForShortcut(shortcut, true, state.transform()).apply();
+        } else {
             let transformBeforeInsert = this.suggestionDeleteExistingTransform(state.transform(), shortcut.getPrefixCharacter());
-			let transformAfterInsert = this.insertStructuredFieldTransform(transformBeforeInsert, shortcut).focus();
-			return transformAfterInsert.apply();
-		}
-	}
-	
-	insertShortcut(shortcutTrigger, transform = undefined) {
-		if (Lang.isUndefined(transform)) {
-			transform = this.state.state.transform();
-		}
-		let shortcut = this.props.newCurrentShortcut(shortcutTrigger);
-		if (!Lang.isNull(shortcut) && shortcut.needToSelectValueFromMultipleOptions()) {
-			return this.openPortalToSelectValueForShortcut(shortcut, false, transform);
-		} else {
-			return this.insertStructuredFieldTransform(transform, shortcut).collapseToStartOfNextText().focus();
-		}
-	}
-	
-	autoReplaceTransform(transform, e, data, matches) {
-		// need to use Transform object provided to this method, which AutoReplace .apply()s after return.
-		this.insertShortcut(matches.before[0], transform);
-	}
-	
-	openPortalToSelectValueForShortcut(shortcut, needToDelete, transform) {
-		let portalOptions = shortcut.getValueSelectionOptions();
-		let pos = position(this.state);
-		
-		this.setState({
-			isPortalOpen: true,
-			portalOptions: portalOptions,
-			needToDelete: needToDelete,
-			left: pos.left,
-			top: pos.top
-		});
-		this.selectingForShortcut = shortcut;
-		return transform.blur();
-	}
+            let transformAfterInsert = this.insertStructuredFieldTransform(transformBeforeInsert, shortcut).focus();
+            return transformAfterInsert.apply();
+        }
+    }
+    
+    insertShortcut(shortcutTrigger, transform = undefined) {
+        if (Lang.isUndefined(transform)) {
+            transform = this.state.state.transform();
+        }
+        let shortcut = this.props.newCurrentShortcut(shortcutTrigger);
+        if (!Lang.isNull(shortcut) && shortcut.needToSelectValueFromMultipleOptions()) {
+            return this.openPortalToSelectValueForShortcut(shortcut, false, transform);
+        } else {
+            return this.insertStructuredFieldTransform(transform, shortcut).collapseToStartOfNextText().focus();
+        }
+    }
+    
+    autoReplaceTransform(transform, e, data, matches) {
+        // need to use Transform object provided to this method, which AutoReplace .apply()s after return.
+        this.insertShortcut(matches.before[0], transform);
+    }
+    
+    openPortalToSelectValueForShortcut(shortcut, needToDelete, transform) {
+        let portalOptions = shortcut.getValueSelectionOptions();
+        let pos = position(this.state);
+        
+        this.setState({
+            isPortalOpen: true,
+            portalOptions: portalOptions,
+            needToDelete: needToDelete,
+            left: pos.left,
+            top: pos.top
+        });
+        this.selectingForShortcut = shortcut;
+        return transform.blur();
+    }
 
-	// called from portal when an item is selected (context is not null) or if portal is closed without
-	// selection (context is null)
-	onPortalSelection = (state, context) => {
-		this.setState({ isPortalOpen: false });
-		if (Lang.isNull(context)) return state;
-		let shortcut = this.selectingForShortcut;
-		this.selectingForShortcut = null;
-		shortcut.clearValueSelectionOptions();
-		shortcut.setText(context.context);
-		if (shortcut.isContext()) {
-			shortcut.setValueObject(context.object);
-		}
-		this.contextManager.contextUpdated();
-		let transform;
-		if (this.state.needToDelete) {
-			transform = this.suggestionDeleteExistingTransform(null, shortcut.getPrefixCharacter());
-		} else {
-			transform = this.state.state.transform();
-		}
-		return this.insertStructuredFieldTransform(transform, shortcut).collapseToStartOfNextText().focus().apply();
-	}
+    // called from portal when an item is selected (context is not null) or if portal is closed without
+    // selection (context is null)
+    onPortalSelection = (state, context) => {
+        this.setState({ isPortalOpen: false });
+        if (Lang.isNull(context)) return state;
+        let shortcut = this.selectingForShortcut;
+        this.selectingForShortcut = null;
+        shortcut.clearValueSelectionOptions();
+        shortcut.setText(context.context);
+        if (shortcut.isContext()) {
+            shortcut.setValueObject(context.object);
+        }
+        this.contextManager.contextUpdated();
+        let transform;
+        if (this.state.needToDelete) {
+            transform = this.suggestionDeleteExistingTransform(null, shortcut.getPrefixCharacter());
+        } else {
+            transform = this.state.state.transform();
+        }
+        return this.insertStructuredFieldTransform(transform, shortcut).collapseToStartOfNextText().focus().apply();
+    }
 
-	// consider reusing this method to replace code in choseSuggestedShortcut function
-	suggestionDeleteExistingTransform(transform = null, prefixCharacter) {
-		const { state } = this.state;
-		if (Lang.isNull(transform)) {
-			transform = state.transform();
-		}
-		const { anchorText, anchorOffset } = state
-		const text = anchorText.text
+    // consider reusing this method to replace code in choseSuggestedShortcut function
+    suggestionDeleteExistingTransform(transform = null, prefixCharacter) {
+        const { state } = this.state;
+        if (Lang.isNull(transform)) {
+            transform = state.transform();
+        }
+        const { anchorText, anchorOffset } = state
+        const text = anchorText.text
 
-		let index = { start: anchorOffset - 1, end: anchorOffset }
+        let index = { start: anchorOffset - 1, end: anchorOffset }
 
-		if (text[anchorOffset - 1] !== prefixCharacter) {
-			index = getIndexRangeForCurrentWord(text, anchorOffset - 1, anchorOffset - 1, prefixCharacter)
-		}
-			
-		const newText = `${text.substring(0, index.start)}`
-		return transform
-			.deleteBackward(anchorOffset)
-			.insertText(newText)	
-	}
-	
+        if (text[anchorOffset - 1] !== prefixCharacter) {
+            index = getIndexRangeForCurrentWord(text, anchorOffset - 1, anchorOffset - 1, prefixCharacter)
+        }
+            
+        const newText = `${text.substring(0, index.start)}`
+        return transform
+            .deleteBackward(anchorOffset)
+            .insertText(newText)    
+    }
+    
     insertStructuredFieldTransform(transform, shortcut) {
-		if (Lang.isNull(shortcut)) return transform.focus();
+        if (Lang.isNull(shortcut)) return transform.focus();
         let result = this.structuredFieldPlugin.transforms.insertStructuredField(transform, shortcut); //2nd param needs to be Shortcut Object, how to create?
         return result[0];
     }
@@ -238,28 +238,28 @@ class FluxNotesEditor extends React.Component {
      * Handle updates when we have a new
      */
     handleSummaryUpdate = (itemToBeInserted) => {
-		let state;
-		const currentState = this.state.state;
-		let transform = currentState.transform();
-		let regExp = new RegExp("([@#][\\w\\-,\\s]+[#@])", "i");
-		let result = regExp.exec(itemToBeInserted);
-		let remainder = itemToBeInserted;
-		let start, before;
-		while (!Lang.isNull(result)) {
-			start = remainder.indexOf(result[0]);
-			before = remainder.substring(0, start);
-			remainder = remainder.substring(start + result[0].length);
-			transform = transform
-				.insertText(before)
-			transform = this.insertShortcut(result[0].substring(0, result[0].length - 1), transform);
-			result = regExp.exec(remainder);
-		}
-		if (remainder.length > 0) {
-			transform = transform.insertText(remainder);
-		}
-		state = transform.focus().apply();
-		this.setState({state: state});
-	}
+        let state;
+        const currentState = this.state.state;
+        let transform = currentState.transform();
+        let regExp = new RegExp("([@#][\\w\\-,\\s]+[#@])", "i");
+        let result = regExp.exec(itemToBeInserted);
+        let remainder = itemToBeInserted;
+        let start, before;
+        while (!Lang.isNull(result)) {
+            start = remainder.indexOf(result[0]);
+            before = remainder.substring(0, start);
+            remainder = remainder.substring(start + result[0].length);
+            transform = transform
+                .insertText(before)
+            transform = this.insertShortcut(result[0].substring(0, result[0].length - 1), transform);
+            result = regExp.exec(remainder);
+        }
+        if (remainder.length > 0) {
+            transform = transform.insertText(remainder);
+        }
+        state = transform.focus().apply();
+        this.setState({state: state});
+    }
 
     /**
      * Check if the current selection has a mark with `type` in it.
@@ -276,10 +276,10 @@ class FluxNotesEditor extends React.Component {
         const {state} = this.state;
         return state.blocks.some(node => node.type === type);
     }
-	
+    
     render = () => {
         const CreatorsPortal = this.suggestionsPluginCreators.SuggestionPortal;
-		const InsertersPortal = this.suggestionsPluginInserters.SuggestionPortal;
+        const InsertersPortal = this.suggestionsPluginInserters.SuggestionPortal;
 
         let noteDescriptionContent = null;
         if (this.props.patient == null) {
@@ -309,17 +309,17 @@ class FluxNotesEditor extends React.Component {
                 </div>
             );
         }
-		let errorDisplay = "";
-		if (this.props.errors && this.props.errors.length > 0) {
-			errorDisplay = (
-				<div>
+        let errorDisplay = "";
+        if (this.props.errors && this.props.errors.length > 0) {
+            errorDisplay = (
+                <div>
                     <Divider className="divider"/>
-					<h1 style={{color:'red'}}>{this.props.errors.join()}</h1>
-					<Divider className="divider"/>
-				</div>
-			);
-		}
-		const callback = {}
+                    <h1 style={{color:'red'}}>{this.props.errors.join()}</h1>
+                    <Divider className="divider"/>
+                </div>
+            );
+        }
+        const callback = {}
         /**
          * Render the editor, toolbar, dropdown and description for note
          */
@@ -343,24 +343,24 @@ class FluxNotesEditor extends React.Component {
                             onChange={this.onChange}
                             schema={schema}
                         />
-						{errorDisplay}
-						<CreatorsPortal 
-							state={this.state.state} />
-						<InsertersPortal
-							state={this.state.state} />
-						<ContextPortal
-							left={this.state.left}
-							top={this.state.top}
-							state={this.state.state}
-							callback={callback}
-							onSelected={this.onPortalSelection}
-							contexts={this.state.portalOptions}
-							capture={/@([\w]*)/}
-							trigger={"@"}
-							onChange={this.onChange}
-							isOpened={this.state.isPortalOpen}
-						/>
-					</div>
+                        {errorDisplay}
+                        <CreatorsPortal 
+                            state={this.state.state} />
+                        <InsertersPortal
+                            state={this.state.state} />
+                        <ContextPortal
+                            left={this.state.left}
+                            top={this.state.top}
+                            state={this.state.state}
+                            callback={callback}
+                            onSelected={this.onPortalSelection}
+                            contexts={this.state.portalOptions}
+                            capture={/@([\w]*)/}
+                            trigger={"@"}
+                            onChange={this.onChange}
+                            isOpened={this.state.isPortalOpen}
+                        />
+                    </div>
                 </Paper>
             </div>
         );
@@ -368,26 +368,52 @@ class FluxNotesEditor extends React.Component {
 }
 
 function getPos(el) {
-    for (var lx=0, ly=0;
-         el != null;
-         lx += el.offsetLeft, ly += el.offsetTop, el = el.offsetParent);
-    return {left: lx,top: ly};
+    const offsetx = 0;
+    const offsety = 0;
+    // This produces an offset relative to the current slate location
+    var pos = { left: 0, top: 20 };
+
+    // Acquire from http://jsfiddle.net/gliheng/vbucs/12/
+    if (document.selection) {
+        var range = document.selection.createRange();
+        pos.left += range.offsetLeft + offsetx;
+        pos.top += range.offsetTop + offsety;
+    } else if (window.getSelection) {
+        var sel = window.getSelection();
+        if (sel.rangeCount === 0)  { 
+            console.log('for whatever reason the range count is zero')
+            return {};
+        }
+        var _range = sel.getRangeAt(0).cloneRange();
+
+        try {
+            _range.setStart(_range.startContainer, _range.startOffset - 1);
+        } catch (e) {console.log("error in setting range start")}
+
+        var rect = _range.getBoundingClientRect();
+        if (_range.endOffset === 0 || _range.toString() === '') {
+            pos.top += _range.startContainer.offsetTop;
+            pos.left += _range.startContainer.offsetLeft;
+        } else {
+            pos.left += rect.left + rect.width + offsetx;
+            pos.top += rect.top + offsety ;
+        }
+    } else { 
+        console.error('Issues getting a proper position for the portal')
+    }
+    return pos;
 }
 
 function position(state) {
-	let pos = {};
-	pos.left = state.left;
-	pos.top = state.top;
-	
-	const parentNode = state.state.document.getParent(state.state.selection.startKey);
-	const el = Slate.findDOMNode(parentNode);
-	return getPos(el);
+    const parentNode = state.state.document.getParent(state.state.selection.startKey);
+    const el = Slate.findDOMNode(parentNode);
+    return getPos(el);
 }
 
 function getIndexRangeForCurrentWord(text, index, initialIndex, initialChar) {
     if (index === initialIndex) {
-        return { 	start: getIndexRangeForCurrentWord(text, index - 1, initialIndex, initialChar), 
-                    end: getIndexRangeForCurrentWord(text, index + 1, initialIndex, initialChar) 	}
+        return {    start: getIndexRangeForCurrentWord(text, index - 1, initialIndex, initialChar), 
+                    end: getIndexRangeForCurrentWord(text, index + 1, initialIndex, initialChar)    }
     }
     if (text[index] === initialChar || text[index] === undefined) {
         return index

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -376,7 +376,7 @@ function getPos(domElement, node, state) {
         if (child.getBoundingClientRect && child.getAttribute("data-key")) { 
             const rect = child.getBoundingClientRect();
             pos.left = rect.left + rect.width + offsetx;
-            pos.top = rect.top + offsety ;
+            pos.top = rect.top + offsety;
         }
     }
     return pos;

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -28,15 +28,10 @@ function StructuredFieldPlugin(opts) {
         let result = state;
         deletedKeys.forEach((key) => {
             shortcut = structuredFieldMap.get(key);
-            //console.log("deleted key = " + key);
-            //console.log(shortcut);
             if (shortcut.onBeforeDeleted()) {
                 structuredFieldMap.delete(key);
                 contextManager.contextUpdated();
             } else {
-                console.log("cancel state change");
-//                console.log(state);
-//                console.log(editor.getState());
                 result = editor.getState(); // don't allow state change
                 //opts.updateErrors(["You can not delete " + shortcut.getText() + " as it has child fields."]);
             }


### PR DESCRIPTION
In this PR: 
- Improved styling of the context menu,
- Improved the positioning function for the context menu based on code in slate-suggestions,
- Improved styling of selected elements in other autocomplete menus to match the new menu styling,
- On files I touched in accomplishing these tasks, I aligned styling with recent style guidelines. Changes include: 
    - Replacing tabs with spaces.
    - Consistently use 4 spaces to indent.
    - Unified use of arrow functions in class definitions to ensure the 'this' keyword means the same thing across functions. 
    - In ContextPortal I refactored the keydown function, removed duplicate reference to context being stored in ContextPortal's state, and fixed selectedIndex to be stored in the component's state.

