### PR TITLE
Spacing between selections and fixed copy button text

### DIFF
--- a/src/forms/ProgressionForm.jsx
+++ b/src/forms/ProgressionForm.jsx
@@ -99,7 +99,7 @@ class ProgressionForm extends Component {
                 </p>
                 <Divider className="divider"/>
 
-                <h4>Status of progression</h4>
+                <h4 className="header-spacing">Status of progression</h4>
                 <p id="data-element-description">
                     {progressionLookup.getDescription("status")}
                     <span className="helper-text"> Choose one</span>
@@ -135,7 +135,7 @@ class ProgressionForm extends Component {
                     })}
                 </div>
 
-                <h4>Rationale for status</h4>
+                <h4 className="header-spacing">Rationale for status</h4>
                 <p id="data-element-description">
                     {progressionLookup.getDescription("reason")}
                     <span className="helper-text"> Choose one or more</span>

--- a/src/forms/ToxicityForm.css
+++ b/src/forms/ToxicityForm.css
@@ -211,3 +211,4 @@
 .helper-text {
     color: #b1b1b1;
 }
+

--- a/src/forms/ToxicityForm.jsx
+++ b/src/forms/ToxicityForm.jsx
@@ -57,7 +57,7 @@ class ToxicityForm extends Component {
     /* 
      * When a valid grade is selected, update potential toxicity 
      */
-    handleGradeSelecion = (e, grade, isSelected) => {
+    handleGradeSelection = (e, grade, isSelected) => {
         e.preventDefault();
         if (isSelected) {
             this.props.updateValue("grade", null);
@@ -193,7 +193,7 @@ class ToxicityForm extends Component {
                 // onHover
                 onClick={(e) => {
                     if (!isDisabled) {
-                        return this.handleGradeSelecion(e, grade.name, isSelected)
+                        return this.handleGradeSelection(e, grade.name, isSelected)
                     }
                 }}
             >
@@ -223,7 +223,7 @@ class ToxicityForm extends Component {
                 </p>
                 <Divider className="divider"/>
 
-                <h4>Adverse Event</h4>
+                <h4 className="header-spacing">Adverse Event</h4>
                 <p id="data-element-description">
                     {toxicityLookup.getDescription("adverseEvent")}
                 </p>
@@ -238,7 +238,7 @@ class ToxicityForm extends Component {
                     inputProps={inputProps}
                 />
 
-                <h4>Grade</h4>
+                <h4 className="header-spacing">Grade</h4>
                 <p id="data-element-description">
                     {toxicityLookup.getDescription("grade")}
                     <span className="helper-text"> Choose one</span>
@@ -253,7 +253,7 @@ class ToxicityForm extends Component {
                     })}
                 </div>
                 
-                <h4>Attribution</h4>
+                <h4 className="header-spacing">Attribution</h4>
                 <p id="data-element-description">
                     {toxicityLookup.getDescription("attribution")}
                     <span className="helper-text"> Choose one</span>

--- a/src/viewer/ShortcutViewer.jsx
+++ b/src/viewer/ShortcutViewer.jsx
@@ -44,7 +44,7 @@ class ShortcutViewer extends Component {
                             {string}
                         </div>
                     </Button>
-                    <span className="helper-text">Copy text and paste it into your EHR</span>
+                    <span className="helper-text">When finished selecting values, click on the copy button above and then paste into a note within your EHR</span>
                 </div>
             </CopyToClipboard>
         );

--- a/src/viewer/ShortcutViewer.jsx
+++ b/src/viewer/ShortcutViewer.jsx
@@ -44,7 +44,7 @@ class ShortcutViewer extends Component {
                             {string}
                         </div>
                     </Button>
-                    <span className="helper-text">Click copy button to copy string</span>
+                    <span className="helper-text">Copy text and paste it into your EHR</span>
                 </div>
             </CopyToClipboard>
         );

--- a/src/views/SlimApp.css
+++ b/src/views/SlimApp.css
@@ -52,3 +52,7 @@
 .SlimApp-content .no-padding { 
     padding: 0!important;
 }
+
+.header-spacing {
+    margin-top: 80px !important;
+}


### PR DESCRIPTION
- Added spacing between selections on the toxicity and progression panels for lite mode (spacing on the landing page is being handled as a part of jira issue 

- Edited helper text for copy button