### PR TITLE
added stage keyword to stageInserter determineText

### DIFF
--- a/src/shortcuts/StageInserter.jsx
+++ b/src/shortcuts/StageInserter.jsx
@@ -4,7 +4,7 @@ export default class StageInserter extends InserterShortcut {
 	determineText(contextManager) {		
 		this.parentContext = contextManager.getActiveContextOfType("#staging");
 		let staging = this.parentContext.getValueObject();
-		return staging.value.coding.displayText;
+		return `stage ${staging.value.coding.displayText}`;
 	}
 	
 	validateInCurrentContext(contextManager) {


### PR DESCRIPTION
PR is pretty simple. Changes the insertion for @stage from '{value}' to 'stage {value}'. If we don't like that direction we can kill the PR, but I thought I'd knock this out since it was feedback directly from Dr. Fairweather. 