### PR TITLE
Fix default reference date so 

### DIFF
--- a/src/forms/ProgressionForm.jsx
+++ b/src/forms/ProgressionForm.jsx
@@ -130,7 +130,29 @@ class ProgressionForm extends Component {
         )
     }
 
+    // formatDate converts javascript date format to YYYY-MM-DD
+    // @param date is a string of a date in D MMM YYYY format
+    // Source: https://stackoverflow.com/questions/23593052/format-javascript-date-to-yyyy-mm-dd
+    formatDate(date) {
+        var d = new Date(date),
+            month = '' + (d.getMonth() + 1),
+            day = '' + d.getDate(),
+            year = d.getFullYear();
+
+        if (month.length < 2) month = '0' + month;
+        if (day.length < 2) day = '0' + day;
+
+        return [year, month, day].join('-');
+    }
+
     render() {
+        const clinicallyRelevantTime = this.props.progression.clinicallyRelevantTime;
+        var formattedClinicallyRelevantTime = null;
+
+        if (clinicallyRelevantTime != null) {
+            formattedClinicallyRelevantTime = this.formatDate(clinicallyRelevantTime);
+        }
+
         return (
             <div>
                 <h1>Disease Status</h1>
@@ -174,7 +196,7 @@ class ProgressionForm extends Component {
                 <TextField
                     id="reference-date"
                     type="date"
-                    defaultValue={this.props.progression.clinicallyRelevantTime}
+                    defaultValue={formattedClinicallyRelevantTime}
                     onChange={this.handleDateSelection}
                 />
             </div>

--- a/src/forms/ProgressionForm.jsx
+++ b/src/forms/ProgressionForm.jsx
@@ -64,14 +64,14 @@ class ProgressionForm extends Component {
             }
         }
     }
-    
+
     handleDateSelection = (event) => {
         const date = event.target.value;
         const formattedDate = new moment(date).format('D MMM YYYY');
         this.props.updateValue("referenceDate", formattedDate);
     }
 
-    renderStatusButtonGroup = (status, i) => { 
+    renderStatusButtonGroup = (status, i) => {
         const marginSize = "10px";
         const statusName = status.name;
         const statusDescription = status.description;
@@ -131,7 +131,6 @@ class ProgressionForm extends Component {
     }
 
     render() {
-        const today = new moment().format('YYYY-MM-DD');
         return (
             <div>
                 <h1>Disease Status</h1>
@@ -166,7 +165,7 @@ class ProgressionForm extends Component {
                         return this.renderReasonButtonGroup(reason, i)
                     })}
                 </div>
-                
+
                 <h4 className="header-spacing">Reference Date</h4>
                 <p id="data-element-description">
                     {progressionLookup.getDescription("referenceDate")}
@@ -175,7 +174,7 @@ class ProgressionForm extends Component {
                 <TextField
                     id="reference-date"
                     type="date"
-                    defaultValue={today}
+                    defaultValue={this.props.progression.clinicallyRelevantTime}
                     onChange={this.handleDateSelection}
                 />
             </div>

--- a/src/forms/ProgressionForm.jsx
+++ b/src/forms/ProgressionForm.jsx
@@ -133,27 +133,12 @@ class ProgressionForm extends Component {
         )
     }
 
-    // formatDate converts javascript date format to YYYY-MM-DD
-    // @param date is a string of a date in D MMM YYYY format
-    // Source: https://stackoverflow.com/questions/23593052/format-javascript-date-to-yyyy-mm-dd
-    formatDate(date) {
-        let d = new Date(date),
-            month = '' + (d.getMonth() + 1),
-            day = '' + d.getDate(),
-            year = d.getFullYear();
-
-        if (month.length < 2) month = '0' + month;
-        if (day.length < 2) day = '0' + day;
-
-        return [year, month, day].join('-');
-    }
-
     render() {
         const clinicallyRelevantTime = this.props.progression.clinicallyRelevantTime;
         var formattedClinicallyRelevantTime = null;
 
         if (clinicallyRelevantTime != null) {
-            formattedClinicallyRelevantTime = this.formatDate(clinicallyRelevantTime);
+            formattedClinicallyRelevantTime = new moment(clinicallyRelevantTime, "D MMM YYYY ").format("YYYY-MM-DD");
         }
 
         return (

--- a/src/forms/ProgressionForm.jsx
+++ b/src/forms/ProgressionForm.jsx
@@ -134,7 +134,7 @@ class ProgressionForm extends Component {
     // @param date is a string of a date in D MMM YYYY format
     // Source: https://stackoverflow.com/questions/23593052/format-javascript-date-to-yyyy-mm-dd
     formatDate(date) {
-        var d = new Date(date),
+        let d = new Date(date),
             month = '' + (d.getMonth() + 1),
             day = '' + d.getDate(),
             year = d.getFullYear();

--- a/src/forms/ProgressionForm.jsx
+++ b/src/forms/ProgressionForm.jsx
@@ -67,7 +67,10 @@ class ProgressionForm extends Component {
 
     handleDateSelection = (event) => {
         const date = event.target.value;
-        const formattedDate = new moment(date).format('D MMM YYYY');
+        let formattedDate = null;
+        if (date) {
+            formattedDate = new moment(date).format('D MMM YYYY');
+        }
         this.props.updateValue("referenceDate", formattedDate);
     }
 

--- a/src/patient/Patient.jsx
+++ b/src/patient/Patient.jsx
@@ -820,7 +820,7 @@ class Patient {
 			"entryType":	[	"http://standardhealthrecord.org/oncology/Progression",
 							"http://standardhealthrecord.org/assessment/Assessment" ],			
 			"value": { "coding": statusCoding },
-			"clinicallyRelevantTime": today,
+			"clinicallyRelevantTime": null,
 			"evidence": reasonCodings,
 			"assessmentType": { "coding": { "value": "#disease status"}},
 			"status": "unknown",

--- a/src/shortcuts/ProgressionCreator.jsx
+++ b/src/shortcuts/ProgressionCreator.jsx
@@ -90,7 +90,7 @@ class ProgressionCreator extends CreatorShortcut {
     
     getReferenceDateString(curProgression) {
         let dateString;
-        if(!Lang.isUndefined(curProgression.clinicallyRelevantTime)) {
+        if(curProgression.clinicallyRelevantTime) {
             const formattedDate = this.formatDateToDDMMYYYY(curProgression.clinicallyRelevantTime);
             dateString = ` relative to #reference date #${formattedDate}`;
         } else {


### PR DESCRIPTION
Fixed the reference date in the disease status form in slim mode so that it doesn't default to today's date. By default it now shows "mm/dd/yyyy" until the user chooses a date.

- Set clinicallyRelevantDate to null in Patient.jsx when a new progression is created
- Edited progression form to use clinicallyRelevantDate for the default date (as opposed to a variable, like today's date, created in the form)
- Added code to convert date format to yyyy-mm-dd which is what the date picker component is expecting (didn't use moment.js to do this because kept getting console warnings that the code is deprecated)
- Added check for null value for clinicallyRelevantDate