### PR TITLE
[Slim Mode] Improve sm screen display

### DIFF
--- a/src/forms/ProgressionForm.jsx
+++ b/src/forms/ProgressionForm.jsx
@@ -71,6 +71,37 @@ class ProgressionForm extends Component {
         this.props.updateValue("referenceDate", formattedDate);
     }
 
+    renderStatusButtonGroup = (status, i) => { 
+        const marginSize = "10px";
+        const statusName = status.name;
+        const statusDescription = status.description;
+        const tooltipClass = (statusDescription.length > 100) ? "tooltiptext large" : "tooltiptext";
+
+        return (
+            <div key={statusName} className="tooltip">
+                <span id={statusName} className={tooltipClass}>{statusDescription}</span>
+                    <Button raised
+                    key={i}
+                    label={statusName}
+                    onClick={(e) => this.handleStatusSelection(e, i)}
+                    className="button_disabled_is_selected"
+                    style={{
+                        marginBottom: marginSize,
+                        marginLeft:   marginSize,
+                        height: "75px",
+                        width: "180px",
+                        padding: "20px 0 20px 0",
+                        backgroundColor: "white",
+                        textTransform: "none"
+                    }}
+                    disabled={this.currentlySelected(this.props.progression.value.coding.displayText, this.state.statusOptions[i].name)}
+                >{statusName}
+                </Button>
+            </div>
+        );
+    }
+
+
     renderReasonButtonGroup = (reason, i) => {
 
         let reasonName = reason.name;
@@ -120,35 +151,7 @@ class ProgressionForm extends Component {
 
                 <div className="btn-group-status-progression">
                     {this.state.statusOptions.map((status, i) => {
-                        let marginSize = "10px";
-                        if(i === 0){
-                            marginSize = "0px";
-                        }
-                        let statusName = status.name;
-                        let statusDescription = status.description;
-                        const tooltipClass = (statusDescription.length > 100) ? "tooltiptext large" : "tooltiptext";
-
-                        return (
-                            <div key={statusName} className="tooltip">
-                                <span id={statusName} className={tooltipClass}>{statusDescription}</span>
-                                    <Button raised
-                                    key={i}
-                                    label={statusName}
-                                    onClick={(e) => this.handleStatusSelection(e, i)}
-                                    className="button_disabled_is_selected"
-                                    style={{
-                                        margin: marginSize,
-                                        height: "75px",
-                                        width: "180px",
-                                        padding: "20px 0 20px 0",
-                                        backgroundColor: "white",
-                                        textTransform: "none"
-                                    }}
-                                    disabled={this.currentlySelected(this.props.progression.value.coding.displayText, this.state.statusOptions[i].name)}
-                                >{statusName}
-                                </Button>
-                            </div>
-                        );
+                        return this.renderStatusButtonGroup(status, i)
                     })}
                 </div>
 

--- a/src/forms/ToxicityForm.css
+++ b/src/forms/ToxicityForm.css
@@ -20,6 +20,7 @@
 
 .grade-menu-item .grade-menu-item-name { 
     margin: 0 0 0 20px;
+    min-width: 95px;
     display: inline-block;
 }
 
@@ -38,7 +39,7 @@
 .grade-menu-item .grade-menu-item-description { 
     margin: 0 20px 0 0;
     display: inline-block;
-    max-width: 80%;
+    max-width: 75%;
 }
 
 .grade-menu-item.selected { 

--- a/src/forms/ToxicityForm.css
+++ b/src/forms/ToxicityForm.css
@@ -61,12 +61,15 @@
 
 .adverse-event-suggestion .adverse-event-suggestion-name {
     margin: 0 0 0 0px;
+    font-size: 0.85rem;
+    word-wrap: break-word;
     width: 20%;
     display: inline-block;
 }
 
 .adverse-event-suggestion .adverse-event-suggestion-description {
     width: 70%;
+    font-size: 0.85rem;
     margin: 0 0px 0 0;
     display: inline-block;
 }

--- a/src/viewer/ShortcutViewer.css
+++ b/src/viewer/ShortcutViewer.css
@@ -32,7 +32,7 @@
 
 .btn_copy {
     display: inline-block;
-    min-width: 96% !important;
+    min-width: 90% !important;
     margin: 20px 32px 20px 20px;
     max-width: 50px;
     justify-content: flex-start !important;

--- a/src/viewer/ShortcutViewer.css
+++ b/src/viewer/ShortcutViewer.css
@@ -52,11 +52,13 @@
 
 #copy-keyword {
     margin: 0 0 0 20px;
+    min-width: 75px;
     display: inline-block;
 }
 
 #copy-content {
-    margin: 0 20px 0 0;
+    margin: 0px 20px 0px 0;
+    text-align: left;
     display: inline-block;
 }
 
@@ -64,4 +66,10 @@
     color: #b1b1b1;
     display:inline-block;
     padding: 0 20px 10px 20px;
+}
+
+@media (max-width:992px) {
+    #shortcut-viewer { 
+        padding: 30px 40px;
+    }
 }

