### PR TITLE
Made copy button a fixed at the bottom of the page so that it doesn't scroll

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2,9 +2,9 @@ body {
   margin: 0;
   padding: 0;
   height:100%;
-
   font-family: 'Roboto', sans-serif;
 }
+
 ::-webkit-scrollbar {
     width: 12px;
     height: 12px;

--- a/src/viewer/ShortcutViewer.css
+++ b/src/viewer/ShortcutViewer.css
@@ -2,8 +2,8 @@
 #shortcut-viewer {
     background: white;
 
-    /* 64 fo navbar; 60px for top/bottom padding */
-    height: calc(100vh - 64px - 60px);
+    /* 64 fo navbar; 60px for top/bottom padding; 104px for copy button */
+    height: calc(100vh - 64px - 60px - 104px);
     text-align: left;
     z-index: 2;
     padding: 30px 60px;

--- a/src/viewer/ShortcutViewer.css
+++ b/src/viewer/ShortcutViewer.css
@@ -19,21 +19,22 @@
 
 #copy-component {
     position: fixed;
-    bottom: 10px;
+    bottom: 0px;
+    left: 25vw;
+    width: calc(75vw - 12px);
     background-color: #ffffff;
     border-top: 1px solid #d9d9d9 !important;
     text-align: left;
-    -webkit-box-shadow: 0px -4px 3px rgba(125,125,125,0.7);
-    -moz-box-shadow:    0px -4px 3px rgba(125,125,125,0.7);
-    box-shadow:         0px -4px 3px rgba(125,125,125,0.7);
+    -webkit-box-shadow: 0px -2px 3px rgba(125,125,125,0.7);
+    -moz-box-shadow:    0px -2px 3px rgba(125,125,125,0.7);
+    box-shadow:         0px -2px 3px rgba(125,125,125,0.7);
 }
 
 .btn_copy {
     display: inline-block;
     min-width: 96% !important;
-    margin-top:  20px;
-    margin-bottom: 20px;
-    margin-left: 20px;
+    margin: 20px 32px 20px 20px;
+    max-width: 50px;
     justify-content: flex-start !important;
 }
 
@@ -62,5 +63,5 @@
 .helper-text {
     color: #b1b1b1;
     display:inline-block;
-    text-indent: 20px;
+    padding: 0 20px 10px 20px;
 }

--- a/src/viewer/ShortcutViewer.css
+++ b/src/viewer/ShortcutViewer.css
@@ -22,7 +22,6 @@
     bottom: 10px;
     background-color: #ffffff;
     border-top: 1px solid #d9d9d9 !important;
-    width: 98%;
     text-align: left;
     -webkit-box-shadow: 0px -4px 3px rgba(125,125,125,0.7);
     -moz-box-shadow:    0px -4px 3px rgba(125,125,125,0.7);
@@ -31,6 +30,7 @@
 
 .btn_copy {
     display: inline-block;
+    min-width: 96% !important;
     margin-top:  20px;
     margin-bottom: 20px;
     margin-left: 20px;

--- a/src/viewer/ShortcutViewer.css
+++ b/src/viewer/ShortcutViewer.css
@@ -13,10 +13,27 @@
     overflow-y: scroll;
 }
 
+#panel-content {
+    margin-bottom: 130px;
+}
+
+#copy-component {
+    position: fixed;
+    bottom: 10px;
+    background-color: #ffffff;
+    border-top: 1px solid #d9d9d9 !important;
+    width: 98%;
+    text-align: left;
+    -webkit-box-shadow: 0px -4px 3px rgba(125,125,125,0.7);
+    -moz-box-shadow:    0px -4px 3px rgba(125,125,125,0.7);
+    box-shadow:         0px -4px 3px rgba(125,125,125,0.7);
+}
+
 .btn_copy {
     display: inline-block;
-    margin-top:  60px;
-    margin-bottom: 10px;
+    margin-top:  20px;
+    margin-bottom: 20px;
+    margin-left: 20px;
     justify-content: flex-start !important;
 }
 
