### PR TITLE
Slim allow per site config

### DIFF
--- a/launch_browser.cmd
+++ b/launch_browser.cmd
@@ -1,0 +1,2 @@
+start "C:\Program Files (x86)\Google\Chrome\Application\chrome.exe" http://localhost:3000/patina
+exit

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,9 +16,9 @@ class App extends Component {
                 <div>
                     {this.views.map((viewObject, i) => {
                         if (viewObject.isExact) { 
-                            return <Route exact path={viewObject.path} component={withTracker(viewObject.app)} key={i}/>
+                            return <Route exact path={viewObject.path} render={(props) => { return React.createElement(withTracker(viewObject.app), Object.assign(props, viewObject)); }} key={i}/>
                         } else { 
-                            return <Route path={viewObject.path} component={withTracker(viewObject.app)} key={i}/>
+                            return <Route path={viewObject.path} render={(props) => { return React.createElement(withTracker(viewObject.app), Object.assign(props, viewObject)); }} key={i}/>
                         }
                     })}
                 </div>

--- a/src/forms/ProgressionForm.jsx
+++ b/src/forms/ProgressionForm.jsx
@@ -2,6 +2,7 @@ import React, {Component} from 'react';
 import Divider from 'material-ui/Divider';
 import Button from 'material-ui/Button';
 import TextField from 'material-ui/TextField';
+import Lang from 'lodash';
 import moment from 'moment';
 import progressionLookup from '../lib/progression_lookup';
 import './ProgressionForm.css';
@@ -10,7 +11,7 @@ import './ProgressionForm.css';
 class ProgressionForm extends Component {
     constructor(props) {
         super(props);
-
+        
         this.state = {
             statusOptions: progressionLookup.getStatusOptions(),
             reasonOptions: progressionLookup.getReasonOptions(),
@@ -140,6 +141,25 @@ class ProgressionForm extends Component {
         if (clinicallyRelevantTime != null) {
             formattedClinicallyRelevantTime = new moment(clinicallyRelevantTime, "D MMM YYYY ").format("YYYY-MM-DD");
         }
+        
+        let referenceDateSection = null;
+        if (Lang.isUndefined(this.props.referenceDateEnabled) || this.props.referenceDateEnabled) {
+            referenceDateSection = (
+                <div>
+                <h4 className="header-spacing">Reference Date</h4>
+                <p id="data-element-description">
+                    {progressionLookup.getDescription("referenceDate")}
+                    <span className="helper-text"> mm/dd/yyyy</span>
+                </p>
+                <TextField
+                    id="reference-date"
+                    type="date"
+                    defaultValue={formattedClinicallyRelevantTime}
+                    onChange={this.handleDateSelection}
+                />
+                </div>
+            );
+        }
 
         return (
             <div>
@@ -176,17 +196,7 @@ class ProgressionForm extends Component {
                     })}
                 </div>
 
-                <h4 className="header-spacing">Reference Date</h4>
-                <p id="data-element-description">
-                    {progressionLookup.getDescription("referenceDate")}
-                    <span className="helper-text"> mm/dd/yyyy</span>
-                </p>
-                <TextField
-                    id="reference-date"
-                    type="date"
-                    defaultValue={formattedClinicallyRelevantTime}
-                    onChange={this.handleDateSelection}
-                />
+                {referenceDateSection}
             </div>
         );
     }

--- a/src/forms/ProgressionForm.jsx
+++ b/src/forms/ProgressionForm.jsx
@@ -146,17 +146,17 @@ class ProgressionForm extends Component {
         if (Lang.isUndefined(this.props.referenceDateEnabled) || this.props.referenceDateEnabled) {
             referenceDateSection = (
                 <div>
-                <h4 className="header-spacing">Reference Date</h4>
-                <p id="data-element-description">
-                    {progressionLookup.getDescription("referenceDate")}
-                    <span className="helper-text"> mm/dd/yyyy</span>
-                </p>
-                <TextField
-                    id="reference-date"
-                    type="date"
-                    defaultValue={formattedClinicallyRelevantTime}
-                    onChange={this.handleDateSelection}
-                />
+                    <h4 className="header-spacing">Reference Date</h4>
+                    <p id="data-element-description">
+                        {progressionLookup.getDescription("referenceDate")}
+                        <span className="helper-text"> mm/dd/yyyy</span>
+                    </p>
+                    <TextField
+                        id="reference-date"
+                        type="date"
+                        defaultValue={formattedClinicallyRelevantTime}
+                        onChange={this.handleDateSelection}
+                    />
                 </div>
             );
         }

--- a/src/shortcuts/ProgressionCreator.jsx
+++ b/src/shortcuts/ProgressionCreator.jsx
@@ -143,12 +143,14 @@ class ProgressionCreator extends CreatorShortcut {
         );      
     }
 */
+
     getFormSpec() {
         return  {
                     tagName: 'ProgressionForm',
                     props:  {   
                                 updateValue: this.setAttributeValue,
-                                progression: this.progression
+                                progression: this.progression,
+                                ...this.configuration
                             },
                     children: []
                 };

--- a/src/shortcuts/Shortcut.jsx
+++ b/src/shortcuts/Shortcut.jsx
@@ -16,6 +16,10 @@ class Shortcut extends Context {
         super.initialize(contextManager);
 	}
 
+    setConfiguration(config) {
+        this.configuration = config;
+    }
+
 	getPrefixCharacter() {
 		throw new TypeError("Primitive shortcut has no prefix character")
 	}

--- a/src/shortcuts/Shortcut.jsx
+++ b/src/shortcuts/Shortcut.jsx
@@ -4,31 +4,32 @@ import Lang from 'lodash';
 
 class Shortcut extends Context {
     constructor() {
-		super();
+        super();
         if (this.constructor === Shortcut) {
             throw new TypeError("Cannot construct Shortcut instances directly");
         }
-		this.optionsToSelectFrom = null;
-		this.valueChangeHandlers = {};
+        this.optionsToSelectFrom = null;
+        this.valueChangeHandlers = {};
     }
-	
-	initialize(contextManager) {
+    
+    initialize(contextManager) {
         super.initialize(contextManager);
-	}
+    }
 
     setConfiguration(config) {
         this.configuration = config;
     }
 
-	getPrefixCharacter() {
-		throw new TypeError("Primitive shortcut has no prefix character")
-	}
-	
-	// Slim App
+    getPrefixCharacter() {
+        throw new TypeError("Primitive shortcut has no prefix character")
+    }
+    
+    // Slim App
     getAsString () { 
         return "#null"; 
     }
-/*    getForm () {
+    /*    
+    getForm () {
         return (<h2>No additional values for current shortcut</h2>);
     }*/
 
@@ -36,43 +37,43 @@ class Shortcut extends Context {
         throw new TypeError("Base Shortcut has no type")
     }
     
-	getText() {
-		return this.getShortcutType();
-	}
+    getText() {
+        return this.getShortcutType();
+    }
 
-	getLabel() {
-		throw new Error("Invalid context. " + this.constructor.name);
-	}	
-		
-	updatePatient(patient, contextManager) {
-		throw new Error("update patient not implemented for " + this.constructor.name);
-	}
-	
-	validateInCurrentContext(contextManager) {
-		return []; // no errors
-	}
-	
-	//options is array of {key: item.entryId, context: item.specificType.coding.displayText, object: item}
-	flagForTextSelection(options) {
-		this.optionsToSelectFrom = options;
-	}
-	
-	getValueSelectionOptions() {
-		return this.optionsToSelectFrom;
-	}
-	
-	needToSelectValueFromMultipleOptions() {
-		return !Lang.isNull(this.optionsToSelectFrom);
-	}
-	
-	clearValueSelectionOptions() {
-		this.optionsToSelectFrom = null;
-	}
+    getLabel() {
+        throw new Error("Invalid context. " + this.constructor.name);
+    }   
+        
+    updatePatient(patient, contextManager) {
+        throw new Error("update patient not implemented for " + this.constructor.name);
+    }
+    
+    validateInCurrentContext(contextManager) {
+        return []; // no errors
+    }
+    
+    //options is array of {key: item.entryId, context: item.specificType.coding.displayText, object: item}
+    flagForTextSelection(options) {
+        this.optionsToSelectFrom = options;
+    }
+    
+    getValueSelectionOptions() {
+        return this.optionsToSelectFrom;
+    }
+    
+    needToSelectValueFromMultipleOptions() {
+        return !Lang.isNull(this.optionsToSelectFrom);
+    }
+    
+    clearValueSelectionOptions() {
+        this.optionsToSelectFrom = null;
+    }
 
-	// by default shortcuts are not Contexts.
-	isContext() {
-		return false;
-	}
+    // by default shortcuts are not Contexts.
+    isContext() {
+        return false;
+    }
     
     onBeforeDeleted() {
         if (this.isContext() && this.hasChildren()) {

--- a/src/shortcuts/StagingCreator.jsx
+++ b/src/shortcuts/StagingCreator.jsx
@@ -113,7 +113,8 @@ class StagingCreator extends CreatorShortcut {
                     tagName: 'StagingForm',
                     props:  {   
                                 updateValue: this.setAttributeValue,
-                                staging: this.staging
+                                staging: this.staging,
+                                ...this.configuration
                             },
                     children: []
                 };

--- a/src/shortcuts/ToxicityCreator.jsx
+++ b/src/shortcuts/ToxicityCreator.jsx
@@ -123,7 +123,8 @@ class ToxicityCreator extends CreatorShortcut {
                     tagName: 'ToxicityForm',
                     props:  {   
                                 updateValue: this.setAttributeValue,
-                                toxicity: this.toxicity
+                                toxicity: this.toxicity,
+                                ...this.configuration
                             },
                     children: []
                 };

--- a/src/views/FullApp.jsx
+++ b/src/views/FullApp.jsx
@@ -15,28 +15,28 @@ class FullApp extends Component {
     constructor(props) {
         super(props);
 
-		this.shortcuts = [ 	"#disease status", "#staging", "#toxicity", "@name", "@condition", "@age", "@dateofbirth", "@gender", "@patient", "@stage" ];
+        this.shortcuts = [  "#disease status", "#staging", "#toxicity", "@name", "@condition", "@age", "@dateofbirth", "@gender", "@patient", "@stage" ];
 
         this.updateErrors = this.updateErrors.bind(this);
-		this.onContextUpdate = this.onContextUpdate.bind(this);
-		
-		let patient = new Patient();
-		this.summaryMetadata = new SummaryMetadata();
-		this.shortcutManager = new ShortcutManager(this.shortcuts);
-		this.contextManager = new ContextManager(patient, this.onContextUpdate);		
+        this.onContextUpdate = this.onContextUpdate.bind(this);
+        
+        let patient = new Patient();
+        this.summaryMetadata = new SummaryMetadata();
+        this.shortcutManager = new ShortcutManager(this.shortcuts);
+        this.contextManager = new ContextManager(patient, this.onContextUpdate);        
 
-	    this.state = {
+        this.state = {
             SummaryItemToInsert: '',
             selectedText: null,
-			summaryMetadata: this.summaryMetadata.getMetadata(),
+            summaryMetadata: this.summaryMetadata.getMetadata(),
             patient: patient
-			//contextManager: this.contextManager			
+            //contextManager: this.contextManager           
         };
     }
-	
-	onContextUpdate = () => {
+    
+    onContextUpdate = () => {
         this.setState({contextManager: this.contextManager});
-	}
+    }
     
     updateErrors(errors) {
         this.setState({errors: errors});
@@ -47,23 +47,23 @@ class FullApp extends Component {
     }
     
     newCurrentShortcut = (shortcutType, obj) => {
-		let newShortcut = this.shortcutManager.createShortcut(shortcutType, this.handleShortcutUpdate, obj);
-		const errors = newShortcut.validateInCurrentContext(this.contextManager);
-		if (errors.length > 0) {
-			errors.forEach((error) => {
-				console.error(error);
-			});
-			newShortcut = null;
-		} else {
-			newShortcut.initialize(this.contextManager, shortcutType);
-		}
+        let newShortcut = this.shortcutManager.createShortcut(shortcutType, this.handleShortcutUpdate, obj);
+        const errors = newShortcut.validateInCurrentContext(this.contextManager);
+        if (errors.length > 0) {
+            errors.forEach((error) => {
+                console.error(error);
+            });
+            newShortcut = null;
+        } else {
+            newShortcut.initialize(this.contextManager, shortcutType);
+        }
         this.updateErrors(errors);
-		return newShortcut;
+        return newShortcut;
     }
-	
+    
     handleShortcutUpdate = (s) =>{
-		let p = this.state.patient;
-		s.updatePatient(p, this.contextManager);
+        let p = this.state.patient;
+        s.updatePatient(p, this.contextManager);
     }
 
     handleStructuredFieldEntered = (field) => {
@@ -100,8 +100,10 @@ class FullApp extends Component {
         console.log("new note");
     }
     
-    menuItems = [   {label: "New Note", action: this.handleNewNote.bind(this)}
-                ];
+    menuItems = [   
+        {label: "New Note", action: this.handleNewNote.bind(this)}
+    ];
+    
     render() {
         return (
                 <div className="FullApp">
@@ -114,21 +116,21 @@ class FullApp extends Component {
                                     onItemClicked={this.handleSummaryItemSelected}
                                     // Properties
                                     allowItemClick={true}
-									summaryMetadata={this.state.summaryMetadata}
+                                    summaryMetadata={this.state.summaryMetadata}
                                     patient={this.state.patient}
                                 />
                             </Col>
                             <Col sm={5}>
                                 <FluxNotesEditor
                                     onSelectionChange={this.handleSelectionChange}
-									newCurrentShortcut={this.newCurrentShortcut}
+                                    newCurrentShortcut={this.newCurrentShortcut}
                                     itemInserted={this.itemInserted}
                                     itemToBeInserted={this.state.SummaryItemToInsert}
                                     patient={this.state.patient}
-									contextManager={this.contextManager}
-									shortcutManager={this.shortcutManager}
+                                    contextManager={this.contextManager}
+                                    shortcutManager={this.shortcutManager}
                                     updateErrors={this.updateErrors}
-									errors={this.state.errors}
+                                    errors={this.state.errors}
                                 />
                             </Col>
                             <Col sm={3}>
@@ -137,7 +139,7 @@ class FullApp extends Component {
                                     // Properties
                                     ref={(comp) => { this.contextTray = comp; }}
                                     patient={this.state.patient}
-									contextManager={this.contextManager}
+                                    contextManager={this.contextManager}
                                     onShortcutClicked={this.handleSummaryItemSelected}
                                 />
                             </Col>

--- a/src/views/FullApp.jsx
+++ b/src/views/FullApp.jsx
@@ -105,7 +105,7 @@ class FullApp extends Component {
     render() {
         return (
                 <div className="FullApp">
-                    <NavBar title="Flux Notes" supportLogin={true} menuItems={this.menuItems}/>
+                    <NavBar title={this.props.display} supportLogin={true} menuItems={this.menuItems}/>
                     <Grid className="FullApp-content" fluid>
                         <Row center="xs">
                             <Col sm={4}>

--- a/src/views/SlimApp.jsx
+++ b/src/views/SlimApp.jsx
@@ -10,8 +10,9 @@ import './SlimApp.css';
 class SlimApp extends Component {
     constructor(props) {
         super(props);
+        //console.log(props);
 
-        this.shortcuts = [ "#disease status", "#toxicity" ];
+        this.shortcuts = []; // not currently used
         this.shortcutManager = new ShortcutManager(this.shortcuts);
 
         this.state = {
@@ -39,7 +40,7 @@ class SlimApp extends Component {
     render() {
         return (
                 <div className="SlimApp">
-                    <NavBar title="Flux Notes Lite" supportLogin={false}/>
+                    <NavBar title={this.props.display} supportLogin={false}/>
                     <Grid className="SlimApp-content" fluid>
                         <div id="forms-panel">
                             <Row center="xs">
@@ -47,7 +48,7 @@ class SlimApp extends Component {
                                     {/*No need for formsearch right now*/}
                                     {/*<FormSearch />*/}
                                     <FormList
-                                        shortcuts={['About Flux Notes Lite', 'Disease Status', 'Toxicity']}
+                                        shortcuts={['About Flux Notes Lite'].concat(this.props.shortcuts)} //, 'Disease Status', 'Toxicity'
                                         currentShortcut={this.state.currentShortcut}
                                         changeShortcut={this.changeShortcut}
                                     />

--- a/src/views/SlimApp.jsx
+++ b/src/views/SlimApp.jsx
@@ -25,7 +25,10 @@ class SlimApp extends Component {
      */
     changeShortcut = (shortcutType) => {
         const newShortcut = (Lang.isNull(shortcutType)) ? null : this.shortcutManager.createShortcut("#" + shortcutType.toLowerCase(), this.handleShortcutUpdate);
-        newShortcut.setConfiguration((this.props.shortcutConfigurations) ? this.props.shortcutConfigurations[shortcutType] : {});
+        if (newShortcut) {
+            newShortcut.setConfiguration((this.props.shortcutConfigurations) ? 
+                    this.props.shortcutConfigurations[shortcutType] : {});
+        }
         this.setState({
             currentShortcut: newShortcut
         });

--- a/src/views/SlimApp.jsx
+++ b/src/views/SlimApp.jsx
@@ -25,6 +25,7 @@ class SlimApp extends Component {
      */
     changeShortcut = (shortcutType) => {
         const newShortcut = (Lang.isNull(shortcutType)) ? null : this.shortcutManager.createShortcut("#" + shortcutType.toLowerCase(), this.handleShortcutUpdate);
+        newShortcut.setConfiguration((this.props.shortcutConfigurations) ? this.props.shortcutConfigurations[shortcutType] : {});
         this.setState({
             currentShortcut: newShortcut
         });

--- a/src/views/ViewManager.jsx
+++ b/src/views/ViewManager.jsx
@@ -11,7 +11,7 @@ class ViewManager {
                 isExact: true
             }, {
                 path: '/patient',
-                display: 'Flux Notes Patient View',
+                display: 'Flux Notes',
                 app: FullApp,
                 isExact: true
             }

--- a/src/views/ViewManager.jsx
+++ b/src/views/ViewManager.jsx
@@ -8,6 +8,9 @@ class ViewManager {
                 shortcuts: ['Disease Status', 'Toxicity'],
                 display: 'Flux Notes Lite (for PATINA endpoints)',
                 app: SlimApp,
+                shortcutConfigurations: {
+                    'Disease Status': { referenceDateEnabled: false }
+                },
                 isExact: true
             }, {
                 path: '/patient',

--- a/src/views/ViewManager.jsx
+++ b/src/views/ViewManager.jsx
@@ -4,15 +4,16 @@ import SlimApp from './SlimApp';
 class ViewManager {
     constructor() {
         this.views = [{
-                path: '/',
-                display: 'Flux Notes Lite',
+                path: '/patina',
+                shortcuts: ['Disease Status', 'Toxicity'],
+                display: 'Flux Notes Lite (for PATINA endpoints)',
                 app: SlimApp,
                 isExact: true
             }, {
                 path: '/patient',
                 display: 'Flux Notes Patient View',
                 app: FullApp,
-                isExact: false
+                isExact: true
             }
         ];
     }


### PR DESCRIPTION
View Manager now controls the list of shortcuts for a SlimApp
Apps now use the display value specified in ViewManager for each view/url
Moved from root URL to /patina
View Manager now supports configuration parameters that end up in form for the shortcut to support customization
Disease Status form supports configuration to show or not show reference date