### PR TITLE
Fix search field style in IE for patient mode

### DIFF
--- a/src/context/ContextOptions.css
+++ b/src/context/ContextOptions.css
@@ -1,9 +1,9 @@
 .btn_template_ctx {
-  width: 100%;
-  margin-left: 2px;
-  margin-right: 2px;
-  margin-bottom: 20px;
-  min-width: 10px !important;
+    width: 100%;
+    margin-left: 2px;
+    margin-right: 2px;
+    margin-bottom: 20px;
+    min-width: 10px !important;
 }
 
 .context-options-list {

--- a/src/context/ContextOptions.css
+++ b/src/context/ContextOptions.css
@@ -16,6 +16,5 @@
     padding: 15px 0;
     background-color: #ffffff;
     text-align: left;
-    /*height: 50px;*/
     margin-bottom: 15px;
 }

--- a/src/context/ContextOptions.css
+++ b/src/context/ContextOptions.css
@@ -1,7 +1,4 @@
 .btn_template_ctx {
-//    display: inline-block !important;
-//  float: left;
-//  clear: left;
   width: 100%;
   margin-left: 2px;
   margin-right: 2px;
@@ -13,14 +10,12 @@
     overflow-y: scroll;
     overflow-x: hidden;
     height: 710px;
-//    margin-top: 20px;
 }
 
 #shortcut-search {
     padding: 15px 0;
     background-color: #ffffff;
     text-align: left;
-    height: 50px;
-//    border-bottom: 1px solid #d9d9d9 !important;
+    /*height: 50px;*/
     margin-bottom: 15px;
 }

--- a/src/viewer/ShortcutViewer.css
+++ b/src/viewer/ShortcutViewer.css
@@ -17,6 +17,7 @@
     display: inline-block;
     margin-top:  60px;
     margin-bottom: 10px;
+    justify-content: flex-start !important;
 }
 
 #copy-keyword:after {


### PR DESCRIPTION
Removed height from ContextOptions.css file, which fixed the spacing issue in IE. Tested to make sure spacing of the search field doesn't overlap buttons in #progression, #toxicity, and #staging for chrome and for IE. 