### PR TITLE
Full mode as of date

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "moment": "2.18.1",
     "positions": "1.6.1",
     "prop-types": "15.5.10",
+    "rc-calendar": "^9.0.4",
     "rc-tooltip": "^3.4.8",
     "react": "15.5.4",
     "react-autosuggest": "9.3.2",

--- a/src/context/ContextManager.jsx
+++ b/src/context/ContextManager.jsx
@@ -113,6 +113,15 @@ class ContextManager {
 	getPatientContext() {
 		return this.patientContext;
 	}
+    
+    getCurrentContext() {
+        const mostRecentContext = this.activeContexts[0];
+        if (!Lang.isUndefined(mostRecentContext) || !Lang.isNull(mostRecentContext)) {
+            return mostRecentContext;
+        } else {
+            return this.patientContext;
+        }
+    }
 }
 
 export default ContextManager;

--- a/src/context/ContextPortal.jsx
+++ b/src/context/ContextPortal.jsx
@@ -144,12 +144,11 @@ class ContextPortal extends React.Component {
     
     handleCalendarSelect = (date) => {
         this.closePortal();
-        const context = { key: 'set-date-id', context: `#${date.format("MM/DD/YYYY")}`, object: date }; //JULIA check about object
+        const context = { key: 'set-date-id', context: `#${date.format("MM/DD/YYYY")}`, object: date };
         const dateParentContext = this.props.contextManager.getCurrentContext();
-        dateParentContext.setAttributeValue("date", date.format("MM/DD/YYYY"), false);
+        dateParentContext.setAttributeValue("date", date.format("D MMM YYYY"), false);
         const state = this.props.onSelected(this.props.state, context);
         this.props.onChange(state);
-        
     }
     
     renderListOptions = () => {

--- a/src/context/ContextPortal.jsx
+++ b/src/context/ContextPortal.jsx
@@ -144,9 +144,7 @@ class ContextPortal extends React.Component {
     
     handleCalendarSelect = (date) => {
         this.closePortal();
-        const context = { key: 'set-date-id', context: `#${date.format("MM/DD/YYYY")}`, object: date };
-        const dateParentContext = this.props.contextManager.getCurrentContext();
-        dateParentContext.setAttributeValue("date", date.format("D MMM YYYY"), false);
+        const context = { key: 'set-date-id', context: `${date.format("MM/DD/YYYY")}`, object: date };
         const state = this.props.onSelected(this.props.state, context);
         this.props.onChange(state);
     }
@@ -173,13 +171,14 @@ class ContextPortal extends React.Component {
     }
     
     renderCalendar = () => {
+        // NOTE: If setTimeout doesn't seem to be setting the focus correctly, try creating a separate component 
+        // that extends Calendar and has componentDidMount to set focus
         return (
-            <div>
-                <Calendar
-                    showDateInput={false}
-                    onSelect={this.handleCalendarSelect}
-                />
-            </div>
+            <Calendar
+                showDateInput={false}
+                onSelect={this.handleCalendarSelect}
+                ref={input => input && setTimeout(() => {input.focus()}, 100)}
+            />
         );
     }
     

--- a/src/context/ContextPortal.jsx
+++ b/src/context/ContextPortal.jsx
@@ -1,8 +1,10 @@
 import React from 'react'
 import Portal from 'react-portal'
+import Calendar from 'rc-calendar';
 import ContextItem from './ContextItem'
 import Lang from 'lodash'
 import './ContextPortal.css';
+import 'rc-calendar/assets/index.css';
 
 const UP_ARROW_KEY = 38
 const DOWN_ARROW_KEY = 40
@@ -139,6 +141,49 @@ class ContextPortal extends React.Component {
             selectedIndex: selectedIndex
         });
     }
+    
+    handleCalendarSelect = (date) => {
+        this.closePortal();
+        const context = { key: 'set-date-id', context: `#${date.format("MM/DD/YYYY")}`, object: date }; //JULIA check about object
+        const dateParentContext = this.props.contextManager.getCurrentContext();
+        dateParentContext.setAttributeValue("date", date.format("MM/DD/YYYY"), false);
+        const state = this.props.onSelected(this.props.state, context);
+        this.props.onChange(state);
+        
+    }
+    
+    renderListOptions = () => {
+        const { contexts } = this.props;
+        return (
+            <ul>
+                {contexts.map((context, index) => {
+                    return <ContextItem
+                        key={context.key}
+                        index={index}
+                        context={context}
+                        selectedIndex={this.state.selectedIndex}
+                        setSelectedIndex={this.setSelectedIndex}
+                        onSelected={this.props.onSelected}
+                        onChange={this.props.onChange}
+                        closePortal={this.closePortal}
+                        state={this.props.state}
+                    />
+                })}
+            </ul>
+        );
+    }
+    
+    renderCalendar = () => {
+        return (
+            <div>
+                <Calendar
+                    showDateInput={false}
+                    onSelect={this.handleCalendarSelect}
+                />
+            </div>
+        );
+    }
+    
     /*
      * View of the current menu
      */
@@ -156,21 +201,7 @@ class ContextPortal extends React.Component {
                 onClose={this.onClose}
             >
                 <div className="context-portal">
-                    <ul>
-                        {contexts.map((context, index) => {
-                            return <ContextItem
-                                key={context.key}
-                                index={index}
-                                context={context}
-                                selectedIndex={this.state.selectedIndex}
-                                setSelectedIndex={this.setSelectedIndex}
-                                onSelected={this.props.onSelected}
-                                onChange={this.props.onChange}
-                                closePortal={this.closePortal}
-                                state={this.props.state}
-                            />
-                        })}
-                    </ul>
+                    {contexts[0].key === 'date-id' ? this.renderCalendar() : this.renderListOptions()}
                 </div>
             </Portal>
         )

--- a/src/forms/ProgressionForm.jsx
+++ b/src/forms/ProgressionForm.jsx
@@ -18,6 +18,11 @@ class ProgressionForm extends Component {
             reasonButtonsActiveState: []
         };
     }
