### PR TITLE
Reference date on progression slim

### DIFF
--- a/src/forms/ProgressionForm.css
+++ b/src/forms/ProgressionForm.css
@@ -65,3 +65,7 @@
 .helper-text {
     color: #b1b1b1;
 }
+
+.MuiInput-inkbar-113:after{
+    background-color: #297DA2 !important;
+}

--- a/src/forms/ProgressionForm.jsx
+++ b/src/forms/ProgressionForm.jsx
@@ -173,7 +173,6 @@ class ProgressionForm extends Component {
                     id="reference-date"
                     type="date"
                     defaultValue={today}
-                    // format='dd-mmm-yyyy'
                     onChange={this.handleDateSelection}
                 />
             </div>

--- a/src/forms/ProgressionForm.jsx
+++ b/src/forms/ProgressionForm.jsx
@@ -1,8 +1,11 @@
 import React, {Component} from 'react';
 import Divider from 'material-ui/Divider';
 import Button from 'material-ui/Button';
+import TextField from 'material-ui/TextField';
+import moment from 'moment';
 import progressionLookup from '../lib/progression_lookup';
 import './ProgressionForm.css';
+
 
 class ProgressionForm extends Component {
     constructor(props) {
@@ -61,6 +64,12 @@ class ProgressionForm extends Component {
             }
         }
     }
+    
+    handleDateSelection = (event) => {
+        const date = event.target.value;
+        const formattedDate = new moment(date).format('D MMM YYYY');
+        this.props.updateValue("referenceDate", formattedDate);
+    }
 
     renderReasonButtonGroup = (reason, i) => {
 
@@ -91,6 +100,7 @@ class ProgressionForm extends Component {
     }
 
     render() {
+        const today = new moment().format('YYYY-MM-DD');
         return (
             <div>
                 <h1>Disease Status</h1>
@@ -153,6 +163,19 @@ class ProgressionForm extends Component {
                         return this.renderReasonButtonGroup(reason, i)
                     })}
                 </div>
+                
+                <h4 className="header-spacing">Reference Date</h4>
+                <p id="data-element-description">
+                    {progressionLookup.getDescription("referenceDate")}
+                    <span className="helper-text"> mm/dd/yyyy</span>
+                </p>
+                <TextField
+                    id="reference-date"
+                    type="date"
+                    defaultValue={today}
+                    // format='dd-mmm-yyyy'
+                    onChange={this.handleDateSelection}
+                />
             </div>
         );
     }

--- a/src/lib/progression_lookup.jsx
+++ b/src/lib/progression_lookup.jsx
@@ -23,6 +23,8 @@ exports.getDescription = (dataElement) => {
       return "Based on on the patient data available to the clinician at the time of evaluation.";
    case "reason": 
       return "Rationale for the choice of status."
+   case "referenceDate":
+      return "The date of the event that disease status is being assessed relative to."
    default: 
       return `Asking for a description for ${dataElement}; one has not been defined.`
    }

--- a/src/patient/Patient.jsx
+++ b/src/patient/Patient.jsx
@@ -855,6 +855,12 @@ class Patient {
     }
     
     static updateAsOfDateForProgression(progression, date) {
+        // TODO: Check with Mark about what this should set
+        progression.originalCreationDate = date;
+    }
+    
+    static updateReferenceDateForProgression(progression, date) {
+        // TODO: Check with Mark about what this should set
         progression.clinicallyRelevantTime = date;
     }
 

