### PR TITLE
Lookup now defines all grades as invalid for an empty AE

### DIFF
--- a/src/lib/toxicity_lookup.jsx
+++ b/src/lib/toxicity_lookup.jsx
@@ -8800,7 +8800,7 @@ exports.isValidGradeForAdverseEvent = (possibleGrade, possibleAdverseEvent) => {
         return false;
     } else if (Lang.isUndefined(possibleAdverseEvent) || Lang.isNull(possibleAdverseEvent)) { 
         // Any grade is valid when there is no event
-        return true;
+        return false;
     }
 
     // If they are both


### PR DESCRIPTION
Simple fix for removing grade value from toxicity when the adverse event is deleted. Original bug could be triggered in no patient mode by doing the following: 
1. Select adverse event; 
2. Select grade; 
3. Delete AE;

Bug: All grade buttons are disabled, but a grade is still selected on the back-end and can be copied into the users clipboard. This bug should no longer be the case. 