+    
+    componentWillMount() {
+        // Default the asOfDate to use in slim mode copy button
+        this.props.updateValue("asOfDate", new moment().format('D MMM YYYY'));
+    }
 
     currentlySelected(item, i) {
         return (item === i ? true : false);

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -142,6 +142,8 @@ class FluxNotesEditor extends React.Component {
         const shortcut = this.props.newCurrentShortcut(suggestion.value.name);
         
         if (!Lang.isNull(shortcut) && shortcut.needToSelectValueFromMultipleOptions()) {
+            // JULIA
+            // console.log("A")
             return this.openPortalToSelectValueForShortcut(shortcut, true, state.transform()).apply();
         } else {
             const transformBeforeInsert = this.suggestionDeleteExistingTransform(state.transform(), shortcut.getPrefixCharacter());
@@ -157,6 +159,7 @@ class FluxNotesEditor extends React.Component {
         let shortcut = this.props.newCurrentShortcut(shortcutTrigger);
         if (!Lang.isNull(shortcut) && shortcut.needToSelectValueFromMultipleOptions()) {
             if (text.length > 0) {
+                // console.log("C")
                 shortcut.setText(text);
                 let portalOptions = shortcut.getValueSelectionOptions();
                 portalOptions.forEach((option) => {
@@ -168,6 +171,8 @@ class FluxNotesEditor extends React.Component {
                 shortcut.clearValueSelectionOptions();
                 return this.insertStructuredFieldTransform(transform, shortcut).collapseToStartOfNextText().focus();
             } else {
+                // JULIA
+                // console.log("B")
                 return this.openPortalToSelectValueForShortcut(shortcut, false, transform);
             }
         } else {
@@ -435,6 +440,7 @@ class FluxNotesEditor extends React.Component {
                             trigger={"@"}
                             onChange={this.onChange}
                             isOpened={this.state.isPortalOpen}
+                            contextManager={this.contextManager}
                         />
                     </div>
                 </Paper>

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -142,8 +142,6 @@ class FluxNotesEditor extends React.Component {
         const shortcut = this.props.newCurrentShortcut(suggestion.value.name);
         
         if (!Lang.isNull(shortcut) && shortcut.needToSelectValueFromMultipleOptions()) {
-            // JULIA
-            // console.log("A")
             return this.openPortalToSelectValueForShortcut(shortcut, true, state.transform()).apply();
         } else {
             const transformBeforeInsert = this.suggestionDeleteExistingTransform(state.transform(), shortcut.getPrefixCharacter());
@@ -159,7 +157,6 @@ class FluxNotesEditor extends React.Component {
         let shortcut = this.props.newCurrentShortcut(shortcutTrigger);
         if (!Lang.isNull(shortcut) && shortcut.needToSelectValueFromMultipleOptions()) {
             if (text.length > 0) {
-                // console.log("C")
                 shortcut.setText(text);
                 let portalOptions = shortcut.getValueSelectionOptions();
                 portalOptions.forEach((option) => {
@@ -171,8 +168,6 @@ class FluxNotesEditor extends React.Component {
                 shortcut.clearValueSelectionOptions();
                 return this.insertStructuredFieldTransform(transform, shortcut).collapseToStartOfNextText().focus();
             } else {
-                // JULIA
-                // console.log("B")
                 return this.openPortalToSelectValueForShortcut(shortcut, false, transform);
             }
         } else {

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -194,7 +194,7 @@ function StructuredFieldPlugin(opts) {
     }
 
     function onCopy(event, data, state, editor) {
-        console.log("onCopy");
+        // console.log("onCopy");
         let { selection } = state;
    
         const window = getWindow(event.target);
@@ -209,7 +209,7 @@ function StructuredFieldPlugin(opts) {
 
         //console.log(state.document);
         let fluxString = convertToText(state, selection);
-        console.log("copy: " + fluxString);
+        // console.log("copy: " + fluxString);
         const encoded = window.btoa(window.encodeURIComponent(fluxString));
         const range = native.getRangeAt(0);
         let contents = range.cloneContents();
@@ -255,7 +255,7 @@ function StructuredFieldPlugin(opts) {
         if (contents.childNodes.length > 1) {
             contents.childNodes[1].setAttribute('flux-string', encoded);
         }
-        console.log(attach);
+        // console.log(attach);
 
         // Add the phony content to the DOM, and select it, so it will be copied.
         const body = window.document.querySelector('body');

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -143,7 +143,7 @@ function StructuredFieldPlugin(opts) {
                 result += (end === -1) ? blk.text.substring(start) : blk.text.substring(start, end);
             } else if (blk.kind === 'inline' && blk.type === 'structured_field') {
                 let shortcut = blk.data.get("shortcut");
-                if (shortcut instanceof InserterShortcut) { //&& Lang.isArray(shortcut.determineText(contextManager))
+                if (shortcut instanceof InserterShortcut || Lang.isArray(shortcut.determineText(contextManager))) {
                     result += `${shortcut.getShortcutType()}[[${shortcut.getText()}]]`;
                 } else {
                     result += shortcut.getText();
@@ -194,7 +194,7 @@ function StructuredFieldPlugin(opts) {
     }
 
     function onCopy(event, data, state, editor) {
-        //console.log("onCopy");
+        console.log("onCopy");
         let { selection } = state;
    
         const window = getWindow(event.target);
@@ -209,7 +209,7 @@ function StructuredFieldPlugin(opts) {
 
         //console.log(state.document);
         let fluxString = convertToText(state, selection);
-        //console.log("copy: " + fluxString);
+        console.log("copy: " + fluxString);
         const encoded = window.btoa(window.encodeURIComponent(fluxString));
         const range = native.getRangeAt(0);
         let contents = range.cloneContents();
@@ -255,7 +255,7 @@ function StructuredFieldPlugin(opts) {
         if (contents.childNodes.length > 1) {
             contents.childNodes[1].setAttribute('flux-string', encoded);
         }
-        //console.log(attach);
+        console.log(attach);
 
         // Add the phony content to the DOM, and select it, so it will be copied.
         const body = window.document.querySelector('body');

--- a/src/patient/Patient.jsx
+++ b/src/patient/Patient.jsx
@@ -469,7 +469,8 @@ class Patient {
         this.nextEntryId = this.nextEntryId + 1;
         entry.focalSubject = this.patientFocalSubject;
         let today = new moment().format("D MMM YYYY");
-        entry.originalCreationDate = null;
+        entry.originalCreationDate = today;
+        entry.asOfDate = null;
         entry.lastUpdateDate = today;
         this.patient.push(entry);
     }
@@ -824,7 +825,8 @@ class Patient {
 			"evidence": reasonCodings,
 			"assessmentType": { "coding": { "value": "#disease status"}},
 			"status": "unknown",
-			"originalCreationDate": null,
+			"originalCreationDate": today,
+            "asOfDate": null,
 			"lastUpdateDate": today
 		};
     }
@@ -856,7 +858,7 @@ class Patient {
     
     static updateAsOfDateForProgression(progression, date) {
         // TODO: Check with Mark about what this should set
-        progression.originalCreationDate = date;
+        progression.asOfDate = date;
     }
     
     static updateReferenceDateForProgression(progression, date) {

--- a/src/patient/Patient.jsx
+++ b/src/patient/Patient.jsx
@@ -469,7 +469,7 @@ class Patient {
         this.nextEntryId = this.nextEntryId + 1;
         entry.focalSubject = this.patientFocalSubject;
         let today = new moment().format("D MMM YYYY");
-        entry.originalCreationDate = today;
+        entry.originalCreationDate = null;
         entry.lastUpdateDate = today;
         this.patient.push(entry);
     }
@@ -824,7 +824,7 @@ class Patient {
 			"evidence": reasonCodings,
 			"assessmentType": { "coding": { "value": "#disease status"}},
 			"status": "unknown",
-			"originalCreationDate": today,
+			"originalCreationDate": null,
 			"lastUpdateDate": today
 		};
     }

--- a/src/shortcuts/CreatorShortcut.jsx
+++ b/src/shortcuts/CreatorShortcut.jsx
@@ -1,4 +1,5 @@
 import Shortcut from './Shortcut';
+import Lang from 'lodash';
 
 export default class CreatorShortcut extends Shortcut {
 	getPrefixCharacter() {
@@ -7,5 +8,19 @@ export default class CreatorShortcut extends Shortcut {
 	
 	initialize(contextManager) {
 		super.initialize(contextManager);
+        let text = this.determineText(contextManager);
+        if (Lang.isArray(text)) {
+			this.flagForTextSelection(text);
+		} else {
+			this.setText(text);
+		}
+	}
+    
+    determineText(contextManager) {
+        return null;
+    }
+    
+    setText(text) {
+		this.text = text;
 	}
 }

--- a/src/shortcuts/DateCreator.jsx
+++ b/src/shortcuts/DateCreator.jsx
@@ -10,15 +10,15 @@ export default class DateCreator extends CreatorShortcut {
         super.initialize(contextManager, trigger);
         this.text = trigger;
         let dateString = trigger.substring(1);
-        this.parentContext = contextManager.getActiveContextOfType("#disease status");
-        this.parentContext.setAttributeValue("asOfDate", dateString, false);
+        this.parentContext = contextManager.getCurrentContext();
+        this.parentContext.setAttributeValue("date", dateString, false);
         this.parentContext.addChild(this);
     }
     
     onBeforeDeleted() {
         let result = super.onBeforeDeleted();
         if(result) {
-            this.parentContext.setAttributeValue("asOfDate", "", false);
+            this.parentContext.setAttributeValue("date", null, false);
             this.parentContext.removeChild(this);
         }
         return result;

--- a/src/shortcuts/DateCreator.jsx
+++ b/src/shortcuts/DateCreator.jsx
@@ -9,6 +9,7 @@ export default class DateCreator extends CreatorShortcut {
         super.initialize(contextManager, trigger);
         this.text = trigger;
         this.parentContext = contextManager.getCurrentContext();
+        this.parentContext.setAttributeValue("date", trigger.substring(1), false);
     }
     
     onBeforeDeleted() {

--- a/src/shortcuts/DateCreator.jsx
+++ b/src/shortcuts/DateCreator.jsx
@@ -9,10 +9,7 @@ export default class DateCreator extends CreatorShortcut {
     initialize(contextManager, trigger) {
         super.initialize(contextManager, trigger);
         this.text = trigger;
-        let dateString = trigger.substring(1);
         this.parentContext = contextManager.getCurrentContext();
-        this.parentContext.setAttributeValue("date", dateString, false);
-        this.parentContext.addChild(this);
     }
     
     onBeforeDeleted() {
@@ -22,6 +19,10 @@ export default class DateCreator extends CreatorShortcut {
             this.parentContext.removeChild(this);
         }
         return result;
+    }
+    
+    determineText(contextManager) { //JULIA Fix
+        return [{key: 'date-id', context: 'some text to show you', object: 'a date'}];
     }
     
     getText() {
@@ -40,7 +41,7 @@ export default class DateCreator extends CreatorShortcut {
     static getTriggers() {
         const today = new moment().format("D MMM YYYY");
         // TODO: name will need to be a regular expression of date format instead of just today's date
-        let result = [{name: `#${today}`, description: "A date."}];
+        let result = [{name: `#date`, description: "A date."}];
         return result;
     }
     

--- a/src/shortcuts/DateCreator.jsx
+++ b/src/shortcuts/DateCreator.jsx
@@ -1,4 +1,5 @@
 import CreatorShortcut from './CreatorShortcut';
+import moment from 'moment';
 
 export default class DateCreator extends CreatorShortcut {
     constructor(onUpdate, obj) {
@@ -9,7 +10,6 @@ export default class DateCreator extends CreatorShortcut {
         super.initialize(contextManager, trigger);
         this.text = trigger;
         this.parentContext = contextManager.getCurrentContext();
-        this.parentContext.setAttributeValue("date", trigger.substring(1), false);
         this.parentContext.addChild(this);
     }
     
@@ -27,8 +27,17 @@ export default class DateCreator extends CreatorShortcut {
         return [{key: 'date-id', context: 'Placeholder for calendar', object: 'a date'}];
     }
     
+    setText(text) {
+        if (text.startsWith('#')) {
+            text = text.substring(1);
+        }
+        super.setText(text);
+        const formattedDate = moment(text, 'MM-DD-YYYY').format('D MMM YYYY');
+        this.parentContext.setAttributeValue("date", formattedDate, false);
+    }
+    
     getText() {
-        return this.text;
+        return `#${this.text}`;
     }
     
     getShortcutType() {

--- a/src/shortcuts/DateCreator.jsx
+++ b/src/shortcuts/DateCreator.jsx
@@ -1,4 +1,3 @@
-import moment from 'moment';
 import CreatorShortcut from './CreatorShortcut';
 
 export default class DateCreator extends CreatorShortcut {
@@ -21,8 +20,9 @@ export default class DateCreator extends CreatorShortcut {
         return result;
     }
     
-    determineText(contextManager) { //JULIA Fix
-        return [{key: 'date-id', context: 'some text to show you', object: 'a date'}];
+    // This returns a placeholder object to trigger opening the Context Portal. Key:'date-id' opens calendar.
+    determineText(contextManager) {
+        return [{key: 'date-id', context: 'Placeholder for calendar', object: 'a date'}];
     }
     
     getText() {
@@ -39,8 +39,6 @@ export default class DateCreator extends CreatorShortcut {
     }
     
     static getTriggers() {
-        const today = new moment().format("D MMM YYYY");
-        // TODO: name will need to be a regular expression of date format instead of just today's date
         let result = [{name: `#date`, description: "A date."}];
         return result;
     }

--- a/src/shortcuts/DateCreator.jsx
+++ b/src/shortcuts/DateCreator.jsx
@@ -10,6 +10,7 @@ export default class DateCreator extends CreatorShortcut {
         this.text = trigger;
         this.parentContext = contextManager.getCurrentContext();
         this.parentContext.setAttributeValue("date", trigger.substring(1), false);
+        this.parentContext.addChild(this);
     }
     
     onBeforeDeleted() {

--- a/src/shortcuts/ProgressionAsOfDateCreator.jsx
+++ b/src/shortcuts/ProgressionAsOfDateCreator.jsx
@@ -1,0 +1,82 @@
+import Lang from 'lodash';
+import CreatorShortcut from './CreatorShortcut';
+import DateCreator from './DateCreator';
+import Patient from '../patient/Patient';
+
+export default class ProgressionAsOfDateCreator extends CreatorShortcut {
+    constructor(onUpdate, progression) {
+        super();
+    }
+    
+    initialize(contextManager, trigger) {
+        super.initialize(contextManager, trigger);
+        this.parentContext = contextManager.getActiveContextOfType("#disease status");
+        if (!Lang.isUndefined(this.parentContext)) {
+            this.parentContext.addChild(this);
+        }
+    }
+    
+    onBeforeDeleted() {
+        let result = super.onBeforeDeleted();
+        if (result) {
+            this.parentContext.removeChild(this);
+        }
+        return result;
+    }
+    
+    getShortcutType() {
+        return "#as of";
+    }
+    
+    setAttributeValue(name, value, publishChanges) {
+        if (name === "date") {
+            this.parentContext.setAttributeValue("asOfDate", value, false);
+            this.updateContextStatus();
+        }
+    }
+    
+    getAttributeValue(name) {
+        if (name === 'date') {
+            this.parentContext.getAttributeValue("asOfDate");
+        }
+    }
+    
+    validateInCurrentContext(contextManager) {
+        let errors = [];
+        if (!contextManager.isContextOfTypeActive("#disease status")) {
+            errors.push("As of values are invalid without #disease status. Use #disease status to add a new disease status to your narrative.");
+            return errors;
+        }
+        let parentContext = contextManager.getActiveContextOfType("#disease status");
+        if (!Lang.isNull(parentContext.getAttributeValue("asOfDate"))) {
+            errors.push("As of date already specified. Only one as of date allowed per #disease status.");
+        }
+        return errors;
+    }
+    
+    shouldBeInContext() {
+        return (Lang.isNull(this.parentContext.progression.originalCreationDate));
+    }
+    
+    getValidChildShortcuts() {
+        let result = [];
+        if (Lang.isNull(this.parentContext.progression.originalCreationDate)) result.push(DateCreator);
+        return result;
+    }
+    
+    isContext() {
+        return true;
+    }
+    
+    getLabel() {
+        return this.getShortcutType();
+    }
+    
+    static getTriggers() {
+        return [{name: "#as of", description: 'Used to reference the date of the current note.'}];
+    }
+    
+    static getShortcutGroupName() {
+        return "As Of Date";
+    }
+}

--- a/src/shortcuts/ProgressionAsOfDateCreator.jsx
+++ b/src/shortcuts/ProgressionAsOfDateCreator.jsx
@@ -1,7 +1,6 @@
 import Lang from 'lodash';
 import CreatorShortcut from './CreatorShortcut';
 import DateCreator from './DateCreator';
-import Patient from '../patient/Patient';
 
 export default class ProgressionAsOfDateCreator extends CreatorShortcut {
     constructor(onUpdate, progression) {

--- a/src/shortcuts/ProgressionAsOfDateCreator.jsx
+++ b/src/shortcuts/ProgressionAsOfDateCreator.jsx
@@ -56,12 +56,12 @@ export default class ProgressionAsOfDateCreator extends CreatorShortcut {
     }
     
     shouldBeInContext() {
-        return (Lang.isNull(this.parentContext.progression.originalCreationDate));
+        return (Lang.isNull(this.parentContext.progression.asOfDate));
     }
     
     getValidChildShortcuts() {
         let result = [];
-        if (Lang.isNull(this.parentContext.progression.originalCreationDate)) result.push(DateCreator);
+        if (Lang.isNull(this.parentContext.progression.asOfDate)) result.push(DateCreator);
         return result;
     }
     

--- a/src/shortcuts/ProgressionAsOfDateCreator.jsx
+++ b/src/shortcuts/ProgressionAsOfDateCreator.jsx
@@ -11,6 +11,7 @@ export default class ProgressionAsOfDateCreator extends CreatorShortcut {
         super.initialize(contextManager, trigger);
         this.parentContext = contextManager.getActiveContextOfType("#disease status");
         if (!Lang.isUndefined(this.parentContext)) {
+            this.parentContext.setAttributeValue("asOf", true, false);
             this.parentContext.addChild(this);
         }
     }
@@ -18,6 +19,7 @@ export default class ProgressionAsOfDateCreator extends CreatorShortcut {
     onBeforeDeleted() {
         let result = super.onBeforeDeleted();
         if (result) {
+            this.parentContext.setAttributeValue("asOf", false, false);
             this.parentContext.removeChild(this);
         }
         return result;

--- a/src/shortcuts/ProgressionCreator.jsx
+++ b/src/shortcuts/ProgressionCreator.jsx
@@ -7,6 +7,7 @@ import ProgressionAsOfDateCreator from './ProgressionAsOfDateCreator';
 import lookup from '../lib/progression_lookup';
 import Patient from '../patient/Patient';
 import Lang from 'lodash'
+import moment from 'moment';
 
 
 class ProgressionCreator extends CreatorShortcut {
@@ -80,8 +81,8 @@ class ProgressionCreator extends CreatorShortcut {
     getDateString(curProgression) {
         let dateString;
         // TODO: Check with Mark about these dates
-        if (curProgression.lastUpdateDate) {
-            const formattedDate = this.formatDateToDDMMYYYY(curProgression.lastUpdateDate);
+        if (curProgression.asOfDate) {
+            const formattedDate = moment(curProgression.asOfDate, 'D MMM YYYY').format("MM/DD/YYYY");
             dateString = ` #as of #${formattedDate}`;
         } else {
             dateString = ``;
@@ -92,29 +93,12 @@ class ProgressionCreator extends CreatorShortcut {
     getReferenceDateString(curProgression) {
         let dateString;
         if(curProgression.clinicallyRelevantTime) {
-            const formattedDate = this.formatDateToDDMMYYYY(curProgression.clinicallyRelevantTime);
+            const formattedDate = moment(curProgression.clinicallyRelevantTime, 'D MMM YYYY').format('MM/DD/YYYY');
             dateString = ` relative to #reference date #${formattedDate}`;
         } else {
             dateString = ``;
         }
         return dateString;
-    }
-    
-    // This convert date format from D MMM YYYY to MM/DD/YYYY
-    // @param date is a string of a date in D MMM YYYY format
-    formatDateToDDMMYYYY(date) {
-        let reformattedDate = new Date(date);
-        let day = reformattedDate.getDate();
-        let month = reformattedDate.getMonth() + 1;
-        const year = reformattedDate.getFullYear();
-        if(day < 10) {
-            day = `0${day}`;
-        }
-        if(month < 10) {
-            month = `0${month}`;
-        }
-        reformattedDate = `${month}/${day}/${year}`;
-        return reformattedDate;
     }
     
     getAsString() { 
@@ -163,7 +147,7 @@ class ProgressionCreator extends CreatorShortcut {
 		} else if (name === "reasons") {
 			Patient.updateReasonsForProgression(this.progression, value);
         } else if (name === "asOf") {
-            this.asOf = value == true;
+            this.asOf = value === true;
 		} else if (name === "asOfDate") {
             Patient.updateAsOfDateForProgression(this.progression, value);
         } else if (name === "referenceDate") {
@@ -190,7 +174,7 @@ class ProgressionCreator extends CreatorShortcut {
             return this.asOf === true;
 		} else if (name === "asOfDate") {
             // TODO: Check with Mark on this
-            return this.progression.originalCreationDate;
+            return this.progression.asOfDate;
         } else if (name === "referenceDate") {
             return this.progression.clinicallyRelevantTime;
         } else {

--- a/src/shortcuts/ProgressionCreator.jsx
+++ b/src/shortcuts/ProgressionCreator.jsx
@@ -4,7 +4,6 @@ import CreatorShortcut from './CreatorShortcut';
 import ProgressionStatusCreator from './ProgressionStatusCreator';
 import ProgressionReasonsCreator from './ProgressionReasonsCreator';
 import ProgressionAsOfDateCreator from './ProgressionAsOfDateCreator';
-import DateCreator from './DateCreator';
 import lookup from '../lib/progression_lookup';
 import Patient from '../patient/Patient';
 import Lang from 'lodash'

--- a/src/shortcuts/ProgressionCreator.jsx
+++ b/src/shortcuts/ProgressionCreator.jsx
@@ -3,6 +3,7 @@ import CreatorShortcut from './CreatorShortcut';
 //import ProgressionForm from '../forms/ProgressionForm';
 import ProgressionStatusCreator from './ProgressionStatusCreator';
 import ProgressionReasonsCreator from './ProgressionReasonsCreator';
+import ProgressionAsOfDateCreator from './ProgressionAsOfDateCreator';
 import DateCreator from './DateCreator';
 import lookup from '../lib/progression_lookup';
 import Patient from '../patient/Patient';
@@ -226,8 +227,8 @@ class ProgressionCreator extends CreatorShortcut {
 		let result = [];
 		if (this.getAttributeValue("status").length === 0) result.push(ProgressionStatusCreator);
 		if (this.getAttributeValue("reasons").length < lookup.getReasonOptions().length) result.push(ProgressionReasonsCreator);
-        result.push(DateCreator); // TODO: This will be changed with the RelevantDate shortcut
-		return result; //[ ProgressionStatusCreator, ProgressionReasonsCreator, DateCreator ];
+        if (Lang.isNull(this.getAttributeValue("asOfDate"))) result.push(ProgressionAsOfDateCreator);
+		return result; //[ ProgressionStatusCreator, ProgressionReasonsCreator, ProgressionAsOfDateCreator ];
 	}
 	
 	isContext() {

--- a/src/shortcuts/ProgressionCreator.jsx
+++ b/src/shortcuts/ProgressionCreator.jsx
@@ -76,11 +76,11 @@ class ProgressionCreator extends CreatorShortcut {
         return reasonString
     }
 
-    getDateString(curProgression) { 
+    getDateString(curProgression) {
         let dateString;
         // TODO: Check with Mark about these dates
-        if (!Lang.isUndefined(curProgression.originalCreationDate)) {
-            const formattedDate = this.formatDateToDDMMYYYY(curProgression.originalCreationDate);
+        if (curProgression.lastUpdateDate) {
+            const formattedDate = this.formatDateToDDMMYYYY(curProgression.lastUpdateDate);
             dateString = ` #as of #${formattedDate}`;
         } else {
             dateString = ``;

--- a/src/shortcuts/ProgressionCreator.jsx
+++ b/src/shortcuts/ProgressionCreator.jsx
@@ -208,14 +208,13 @@ class ProgressionCreator extends CreatorShortcut {
     shouldBeInContext() {
         return  (this.getAttributeValue("status").length === 0) ||
                 (this.getAttributeValue("reasons").length < lookup.getReasonOptions().length) ||
-                (this.getAttributeValue("asOfDate").length === 0); // TODO: This will be changed with RelevantDate shortcut
+                (this.getAttributeValue("asOf") !== true);
     }
     
 	getValidChildShortcuts() {
 		let result = [];
 		if (this.getAttributeValue("status").length === 0) result.push(ProgressionStatusCreator);
 		if (this.getAttributeValue("reasons").length < lookup.getReasonOptions().length) result.push(ProgressionReasonsCreator);
-        //if (Lang.isNull(this.getAttributeValue("asOfDate"))) result.push(ProgressionAsOfDateCreator);
         if (this.getAttributeValue("asOf") !== true) result.push(ProgressionAsOfDateCreator);
 		return result; //[ ProgressionStatusCreator, ProgressionReasonsCreator, ProgressionAsOfDateCreator ];
 	}

--- a/src/shortcuts/ProgressionCreator.jsx
+++ b/src/shortcuts/ProgressionCreator.jsx
@@ -22,6 +22,7 @@ class ProgressionCreator extends CreatorShortcut {
             this.isProgressionNew = false;
         }
 		this.setValueObject(this.progression);
+        this.asOf = false;
         this.onUpdate = onUpdate;
 		this.setAttributeValue = this.setAttributeValue.bind(this);
         this.state = { resetReferenceDate: false }
@@ -161,6 +162,8 @@ class ProgressionCreator extends CreatorShortcut {
 			Patient.updateStatusForProgression(this.progression, value);
 		} else if (name === "reasons") {
 			Patient.updateReasonsForProgression(this.progression, value);
+        } else if (name === "asOf") {
+            this.asOf = value == true;
 		} else if (name === "asOfDate") {
             Patient.updateAsOfDateForProgression(this.progression, value);
         } else if (name === "referenceDate") {
@@ -183,6 +186,8 @@ class ProgressionCreator extends CreatorShortcut {
             return this.progression.evidence.map((e) => {
                 return e.coding.displayText;
             });
+        } else if (name === "asOf") {
+            return this.asOf === true;
 		} else if (name === "asOfDate") {
             // TODO: Check with Mark on this
             return this.progression.originalCreationDate;
@@ -226,7 +231,8 @@ class ProgressionCreator extends CreatorShortcut {
 		let result = [];
 		if (this.getAttributeValue("status").length === 0) result.push(ProgressionStatusCreator);
 		if (this.getAttributeValue("reasons").length < lookup.getReasonOptions().length) result.push(ProgressionReasonsCreator);
-        if (Lang.isNull(this.getAttributeValue("asOfDate"))) result.push(ProgressionAsOfDateCreator);
+        //if (Lang.isNull(this.getAttributeValue("asOfDate"))) result.push(ProgressionAsOfDateCreator);
+        if (this.getAttributeValue("asOf") !== true) result.push(ProgressionAsOfDateCreator);
 		return result; //[ ProgressionStatusCreator, ProgressionReasonsCreator, ProgressionAsOfDateCreator ];
 	}
 	

--- a/src/shortcuts/ShortcutManager.js
+++ b/src/shortcuts/ShortcutManager.js
@@ -14,6 +14,7 @@ import StagingNCreator from './StagingNCreator';
 import StagingMCreator from './StagingMCreator';
 import ProgressionStatusCreator from './ProgressionStatusCreator';
 import ProgressionReasonsCreator from './ProgressionReasonsCreator';
+import ProgressionAsOfDateCreator from './ProgressionAsOfDateCreator';
 import DateCreator from './DateCreator';
 import ToxicityAdverseEventCreator from './ToxicityAdverseEventCreator';
 import ToxicityGradeCreator from './ToxicityGradeCreator';
@@ -28,6 +29,7 @@ class ShortcutManager {
         '#disease status': ProgressionCreator,
         '#progression-status': ProgressionStatusCreator,
         '#progression-reasons': ProgressionReasonsCreator,
+        '#progression-as-of': ProgressionAsOfDateCreator,
         '#staging': StagingCreator,
         '#toxicity': ToxicityCreator,
         '#toxicity-adverse-event': ToxicityAdverseEventCreator,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1239,7 +1239,7 @@ clap@^1.0.9:
   dependencies:
     chalk "^1.1.3"
 
-classnames@^2.2.5:
+classnames@2.x, classnames@^2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
 
@@ -3866,7 +3866,7 @@ mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkd
   dependencies:
     minimist "0.0.8"
 
-moment@2.18.1:
+moment@2.18.1, moment@2.x:
   version "2.18.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
 
@@ -4684,6 +4684,18 @@ rc-animate@2.x:
     css-animation "^1.3.2"
     prop-types "15.x"
 
+rc-calendar@^9.0.4:
+  version "9.0.4"
+  resolved "https://registry.yarnpkg.com/rc-calendar/-/rc-calendar-9.0.4.tgz#35810a8df6428f4fb85e8debdb07bd8d2eb3c5f5"
+  dependencies:
+    babel-runtime "6.x"
+    classnames "2.x"
+    create-react-class "^15.5.2"
+    moment "2.x"
+    prop-types "^15.5.8"
+    rc-trigger "1.x"
+    rc-util "^4.0.4"
+
 rc-tooltip@^3.4.8:
   version "3.4.8"
   resolved "https://registry.yarnpkg.com/rc-tooltip/-/rc-tooltip-3.4.8.tgz#4a422374f57f3b00f4d04941863850ceddd24c56"
@@ -4703,7 +4715,7 @@ rc-trigger@1.x:
     rc-animate "2.x"
     rc-util "4.x"
 
-rc-util@4.x:
+rc-util@4.x, rc-util@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-4.0.4.tgz#99813dd90aee7e29b64939a70ac176ead3f4ff39"
   dependencies:


### PR DESCRIPTION
This creates a context for #as of and adds the shortcut #date as a child of that context. #date opens a calendar in the portal in the editor to pick a date. Let me know if this is the expected behavior.

One thing that I was unsure of and I'm open to feedback on is the decision to open a calendar in the portal. Right now, if an array of objects is returned by a shortcut, then the portal opens with a list of options instead of just inserting the text of the shortcut. In order to decide if that list should open a calendar instead of a list of options, I added a placeholder object that is structured the same as the list of options you would get with @condition. However, the portal will check if the key is equal to 'date-id' and if it is, it will open the calendar. This might not be the neatest way to do this, but was the simplest to work within the existing structure. If anyone thinks this should work differently, please just let me know.