### PR TITLE
Remove ripple from copy button (couldn't change ripple color). 

### DIFF
--- a/src/viewer/ShortcutViewer.jsx
+++ b/src/viewer/ShortcutViewer.jsx
@@ -1,4 +1,5 @@
 import React, {Component} from 'react';
+import ReactDOM from 'react-dom';
 import CopyToClipboard from 'react-copy-to-clipboard';
 import Button from 'material-ui/Button';
 import LandingPageForm from '../forms/LandingPageForm';
@@ -30,6 +31,7 @@ class ShortcutViewer extends Component {
                     <Button 
                         raised 
                         className="btn_copy"
+                        ref="copyButton"
                         style={{
                             textTransform: "none",
                             justifyContent: 'left',
@@ -39,7 +41,9 @@ class ShortcutViewer extends Component {
                             backgroundColor: "white"
                         }}
                         focusRipple={false}
-                        onClick={function () { document.getElementsByClassName('btn_copy')[0].blur()}}
+                        onClick={() => {
+                            ReactDOM.findDOMNode(this.refs.copyButton).blur();
+                        }}
                     > 
                         <div id="copy-keyword">
                             Copy

--- a/src/viewer/ShortcutViewer.jsx
+++ b/src/viewer/ShortcutViewer.jsx
@@ -39,6 +39,7 @@ class ShortcutViewer extends Component {
                             backgroundColor: "white"
                         }}
                         focusRipple={false}
+                        onClick={function () { document.getElementsByClassName('btn_copy')[0].blur()}}
                     > 
                         <div id="copy-keyword">
                             Copy

--- a/src/viewer/ShortcutViewer.jsx
+++ b/src/viewer/ShortcutViewer.jsx
@@ -38,7 +38,8 @@ class ShortcutViewer extends Component {
                             padding: "5px 0 4px 0",
                             backgroundColor: "white"
                         }}
-                    >
+                        focusRipple={false}
+                    > 
                         <div id="copy-keyword">
                             Copy
                         </div>


### PR DESCRIPTION
Shocker: Turns out changing the color of the ripples is, as far as I can tell, obscured away from us. I tried playing with MUIThemeProvider and specifying ripple styling – no luck. I tried passing a prop called rippleColor with new value – no luck. (N.B. these were the top stack overflow suggestions I could find).

One alternative solution would be to disable the ripples on the copy button altogether, and blur focus from the button onClick. I've implemented this and have it on a branch, but we should review it as a team and decide if this is something we want. Furthermore, if someone can see how to change ripple color, we should implement that and consider it as an option -- I wasn't able to in the timebox I allotted.  