### PR TITLE
Progression date assessed

### DIFF
--- a/src/patient/Patient.jsx
+++ b/src/patient/Patient.jsx
@@ -853,6 +853,10 @@ class Patient {
         });
         progression.evidence = reasonObjects;
     }
+    
+    static updateDateForProgression(progression, date) {
+        progression.clinicallyRelevantTime = date;
+    }
 
     static _progressionStatusToCodeableConcept(status) {
         if (status.toLowerCase() === 'complete response') return { value: "C0677874", codeSystem: "http://ncimeta.nci.nih.gov", displayText: "Complete Response"};

--- a/src/patient/Patient.jsx
+++ b/src/patient/Patient.jsx
@@ -854,7 +854,7 @@ class Patient {
         progression.evidence = reasonObjects;
     }
     
-    static updateDateForProgression(progression, date) {
+    static updateAsOfDateForProgression(progression, date) {
         progression.clinicallyRelevantTime = date;
     }
 

--- a/src/shortcuts/DateCreator.jsx
+++ b/src/shortcuts/DateCreator.jsx
@@ -1,7 +1,7 @@
 import moment from 'moment';
 import CreatorShortcut from './CreatorShortcut';
 
-export default class ProgressionDateCreator extends CreatorShortcut {
+export default class DateCreator extends CreatorShortcut {
     constructor(onUpdate, obj) {
         super();
     }

--- a/src/shortcuts/DateCreator.jsx
+++ b/src/shortcuts/DateCreator.jsx
@@ -11,14 +11,14 @@ export default class DateCreator extends CreatorShortcut {
         this.text = trigger;
         let dateString = trigger.substring(1);
         this.parentContext = contextManager.getActiveContextOfType("#progression");
-        this.parentContext.setAttributeValue("date", dateString, false);
+        this.parentContext.setAttributeValue("asOfDate", dateString, false);
         this.parentContext.addChild(this);
     }
     
     onBeforeDeleted() {
         let result = super.onBeforeDeleted();
         if(result) {
-            this.parentContext.setAttributeValue("date", "", false);
+            this.parentContext.setAttributeValue("asOfDate", "", false);
             this.parentContext.removeChild(this);
         }
         return result;
@@ -29,27 +29,23 @@ export default class DateCreator extends CreatorShortcut {
     }
     
     getShortcutType() {
-        return "#progression-date";
+        return "#date";
     }
     
     validateInCurrentContext(contextManager) {
         let errors = [];
-        if(!contextManager.isContextOfTypeActive("#progression")) {
-            errors.push("Progression Date values invalid without #progression. Use #progression to add a new progression to your narrative.");
-            return errors;
-        }
         return errors;
     }
     
     static getTriggers() {
         const today = new moment().format("D MMM YYYY");
         // TODO: name will need to be a regular expression of date format instead of just today's date
-        let result = [{name: `#${today}`, description: "Today's date."}];
+        let result = [{name: `#${today}`, description: "A date."}];
         return result;
     }
     
     static getDescription() {
-        return "Today's date.";
+        return "A date.";
     }
     
     static getShortcutGroupName() {

--- a/src/shortcuts/ProgressionCreator.jsx
+++ b/src/shortcuts/ProgressionCreator.jsx
@@ -3,7 +3,7 @@ import CreatorShortcut from './CreatorShortcut';
 //import ProgressionForm from '../forms/ProgressionForm';
 import ProgressionStatusCreator from './ProgressionStatusCreator';
 import ProgressionReasonsCreator from './ProgressionReasonsCreator';
-import ProgressionDateCreator from './ProgressionDateCreator';
+import DateCreator from './DateCreator';
 import lookup from '../lib/progression_lookup';
 import Patient from '../patient/Patient';
 import Lang from 'lodash'
@@ -194,8 +194,8 @@ class ProgressionCreator extends CreatorShortcut {
 		let result = [];
 		if (this.getAttributeValue("status").length === 0) result.push(ProgressionStatusCreator);
 		if (this.getAttributeValue("reasons").length < lookup.getReasonOptions().length) result.push(ProgressionReasonsCreator);
-        result.push(ProgressionDateCreator); // TODO: This will be changed with the RelevantDate shortcut
-		return result; //[ ProgressionStatusCreator, ProgressionReasonsCreator, ProgressionDateCreator ];
+        result.push(DateCreator); // TODO: This will be changed with the RelevantDate shortcut
+		return result; //[ ProgressionStatusCreator, ProgressionReasonsCreator, DateCreator ];
 	}
 	
 	isContext() {

--- a/src/shortcuts/ProgressionCreator.jsx
+++ b/src/shortcuts/ProgressionCreator.jsx
@@ -135,8 +135,8 @@ class ProgressionCreator extends CreatorShortcut {
 			Patient.updateStatusForProgression(this.progression, value);
 		} else if (name === "reasons") {
 			Patient.updateReasonsForProgression(this.progression, value);
-		} else if (name === "date") {
-            Patient.updateDateForProgression(this.progression, value);
+		} else if (name === "asOfDate") {
+            Patient.updateAsOfDateForProgression(this.progression, value);
         } else {
 			console.error("Error: Unexpected value selected for progression: " + name);
 			return;
@@ -154,7 +154,7 @@ class ProgressionCreator extends CreatorShortcut {
             return this.progression.evidence.map((e) => {
                 return e.coding.displayText;
             });
-		} else if (name === "date") {
+		} else if (name === "asOfDate") {
             return this.progression.clinicallyRelevantTime;
         } else {
 			console.error("Error: Unexpected value requested for progression: " + name);
@@ -187,7 +187,7 @@ class ProgressionCreator extends CreatorShortcut {
     shouldBeInContext() {
         return  (this.getAttributeValue("status").length === 0) ||
                 (this.getAttributeValue("reasons").length < lookup.getReasonOptions().length) ||
-                (this.getAttributeValue("date").length === 0); // TODO: This will be changed with RelevantDate shortcut
+                (this.getAttributeValue("asOfDate").length === 0); // TODO: This will be changed with RelevantDate shortcut
     }
     
 	getValidChildShortcuts() {

--- a/src/shortcuts/ProgressionCreator.jsx
+++ b/src/shortcuts/ProgressionCreator.jsx
@@ -3,10 +3,10 @@ import CreatorShortcut from './CreatorShortcut';
 //import ProgressionForm from '../forms/ProgressionForm';
 import ProgressionStatusCreator from './ProgressionStatusCreator';
 import ProgressionReasonsCreator from './ProgressionReasonsCreator';
+import ProgressionDateCreator from './ProgressionDateCreator';
 import lookup from '../lib/progression_lookup';
 import Patient from '../patient/Patient';
 import Lang from 'lodash'
-import moment from 'moment';
 
 
 class ProgressionCreator extends CreatorShortcut {
@@ -76,10 +76,9 @@ class ProgressionCreator extends CreatorShortcut {
     }
 
     getDateString(curProgression) { 
-        const today = moment(new Date());
         let dateString;
         if (!Lang.isUndefined(curProgression.clinicallyRelevantTime)) {
-            dateString = (curProgression.clinicallyRelevantTime === today.format("D MMM YYYY")) ? `` : ` as of ${this.progression.clinicallyRelevantTime}`;
+            dateString = ` #as of #${this.progression.clinicallyRelevantTime}`;
         } else {
             dateString = ``;
         }
@@ -136,7 +135,9 @@ class ProgressionCreator extends CreatorShortcut {
 			Patient.updateStatusForProgression(this.progression, value);
 		} else if (name === "reasons") {
 			Patient.updateReasonsForProgression(this.progression, value);
-		} else {
+		} else if (name === "date") {
+            Patient.updateDateForProgression(this.progression, value);
+        } else {
 			console.error("Error: Unexpected value selected for progression: " + name);
 			return;
 		}
@@ -153,7 +154,9 @@ class ProgressionCreator extends CreatorShortcut {
             return this.progression.evidence.map((e) => {
                 return e.coding.displayText;
             });
-		} else {
+		} else if (name === "date") {
+            return this.progression.clinicallyRelevantTime;
+        } else {
 			console.error("Error: Unexpected value requested for progression: " + name);
 			return null;
 		}
@@ -183,14 +186,16 @@ class ProgressionCreator extends CreatorShortcut {
     
     shouldBeInContext() {
         return  (this.getAttributeValue("status").length === 0) ||
-                (this.getAttributeValue("reasons").length < lookup.getReasonOptions().length);
+                (this.getAttributeValue("reasons").length < lookup.getReasonOptions().length) ||
+                (this.getAttributeValue("date").length === 0); // TODO: This will be changed with RelevantDate shortcut
     }
     
 	getValidChildShortcuts() {
 		let result = [];
 		if (this.getAttributeValue("status").length === 0) result.push(ProgressionStatusCreator);
 		if (this.getAttributeValue("reasons").length < lookup.getReasonOptions().length) result.push(ProgressionReasonsCreator);
-		return result; //[ ProgressionStatusCreator, ProgressionReasonsCreator ];
+        result.push(ProgressionDateCreator); // TODO: This will be changed with the RelevantDate shortcut
+		return result; //[ ProgressionStatusCreator, ProgressionReasonsCreator, ProgressionDateCreator ];
 	}
 	
 	isContext() {

--- a/src/shortcuts/ProgressionDateCreator.jsx
+++ b/src/shortcuts/ProgressionDateCreator.jsx
@@ -1,0 +1,59 @@
+import moment from 'moment';
+import CreatorShortcut from './CreatorShortcut';
+
+export default class ProgressionDateCreator extends CreatorShortcut {
+    constructor(onUpdate, obj) {
+        super();
+    }
+    
+    initialize(contextManager, trigger) {
+        super.initialize(contextManager, trigger);
+        this.text = trigger;
+        let dateString = trigger.substring(1);
+        this.parentContext = contextManager.getActiveContextOfType("#progression");
+        this.parentContext.setAttributeValue("date", dateString, false);
+        this.parentContext.addChild(this);
+    }
+    
+    onBeforeDeleted() {
+        let result = super.onBeforeDeleted();
+        if(result) {
+            this.parentContext.setAttributeValue("date", "", false);
+            this.parentContext.removeChild(this);
+        }
+        return result;
+    }
+    
+    getText() {
+        return this.text;
+    }
+    
+    getShortcutType() {
+        return "#progression-date";
+    }
+    
+    validateInCurrentContext(contextManager) {
+        let errors = [];
+        if(!contextManager.isContextOfTypeActive("#progression")) {
+            errors.push("Progression Date values invalid without #progression. Use #progression to add a new progression to your narrative.");
+            return errors;
+        }
+        return errors;
+    }
+    
+    static getTriggers() {
+        const today = new moment().format("D MMM YYYY");
+        // TODO: name will need to be a regular expression of date format instead of just today's date
+        let result = [{name: `#${today}`, description: "Today's date."}];
+        return result;
+    }
+    
+    static getDescription() {
+        return "Today's date.";
+    }
+    
+    static getShortcutGroupName() {
+        return "Date";
+    }
+    
+}

--- a/src/shortcuts/ShortcutManager.js
+++ b/src/shortcuts/ShortcutManager.js
@@ -14,7 +14,7 @@ import StagingNCreator from './StagingNCreator';
 import StagingMCreator from './StagingMCreator';
 import ProgressionStatusCreator from './ProgressionStatusCreator';
 import ProgressionReasonsCreator from './ProgressionReasonsCreator';
-import ProgressionDateCreator from './ProgressionDateCreator';
+import DateCreator from './DateCreator';
 import ToxicityAdverseEventCreator from './ToxicityAdverseEventCreator';
 import ToxicityGradeCreator from './ToxicityGradeCreator';
 import ToxicityAttributionCreator from './ToxicityAttributionCreator';
@@ -28,12 +28,12 @@ class ShortcutManager {
         '#progression': ProgressionCreator,
         '#progression-status': ProgressionStatusCreator,
         '#progression-reasons': ProgressionReasonsCreator,
-        '#progression-date': ProgressionDateCreator,
         '#staging': StagingCreator,
         '#toxicity': ToxicityCreator,
         '#toxicity-adverse-event': ToxicityAdverseEventCreator,
         '#toxicity-grade': ToxicityGradeCreator,
         '#toxicity-attribution': ToxicityAttributionCreator,
+        '#date': DateCreator,
         '@condition': ConditionInserter,
         '@name': NameInserter,
         '@age': AgeInserter,

--- a/src/shortcuts/ShortcutManager.js
+++ b/src/shortcuts/ShortcutManager.js
@@ -14,6 +14,7 @@ import StagingNCreator from './StagingNCreator';
 import StagingMCreator from './StagingMCreator';
 import ProgressionStatusCreator from './ProgressionStatusCreator';
 import ProgressionReasonsCreator from './ProgressionReasonsCreator';
+import ProgressionDateCreator from './ProgressionDateCreator';
 import ToxicityAdverseEventCreator from './ToxicityAdverseEventCreator';
 import ToxicityGradeCreator from './ToxicityGradeCreator';
 import ToxicityAttributionCreator from './ToxicityAttributionCreator';
@@ -27,6 +28,7 @@ class ShortcutManager {
         '#progression': ProgressionCreator,
         '#progression-status': ProgressionStatusCreator,
         '#progression-reasons': ProgressionReasonsCreator,
+        '#progression-date': ProgressionDateCreator,
         '#staging': StagingCreator,
         '#toxicity': ToxicityCreator,
         '#toxicity-adverse-event': ToxicityAdverseEventCreator,


### PR DESCRIPTION
The goal of this pull request is to add the "#as of #13 Sep 2017" string automatically to the copy line in slim mode. There is no way to adjust the as of date. The "#as of" shortcut is not created yet either. Although it does have some functionality in full mode, the goal of this task is not to have that fully functioning yet, so not everything that will be needed there is implemented.