--- a/src/shortcuts/ProgressionCreator.jsx
+++ b/src/shortcuts/ProgressionCreator.jsx
@@ -24,6 +24,7 @@ class ProgressionCreator extends CreatorShortcut {
 		this.setValueObject(this.progression);
         this.onUpdate = onUpdate;
 		this.setAttributeValue = this.setAttributeValue.bind(this);
+        this.state = { resetReferenceDate: false }
     }
 
     initialize(contextManager, trigger) {
@@ -77,36 +78,58 @@ class ProgressionCreator extends CreatorShortcut {
 
     getDateString(curProgression) { 
         let dateString;
-        if (!Lang.isUndefined(curProgression.clinicallyRelevantTime)) {
-            dateString = ` #as of #${this.progression.clinicallyRelevantTime}`;
+        // TODO: Check with Mark about these dates
+        if (!Lang.isUndefined(curProgression.originalCreationDate)) {
+            dateString = ` #as of #${this.progression.originalCreationDate}`;
         } else {
             dateString = ``;
         }
         return dateString
     }
     
+    getReferenceDateString(curProgression) {
+        let dateString;
+        if(!Lang.isUndefined(curProgression.clinicallyRelevantTime)) {
+            let formattedDate = this.formatDateToDDMMYYYY(curProgression.clinicallyRelevantTime);
+            dateString = ` relative to #reference date #${formattedDate}`;
+        } else {
+            dateString = ``;
+        }
+        return dateString;
+    }
+    
+    // This convert date format from D MMM YYYY to MM/DD/YYYY
+    // @param date is a string of a date in D MMM YYYY format
+    formatDateToDDMMYYYY(date) {
+        let reformattedDate = new Date(date);
+        let day = reformattedDate.getDate();
+        let month = reformattedDate.getMonth() + 1;
+        const year = reformattedDate.getFullYear();
+        if(day < 10) {
+            day = `0${day}`;
+        }
+        if(month < 10) {
+            month = `0${month}`;
+        }
+        reformattedDate = `${month}/${day}/${year}`;
+        return reformattedDate;
+    }
+    
     getAsString() { 
-        if(Lang.isUndefined(this.progression.value) || this.progression.value.coding.displayText.length === 0) { 
-            // 1. No status -- this case we just want a hash
-            if(Lang.isEmpty(this.progression.evidence)) { 
-                return `#disease status`;
-            } else {    
-                // No status but reasons -- show what we can and provide blank for status 
-                const statusString = this.getStatusString(this.progression);
-                let reasonString   = this.getReasonString(this.progression);
-                if (!Lang.isEmpty(reasonString)) {reasonString = ` ` + reasonString;}
-                let dateString     = this.getDateString(this.progression);
-                if (!Lang.isEmpty(dateString)) {dateString = ` ` + dateString;}
-                return `#disease status${statusString}${reasonString}${dateString}`;
-            } 
-        } else { 
+        if((Lang.isUndefined(this.progression.value) || this.progression.value.coding.displayText.length === 0)
+            && Lang.isEmpty(this.progression.evidence)
+            && !this.state.resetReferenceDate) {
+            // No value or status or updated reference date, return just the hash
+            return `#disease status`;
+        } else {
             const statusString = this.getStatusString(this.progression);
             let reasonString   = this.getReasonString(this.progression);
             if (!Lang.isEmpty(reasonString)) {reasonString = ` ` + reasonString;}
             let dateString     = this.getDateString(this.progression);
             if (!Lang.isEmpty(dateString)) {dateString = ` ` + dateString;}
+            let refDateString = this.getReferenceDateString(this.progression);
             // Don't put any spaces -- the spaces should be dictated by the current reason and date
-            return `#disease status${statusString}${reasonString}${dateString}`;
+            return `#disease status${statusString}${reasonString}${refDateString}${dateString}`;
         }
     }
     
@@ -137,6 +160,9 @@ class ProgressionCreator extends CreatorShortcut {
 			Patient.updateReasonsForProgression(this.progression, value);
 		} else if (name === "asOfDate") {
             Patient.updateAsOfDateForProgression(this.progression, value);
+        } else if (name === "referenceDate") {
+            this.state.resetReferenceDate = true;
+            Patient.updateReferenceDateForProgression(this.progression, value);
         } else {
 			console.error("Error: Unexpected value selected for progression: " + name);
 			return;
@@ -155,6 +181,9 @@ class ProgressionCreator extends CreatorShortcut {
                 return e.coding.displayText;
             });
 		} else if (name === "asOfDate") {
+            // TODO: Check with Mark on this
+            return this.progression.originalCreationDate;
+        } else if (name === "referenceDate") {
             return this.progression.clinicallyRelevantTime;
         } else {
 			console.error("Error: Unexpected value requested for progression: " + name);

--- a/src/shortcuts/ProgressionCreator.jsx
+++ b/src/shortcuts/ProgressionCreator.jsx
@@ -80,7 +80,8 @@ class ProgressionCreator extends CreatorShortcut {
         let dateString;
         // TODO: Check with Mark about these dates
         if (!Lang.isUndefined(curProgression.originalCreationDate)) {
-            dateString = ` #as of #${this.progression.originalCreationDate}`;
+            const formattedDate = this.formatDateToDDMMYYYY(curProgression.originalCreationDate);
+            dateString = ` #as of #${formattedDate}`;
         } else {
             dateString = ``;
         }
@@ -90,7 +91,7 @@ class ProgressionCreator extends CreatorShortcut {
     getReferenceDateString(curProgression) {
         let dateString;
         if(!Lang.isUndefined(curProgression.clinicallyRelevantTime)) {
-            let formattedDate = this.formatDateToDDMMYYYY(curProgression.clinicallyRelevantTime);
+            const formattedDate = this.formatDateToDDMMYYYY(curProgression.clinicallyRelevantTime);
             dateString = ` relative to #reference date #${formattedDate}`;
         } else {
             dateString = ``;


### PR DESCRIPTION
This adds a reference date onto the progression form in slim mode. It uses a date picker, which I wasn't able to change the date format of, so I adjusted the format of the date in the copy button for the reference date and the as of date. The date that is saved in the Patient model is still the old format (ex. 15 Sep 2017). I didn't create a #reference date shortcut either yet, since that is a separate task I believe.