@@ -44,4 +61,6 @@
 
 .helper-text {
     color: #b1b1b1;
+    display:inline-block;
+    text-indent: 20px;
 }

--- a/src/viewer/ShortcutViewer.css
+++ b/src/viewer/ShortcutViewer.css
@@ -2,8 +2,8 @@
 #shortcut-viewer {
     background: white;
 
-    /* 64 fo navbar; 60px for top/bottom padding; 104px for copy button */
-    height: calc(100vh - 64px - 60px - 104px);
+    /* 64 fo navbar; 60px for top/bottom padding */
+    height: calc(100vh - 64px - 60px);
     text-align: left;
     z-index: 2;
     padding: 30px 60px;

--- a/src/viewer/ShortcutViewer.jsx
+++ b/src/viewer/ShortcutViewer.jsx
@@ -26,16 +26,16 @@ class ShortcutViewer extends Component {
     _getCopyComponent(string) {
         return (
             <CopyToClipboard text={string}>
-                <div>
+                <div id="copy-component">
                     <Button raised className="btn_copy"
-                        style={{
-                            textTransform: "none",
-                            justifyContent: 'left',
-                            minWidth: "99.8%",
-                            height: "45px",
-                            padding: "5px 0 4px 0",
-                            backgroundColor: "white"
-                        }}
+                            style={{
+                                textTransform: "none",
+                                justifyContent: 'left',
+                                minWidth: "99.8%",
+                                height: "45px",
+                                padding: "5px 0 4px 0",
+                                backgroundColor: "white"
+                            }}
                     >
                         <div id="copy-keyword">
                             Copy
@@ -65,23 +65,24 @@ class ShortcutViewer extends Component {
         if (!Lang.isNull(this.props.currentShortcut)) {
             //panelContent = this.props.currentShortcut.getForm();
             const formSpec = this.props.currentShortcut.getFormSpec();
-/* eslint-disable no-eval */            
+            /* eslint-disable no-eval */
             panelContent = React.createElement(eval("forms." + formSpec.tagName), formSpec.props, formSpec.children);
-/* eslint-enable no-eval */            
+            /* eslint-enable no-eval */
         } else {
             panelContent = this._getInitialState();
         }
 
         return (
-            <div id="shortcut-viewer">
-                {panelContent}
-                <br/>
-                {copyComponent}
+            <div>
+                <div id="shortcut-viewer">
+                    <div id="panel-content">
+                        {panelContent}
+                    </div>
+                </div>
+                    {copyComponent}
             </div>
         )
     }
-
-
 }
 
 export default ShortcutViewer;

--- a/src/viewer/ShortcutViewer.jsx
+++ b/src/viewer/ShortcutViewer.jsx
@@ -78,8 +78,9 @@ class ShortcutViewer extends Component {
                     <div id="panel-content">
                         {panelContent}
                     </div>
-                </div>
                     {copyComponent}
+                </div>
+
             </div>
         )
     }

--- a/src/views/SlimApp.css
+++ b/src/views/SlimApp.css
@@ -41,11 +41,13 @@
 
 .SlimApp-content ::-webkit-scrollbar-track {
     -webkit-box-shadow: inset 0 0 1px rgba(0,0,0,0);
-    border-radius: 10px;
+    background-color: #F3F3F3;
+    border-radius: 5px;
 }
 
 .SlimApp-content ::-webkit-scrollbar-thumb {
     border-radius: 10px;
+    background-color: #FFF;
     -webkit-box-shadow: inset 0 0 5px rgba(0,0,0,0.5);
 }
 


### PR DESCRIPTION
Tested this on both chrome and IE. Please make sure to test on both browsers when checking this pull request.

Note: css `position: sticky` would have easily solved this jira issue but it is not supported by IE so ended up having to do some styling with css and `position: fixed`. 

Changes made:
- Fixed the position of the copy button component
- Added background color and shadow border to div containing copy button component
- Added extra margin bottom to the panel content component so that it doesn't get overlapped by the copy button component