### PR TITLE
Removed public url line

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,1 @@
-PUBLIC_URL=http://localhost:3000/patina
 BROWSER=http://localhost:3000/patina


### PR DESCRIPTION
In order to get flux notes to deploy on the server, needed to remove the public url from the .env file. Worked with Greg on this issue