### PR TITLE
Avatar & minor styling fixes

### DIFF
--- a/src/summary/DataSummaryPanel.jsx
+++ b/src/summary/DataSummaryPanel.jsx
@@ -66,7 +66,7 @@ inkBarStyle={{background: 'steelblue'}}
 						changeConditionIndex={this.changeConditionIndex}
                     />
 
-                    <Tabs  value={value} onChange={this.handleChange} indicatorColor="steelblue">
+                    <Tabs  value={value} onChange={this.handleChange} indicatorColor="steelblue" centered={true}>
                         <Tab label="Problem Summary" value={0}/>
                         <Tab label="Clinical Notes"  value={1}/>
                     </Tabs>

--- a/src/summary/SummaryHeader.css
+++ b/src/summary/SummaryHeader.css
@@ -16,7 +16,6 @@ h2, h3 {
 .patient-info {
   float: left;
   margin-left: 10px;
-  /*Can't go all the way to 100% width because of padding*/
   min-width: 70%;
   max-width: 70%;
 }

--- a/src/summary/SummaryHeader.css
+++ b/src/summary/SummaryHeader.css
@@ -9,12 +9,14 @@ h2, h3 {
 
 .avatar {
   float: left;
-  min-width: 30%;
-  max-width: 30%;
+  min-width: 25%;
+  max-width: 25%;
 }
 
 .patient-info {
   float: left;
+  margin-left: 10px;
+  /*Can't go all the way to 100% width because of padding*/
   min-width: 70%;
   max-width: 70%;
 }

--- a/src/summary/SummaryHeader.jsx
+++ b/src/summary/SummaryHeader.jsx
@@ -7,50 +7,56 @@ import './SummaryHeader.css';
 class SummaryHeader extends Component {
 
   render() {
-    return (
-      <div id="summary-header">
-        <div className="avatar">
-          <Avatar
-              src={this.props.photo}
-              size={70}
-          />
-        </div>
-        <div className="patient-info">
-          <div className="name-and-mrn">
-              <h1>{this.props.patientName}</h1>
-              <h2>MRN: {this.props.mrn}</h2>
-          </div>
-
-          <div className="basic-info">
-              <div className="item">
-                  <h3>DOB:</h3>
-                  <span>{this.props.dateOfBirth}</span>
-              </div>
-              <div className="item">
-                  <h3>Admin. Sex:</h3>
-                  <span>{this.props.administrativeSex}</span>
-              </div>
-              <div className="item">
-                  <h3>Location:</h3>
-                  <span>{this.props.address.city}, {this.props.address.state}</span>
-              </div>
-          </div>
-        </div>
-      </div>
-    );
-  }
+        return (
+            <div id="summary-header">
+                <div className="avatar">
+                    <Avatar
+                        src={this.props.photo}
+                        size={70}
+                        style={{
+                            marginTop: "15px",
+                            marginLeft: "auto",
+                            marginRight: "auto",
+                            width: "65px",
+                            height: "65px"
+                        }}
+                    />
+                </div>
+                <div className="patient-info">
+                    <div className="name-and-mrn">
+                        <h1>{this.props.patientName}</h1>
+                        <h2>MRN: {this.props.mrn}</h2>
+                    </div>
+                    <div className="basic-info">
+                        <div className="item">
+                            <h3>DOB:</h3>
+                            <span>{this.props.dateOfBirth}</span>
+                        </div>
+                        <div className="item">
+                            <h3>Admin. Sex:</h3>
+                            <span>{this.props.administrativeSex}</span>
+                        </div>
+                        <div className="item">
+                            <h3>Location:</h3>
+                            <span>{this.props.address.city}, {this.props.address.state}</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        );
+    }
 }
 
 SummaryHeader.propTypes = {
-  photo: PropTypes.string,
-  patientName: PropTypes.string,
-  mrn: PropTypes.string,
-  dateOfBirth: PropTypes.string,
-  administrativeSex: PropTypes.string,
-  address: PropTypes.shape({
-    city: PropTypes.string,
-    state: PropTypes.state
-  })
+        photo: PropTypes.string,
+        patientName: PropTypes.string,
+        mrn: PropTypes.string,
+        dateOfBirth: PropTypes.string,
+        administrativeSex: PropTypes.string,
+        address: PropTypes.shape({
+        city: PropTypes.string,
+        state: PropTypes.state
+    })
 };
 
 export default SummaryHeader;

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -2,62 +2,217 @@ import Lang from 'lodash'
 import moment from 'moment';
 
 class SummaryMetadata {
-	hardCodedMetadata = { "http://ncimeta.nci.nih.gov/C1334276" :	{ sections: [	{ 	name: "Current Diagnosis",
-																							items:	[	{ name: "Name", value: (patient, currentConditionEntry) => { return currentConditionEntry.specificType.coding.displayText; }},
-																										{ name: "Stage", value: (patient, currentConditionEntry) => { let s = patient.getMostRecentStagingForCondition(currentConditionEntry); if (s && s.value.coding.displayText.length > 0) { return s.value.coding.displayText + " (" + s.tStage.coding.displayText + s.nStage.coding.displayText + s.mStage.coding.displayText + ")";  } else { return null; } } }
-																								    ]},
-																						{	name: "Progression",
-																							items:	[	{ name: "Current Progression", value: (patient, currentConditionEntry) => { let p = patient.getMostRecentProgressionForCondition(currentConditionEntry, moment().subtract(6, 'months')); if (Lang.isNull(p)) return null; else return p.value.coding.displayText; }},
-																										{ name: "Progression Date", value: (patient, currentConditionEntry) => { let p = patient.getMostRecentProgressionForCondition(currentConditionEntry, moment().subtract(6, 'months')); if (Lang.isNull(p)) return null; else return p.clinicallyRelevantTime; }},
-																										{ name: "Progression Basis", value: (patient, currentConditionEntry) => { let p = patient.getMostRecentProgressionForCondition(currentConditionEntry, moment().subtract(6, 'months')); if (Lang.isNull(p)) return null; else return p.evidence.map(function(ev){ return ev.coding.displayText; }).join(); }}
-																									]},
-																						{ 	name: "Key Dates",
-																							items:	[	{ name: "Diagnosis", value: (patient, currentConditionEntry) => { return currentConditionEntry.whenClinicallyRecognized }},
-																										{ name: "Recurence", value: (patient, currentConditionEntry) => { return null; }}
-																									]},
-																						{ 	name: "Procedures", itemsFunction: this.getItemListForProcedures },
-																						{ 	name: "Pathology Results (Initial Diagnosis)",
-																							items:	[	{ name: "Color", value: null },
-																										{ name: "Weight", value: null },
-																										{ name: "Size", value: (patient, currentConditionEntry) => { let list = patient.getObservationsForCondition(currentConditionEntry, "http://standardhealthrecord.org/oncology/TumorSize"); return list[0].value.value + " " + list[0].value.units.value; }},
-																										{ name: "Tumor Margins", value: null },
-																										{ name: "Histological Grade", value: (patient, currentConditionEntry) => { return currentConditionEntry.breastCancerHistologicGrade.coding.displayText; }},
-																										{ name: "Receptor Status ER", value: (patient, currentConditionEntry) => { let er = patient.getReceptorStatus(currentConditionEntry, "23307004"); if (Lang.isNull(er)) { return null; } else { return er.value.coding.displayText; } }},
-																										{ name: "Receptor Status PR", value: (patient, currentConditionEntry) => { let pr = patient.getReceptorStatus(currentConditionEntry, "C0034833"); if (Lang.isNull(pr)) { return null; } else { return pr.value.coding.displayText; } }},
-																										{ name: "Receptor Status HER2", value: (patient, currentConditionEntry) => { let her2 = patient.getReceptorStatus(currentConditionEntry, "C0069515"); if (Lang.isNull(her2)) { return null; } else { return her2.value.coding.displayText; } }}
-																									]},
-																						{ 	name: "Genetics",
-																							items:	[	{ name: "Oncotype DX Recurrence Score", value: null},
-																										{ name: "Genetic Testing", value: null }
-																									]}
-																					]},
-								  "default":								{ sections: [	{	name: "Current Diagnosis",
-																							items:	[	{ name: "Name", value: (patient, currentConditionEntry) => { return currentConditionEntry.specificType.coding.displayText; }}
-																									]},
-																							{ 	name: "Key Dates",
-																							items:	[	{ name: "Diagnosis", value: (patient, currentConditionEntry) => { return currentConditionEntry.whenClinicallyRecognized }}
-																									]},
-																							{ 	name: "Procedures", itemsFunction: this.getItemListForProcedures },
-																						]}
-								};
-	constructor() {
-		this.metadata = this.hardCodedMetadata;
-	}
-	
-	getMetadata() {
-		return this.metadata;
-	}
+    hardCodedMetadata = { 
+        "http://ncimeta.nci.nih.gov/C1334276" : { 
+            sections: [   
+                {   
+                    name: "Current Diagnosis",
+                    items:  [
+                        { 
+                            name: "Name", 
+                            value: (patient, currentConditionEntry) => { 
+                                return currentConditionEntry.specificType.coding.displayText; 
+                            }
+                        }, {
+                             name: "Stage", 
+                             value: (patient, currentConditionEntry) => { 
+                                let s = patient.getMostRecentStagingForCondition(currentConditionEntry); 
+                                if (s && s.value.coding.displayText.length > 0) { 
+                                    return s.value.coding.displayText + " (" + s.tStage.coding.displayText + s.nStage.coding.displayText + s.mStage.coding.displayText + ")";  
+                                } else { 
+                                    return null; 
+                                } 
+                            } 
+                        }
+                    ]
+                },
+                {   
+                    name: "Progression",
+                    items:  [   
+                        { 
+                            name: "Current Progression", 
+                            value: (patient, currentConditionEntry) => { 
+                                let p = patient.getMostRecentProgressionForCondition(currentConditionEntry, moment().subtract(6, 'months')); 
+                                if (Lang.isNull(p)) {
+                                    return null; 
+                                } else {
+                                    return p.value.coding.displayText; 
+                                }
+                            }
+                        },
+                        { 
+                            name: "Progression Date", 
+                            value: (patient, currentConditionEntry) => {
+                                let p = patient.getMostRecentProgressionForCondition(currentConditionEntry, moment().subtract(6, 'months')); 
+                                if (Lang.isNull(p)) {
+                                    return null;   
+                                } else {
+                                    return p.clinicallyRelevantTime; 
+                                }
+                            }
+                        },
+                        { 
+                            name: "Progression Basis", 
+                            value: (patient, currentConditionEntry) => { 
+                                let p = patient.getMostRecentProgressionForCondition(currentConditionEntry, moment().subtract(6, 'months')); 
+                                if (Lang.isNull(p)) {
+                                    return null;
+                                } else {
+                                    return p.evidence.map(function(ev){ 
+                                        return ev.coding.displayText; 
+                                    }).join();
+                                } 
+                            }
+                        }
+                    ]
+                },
+                {   
+                    name: "Key Dates",
+                    items:  [   
+                        { 
+                            name: "Diagnosis", 
+                            value: (patient, currentConditionEntry) => { 
+                                return currentConditionEntry.whenClinicallyRecognized 
+                            }
+                        },
+                        { 
+                            name: "Recurence", 
+                            value: (patient, currentConditionEntry) => { 
+                                return null; 
+                            }
+                        }
+                    ]
+                },
+                {   
+                    name: "Procedures", 
+                    itemsFunction: this.getItemListForProcedures 
+                },
+                {   
+                    name: "Pathology Results (Initial Diagnosis)",
+                    items:  [   
+                        { 
+                            name: "Color", 
+                            value: null 
+                        },
+                        { 
+                            name: "Weight", 
+                            value: null },
+                        { 
+                            name: "Size", 
+                            value: (patient, currentConditionEntry) => { 
+                                let list = patient.getObservationsForCondition(currentConditionEntry, "http://standardhealthrecord.org/oncology/TumorSize"); 
+                                return list[0].value.value + " " + list[0].value.units.value; 
+                            }
+                        },
+                        { 
+                            name: "Tumor Margins", 
+                            value: null 
+                        },
+                        { 
+                            name: "Histological Grade", 
+                            value: (patient, currentConditionEntry) => { 
+                                return currentConditionEntry.breastCancerHistologicGrade.coding.displayText; 
+                            }
+                        },
+                        { 
+                            name: "Receptor Status ER", 
+                            value: (patient, currentConditionEntry) => { 
+                                let er = patient.getReceptorStatus(currentConditionEntry, "23307004"); 
+                                if (Lang.isNull(er)) { 
+                                    return null; 
+                                } else { 
+                                    return er.value.coding.displayText; 
+                                }
+                            }
+                        },
+                        { 
+                            name: "Receptor Status PR", 
+                            value: (patient, currentConditionEntry) => { 
+                                let pr = patient.getReceptorStatus(currentConditionEntry, "C0034833"); 
+                                if (Lang.isNull(pr)) { 
+                                    return null; 
+                                } else { 
+                                    return pr.value.coding.displayText; 
+                                }
+                            }
+                        },
+                        { 
+                            name: "Receptor Status HER2", 
+                            value: (patient, currentConditionEntry) => { 
+                                let her2 = patient.getReceptorStatus(currentConditionEntry, "C0069515"); 
+                                if (Lang.isNull(her2)) { 
+                                    return null;
+                                } else { 
+                                    return her2.value.coding.displayText; 
+                                }
+                            }
+                        }
+                    ]
+                }, 
+                {   
+                    name: "Genetics",
+                    items:  [  
+                        { 
+                            name: "Oncotype DX Recurrence Score", 
+                            value: null
+                        },
+                        { 
+                            name: "Genetic Testing", 
+                            value: null 
+                        }
+                    ]
+                }
+            ]
+        },
+        "default": { 
+            sections: [   
+                {   
+                    name: "Current Diagnosis",
+                    items:  [   
+                        { 
+                            name: "Name", 
+                            value: (patient, currentConditionEntry) => { 
+                                return currentConditionEntry.specificType.coding.displayText; 
+                            }
+                        }
+                    ]
+                },
+                {   
+                    name: "Key Dates",
+                    items:  [
+                        { 
+                            name: "Diagnosis", 
+                            value: (patient, currentConditionEntry) => { 
+                                return currentConditionEntry.whenClinicallyRecognized 
+                            }
+                        }
+                    ]
+                },
+                {   
+                    name: "Procedures", 
+                    itemsFunction: this.getItemListForProcedures 
+                },
+            ]
+        }
+    };
+    constructor() {
+        this.metadata = this.hardCodedMetadata;
+    }
+    
+    getMetadata() {
+        return this.metadata;
+    }
 
-	getItemListForProcedures(patient, currentConditionEntry) {
-		let procedures = patient.getProceduresForConditionChronologicalOrder(currentConditionEntry);
-		return procedures.map((p, i) => {
-			if (Lang.isObject(p.occurrenceTime)) {
-				return {name: p.specificType.coding.displayText, value: p.occurrenceTime.timePeriodStart + " to " + p.occurrenceTime.timePeriodEnd};
-			} else {
-				return {name: p.specificType.coding.displayText, value: p.occurrenceTime };
-			}
-		});
-	}
+    getItemListForProcedures(patient, currentConditionEntry) {
+        const procedures = patient.getProceduresForConditionChronologicalOrder(currentConditionEntry);
+        return procedures.map((p, i) => {
+            if (Lang.isObject(p.occurrenceTime)) {
+                return {name: p.specificType.coding.displayText, value: p.occurrenceTime.timePeriodStart + " to " + p.occurrenceTime.timePeriodEnd};
+            } else {
+                return {name: p.specificType.coding.displayText, value: p.occurrenceTime };
+            }
+        });
+    }
 }
 
 export default SummaryMetadata;


### PR DESCRIPTION
Minor styling changes that don't over-write any explicit changes made in the switch to a context-driven approach. Changes include: 
- Fixes avatar sizing and positioning that were lost in the move to material-1.
- Centers data-summary panel tabs, which was lost in the move to material-1.
- Aligned metadata file to meet new style guidelines. 