### PR TITLE
Fix loss of focus after text-driven insertion of text 

### DIFF
--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -132,13 +132,13 @@ class FluxNotesEditor extends React.Component {
     
     choseSuggestedShortcut(suggestion) {
         const { state } = this.state; 
-        let shortcut = this.props.newCurrentShortcut(suggestion.value);
+        const shortcut = this.props.newCurrentShortcut(suggestion.value);
         
         if (!Lang.isNull(shortcut) && shortcut.needToSelectValueFromMultipleOptions()) {
             return this.openPortalToSelectValueForShortcut(shortcut, true, state.transform()).apply();
         } else {
-            let transformBeforeInsert = this.suggestionDeleteExistingTransform(state.transform(), shortcut.getPrefixCharacter());
-            let transformAfterInsert = this.insertStructuredFieldTransform(transformBeforeInsert, shortcut).focus();
+            const transformBeforeInsert = this.suggestionDeleteExistingTransform(state.transform(), shortcut.getPrefixCharacter());
+            const transformAfterInsert = this.insertStructuredFieldTransform(transformBeforeInsert, shortcut).collapseToStartOfNextText().focus();
             return transformAfterInsert.apply();
         }
     }


### PR DESCRIPTION
Inserting text using dropdown-driven suggestions and the enter key now puts focus back into the editor. Issue was with the slate Selection being incompatible with the newly inserted text. Using collapseToStartOfNextText we can move our Selection to the end of the structuredField block and onto a new text block.