### PR TITLE
Enable toolbar buttons

### DIFF
--- a/src/notes/EditorToolbar.css
+++ b/src/notes/EditorToolbar.css
@@ -38,7 +38,7 @@
 }
 
 .MyEditor-root .autocomplete-menu .menu-item[data-active="true"] {
-    background-color: rgba(0,0,0,0.1);
+    background-color: rgba(211,211,211,0.1);
 }
 
 .MyEditor-root p {

--- a/src/notes/EditorToolbar.css
+++ b/src/notes/EditorToolbar.css
@@ -38,7 +38,7 @@
 }
 
 .MyEditor-root .autocomplete-menu .menu-item[data-active="true"] {
-    background-color: rgba(211,211,211,0.1);
+    background-color: rgba(0,0,0,0.1);
 }
 
 .MyEditor-root p {

--- a/src/notes/EditorToolbar.jsx
+++ b/src/notes/EditorToolbar.jsx
@@ -61,7 +61,7 @@ class EditorToolbar extends React.Component {
      * Render a block-toggling toolbar button.
      */
     renderBlockButton = (type, icon) => {
-        const isActive = this.handleBlockCheck(type)
+        const isActive = this.handleBlockCheck(type + '-item')
         const onMouseDown = e => this.onClickBlock(e, type)
 
         return (

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -377,7 +377,7 @@ class FluxNotesEditor extends React.Component {
     handleBlockUpdate = (type) =>  {
         let { state } = this.state;
         const transform = state.transform();
-        const DEFAULT_NODE = 'paragraph';
+        const DEFAULT_NODE = "";
 
         // Handle list buttons.
         if (type === 'bulleted-list' || type === 'numbered-list') {

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -23,9 +23,14 @@ const schema = {
     nodes: {
         paragraph: props => <p {...props.attributes}>{props.children}</p>,
         heading: props => <h1 {...props.attributes}>{props.children}</h1>,
+        'list-item':     props => <li {...props.attributes}>{props.children}</li>,  
+        'bulleted-list': props => <ul {...props.attributes}>{props.children}</ul>,
+        'numbered-list': props => <ol {...props.attributes}>{props.children}</ol>,
     },
     marks: {
-        bold: (props) => <strong>{props.children}</strong>
+        bold: (props) => <strong>{props.children}</strong>,
+        italic: (props) => <em>{props.children}</em>,
+        underlined: (props) => <u>{props.children}</u>,      
     }
 };
 
@@ -347,8 +352,58 @@ class FluxNotesEditor extends React.Component {
      */
     handleBlockCheck = (type) => {
         const {state} = this.state;
-        return state.blocks.some(node => node.type === type);
+    return state.blocks.some(node => node.type === type);
+    }    
+    
+      /**
+       * Handle any changes to the current mark type.
+       */
+    handleMarkUpdate = (type) =>  {
+        let { state } = this.state
+        state = state
+         .transform()
+         .toggleMark(type)
+         .apply()
+       this.setState({ state });
     }
+
+      /**
+       * Handle any changes to the current block type.
+       */
+    handleBlockUpdate = (type) =>  {
+        let { state } = this.state;
+        const transform = state.transform();
+        const DEFAULT_NODE = 'paragraph';
+
+        // Handle list buttons.
+        if (type === 'bulleted-list' || type === 'numbered-list') {
+          const isList = this.handleBlockCheck('list-item')
+          const ParentNode = state.document.getParent(state.selection.startKey);
+          console.log(ParentNode.type);
+
+
+          if (isList) {
+            transform
+              .setBlock(DEFAULT_NODE)
+              .unwrapBlock('bulleted-list')
+              .unwrapBlock('numbered-list')
+          } else if (isList) {
+            transform
+              .unwrapBlock(type === 'bulleted-list' ? 'numbered-list' : 'bulleted-list')
+              .wrapBlock(type)
+          } else {
+            transform
+              .setBlock('list-item')
+              .wrapBlock(type)
+          }
+        } else {
+          // We don't handle any other kinds of block style formatting right now, but if we did it would go here.
+        }
+
+        state = transform.apply()
+        this.setState({ state });
+    
+    }        
     
     render = () => {
         const CreatorsPortal = this.suggestionsPluginCreators.SuggestionPortal;

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -23,7 +23,8 @@ const schema = {
     nodes: {
         paragraph: props => <p {...props.attributes}>{props.children}</p>,
         heading: props => <h1 {...props.attributes}>{props.children}</h1>,
-        'list-item':     props => <li {...props.attributes}>{props.children}</li>,  
+        'bulleted-list-item':     props => <li {...props.attributes}>{props.children}</li>,
+        'numbered-list-item':     props => <li {...props.attributes}>{props.children}</li>,        
         'bulleted-list': props => <ul {...props.attributes}>{props.children}</ul>,
         'numbered-list': props => <ol {...props.attributes}>{props.children}</ol>,
     },
@@ -352,7 +353,10 @@ class FluxNotesEditor extends React.Component {
      */
     handleBlockCheck = (type) => {
         const {state} = this.state;
-    return state.blocks.some(node => node.type === type);
+           return state.blocks.some((node) => {
+               return node.type === type;
+
+           }); 
     }    
     
       /**
@@ -377,9 +381,7 @@ class FluxNotesEditor extends React.Component {
 
         // Handle list buttons.
         if (type === 'bulleted-list' || type === 'numbered-list') {
-          const isList = this.handleBlockCheck('list-item')
-          const ParentNode = state.document.getParent(state.selection.startKey);
-          console.log(ParentNode.type);
+          const isList = this.handleBlockCheck(type + '-item')
 
 
           if (isList) {
@@ -393,7 +395,7 @@ class FluxNotesEditor extends React.Component {
               .wrapBlock(type)
           } else {
             transform
-              .setBlock('list-item')
+              .setBlock(type + '-item')
               .wrapBlock(type)
           }
         } else {


### PR DESCRIPTION
The toolbar is now active. When you click on one of the buttons it will bold the symbol and as you type in the editor the text with have the right style. Once you delete all text with that specified style in the editor the button will gray out again. For bulleted-list and numbered-list only the button can toggle them on and off once you backspace to the initial bullet/number. I have added a issue in JIRA for this since I wanted to get this pull request in before the end of the sprint and I believe that might take a little more investigation since the current slate demo for the toolbar also has this problem (http://slatejs.org/#/rich-text)