--- a/src/viewer/ShortcutViewer.css
+++ b/src/viewer/ShortcutViewer.css
@@ -14,7 +14,7 @@
 }
 
 #panel-content {
-    margin-bottom: 130px;
+    margin-bottom: 170px;
 }
 
 #copy-component {

--- a/src/viewer/ShortcutViewer.css
+++ b/src/viewer/ShortcutViewer.css
@@ -57,12 +57,11 @@
 }
 
 #copy-content {
-    margin: 0px 20px 0px 0;
     text-align: left;
     display: inline-block;
 }
 
-.helper-text {
+.helper-text-multi-line {
     color: #b1b1b1;
     display:inline-block;
     padding: 0 20px 10px 20px;

--- a/src/viewer/ShortcutViewer.jsx
+++ b/src/viewer/ShortcutViewer.jsx
@@ -27,21 +27,25 @@ class ShortcutViewer extends Component {
         return (
             <CopyToClipboard text={string}>
                 <div id="copy-component">
-                    <Button raised className="btn_copy"
-                            style={{
-                                textTransform: "none",
-                                justifyContent: 'left',
-                                minWidth: "99.8%",
-                                height: "45px",
-                                padding: "5px 0 4px 0",
-                                backgroundColor: "white"
-                            }}
+                    <Button 
+                        raised 
+                        className="btn_copy"
+                        style={{
+                            textTransform: "none",
+                            justifyContent: 'left',
+                            minWidth: "99.8%",
+                            minHeight: "45px",
+                            padding: "5px 0 4px 0",
+                            backgroundColor: "white"
+                        }}
                     >
                         <div id="copy-keyword">
                             Copy
                         </div>
                         <div id="copy-content">
-                            {string}
+                            <p> 
+                                {string}
+                            </p>
                         </div>
                     </Button>
                     <span className="helper-text">When finished selecting values, click on the copy button above and then paste into a note within your EHR</span>
@@ -51,13 +55,12 @@ class ShortcutViewer extends Component {
     }
 
     render() {
-        let string = "";
         let copyComponent = null;
         let panelContent = null;
 
         // If there is a currentShortcut, use it in the copy component
         if (this.props.currentShortcut) {
-            string = this.props.currentShortcut.getAsString();
+            const string = this.props.currentShortcut.getAsString();
             copyComponent = this._getCopyComponent(string);
         }
 
@@ -65,14 +68,20 @@ class ShortcutViewer extends Component {
         if (!Lang.isNull(this.props.currentShortcut)) {
             //panelContent = this.props.currentShortcut.getForm();
             const formSpec = this.props.currentShortcut.getFormSpec();
+<<<<<<< HEAD
             /* eslint-disable no-eval */
             panelContent = React.createElement(eval("forms." + formSpec.tagName), formSpec.props, formSpec.children);
             /* eslint-enable no-eval */
+=======
+            const currentForm = forms[formSpec.tagName]
+            panelContent = React.createElement(currentForm, formSpec.props, formSpec.children);
+>>>>>>> dca23af... copy button handles text overflow, margins smaller, font smaller, tox-dropdown words now smaller and wrap
         } else {
             panelContent = this._getInitialState();
         }
 
         return (
+<<<<<<< HEAD
             <div>
                 <div id="shortcut-viewer">
                     <div id="panel-content">
@@ -81,6 +90,11 @@ class ShortcutViewer extends Component {
                     {copyComponent}
                 </div>
 
+=======
+            <div id="shortcut-viewer">
+                {panelContent}
+                {copyComponent}
+>>>>>>> dca23af... copy button handles text overflow, margins smaller, font smaller, tox-dropdown words now smaller and wrap
             </div>
         )
     }

--- a/src/viewer/ShortcutViewer.jsx
+++ b/src/viewer/ShortcutViewer.jsx
@@ -75,9 +75,13 @@ class ShortcutViewer extends Component {
         }
 
         return (
-            <div id="shortcut-viewer">
-                {panelContent}
-                {copyComponent}
+            <div>
+                <div id="shortcut-viewer">
+                    <div id="panel-content">
+                        {panelContent}
+                    </div>
+                    {copyComponent}
+                </div>
             </div>
         )
     }

--- a/src/viewer/ShortcutViewer.jsx
+++ b/src/viewer/ShortcutViewer.jsx
@@ -48,7 +48,7 @@ class ShortcutViewer extends Component {
                             </p>
                         </div>
                     </Button>
-                    <span className="helper-text">When finished selecting values, click on the copy button above and then paste into a note within your EHR</span>
+                    <span className="helper-text-multi-line">When finished selecting values, click on the copy button above and then paste into a note within your EHR</span>
                 </div>
             </CopyToClipboard>
         );

--- a/src/viewer/ShortcutViewer.jsx
+++ b/src/viewer/ShortcutViewer.jsx
@@ -68,33 +68,16 @@ class ShortcutViewer extends Component {
         if (!Lang.isNull(this.props.currentShortcut)) {
             //panelContent = this.props.currentShortcut.getForm();
             const formSpec = this.props.currentShortcut.getFormSpec();
-<<<<<<< HEAD
-            /* eslint-disable no-eval */
-            panelContent = React.createElement(eval("forms." + formSpec.tagName), formSpec.props, formSpec.children);
-            /* eslint-enable no-eval */
-=======
             const currentForm = forms[formSpec.tagName]
             panelContent = React.createElement(currentForm, formSpec.props, formSpec.children);
->>>>>>> dca23af... copy button handles text overflow, margins smaller, font smaller, tox-dropdown words now smaller and wrap
         } else {
             panelContent = this._getInitialState();
         }
 
         return (
-<<<<<<< HEAD
-            <div>
-                <div id="shortcut-viewer">
-                    <div id="panel-content">
-                        {panelContent}
-                    </div>
-                    {copyComponent}
-                </div>
-
-=======
             <div id="shortcut-viewer">
                 {panelContent}
                 {copyComponent}
->>>>>>> dca23af... copy button handles text overflow, margins smaller, font smaller, tox-dropdown words now smaller and wrap
             </div>
         )
     }

--- a/src/views/SlimApp.css
+++ b/src/views/SlimApp.css
@@ -4,6 +4,7 @@
 /* Restricts app to max fixed width for very wide screens. */
 .SlimApp-content {
     background-color: white;
+    font-size:0.93rem;
     /*64 px is the height of the nav bar*/
     height: calc(100vh - 64px);
     padding: 0 0;
@@ -56,5 +57,10 @@
 }
 
 .header-spacing {
-    margin-top: 80px !important;
+    margin-top: 60px;
+}
+@media (max-width: 992px) { 
+    .header-spacing {
+        margin-top: 45px;
+    }
 }


### PR DESCRIPTION
Various changes to improve the look of elements on the page when screen-width is restricted to half of a laptop/desktop monitor, including: 
- Font sizes are decreased slightly to make for less bloat without limiting readability.
- Prevent text overflowing of copy button when full on small screens.
- Slightly decrease the margins on small screens.
- Fix text-wrap on toxicity AdverseEvent dropdowns.
- Fix text overflow on toxicity Grade menu items when on small screens.
- Improved margins on disease status Status buttons to fix weird margins displayed when rows wrap.
- Increased margin-bottom of ShortcutViewer for better reading when copy button is full of content.
- Changed up helper-text padding for more uniform display on all screen sizes.

Let me know if there is anything else you flagged as looking odd on smalls screens and whether or not you would like me to make those fixes in this sprint or if we want to make separate tasks. 