### PR TITLE
Shortcut refactoring + more (554, 519, 526, 555, 595)

### DIFF
--- a/src/context/ContextOptions.jsx
+++ b/src/context/ContextOptions.jsx
@@ -30,7 +30,7 @@ export default class ContextOptions extends Component {
         // count how many triggers we have
         let count = 0;
         validShortcuts.forEach((shortcut, i) => {
-            shortcut.getTriggers(context).forEach((trigger, j) => {
+            shortcut.getStringTriggers(context).forEach((trigger, j) => {
                 count++;
             });
         });
@@ -46,7 +46,7 @@ export default class ContextOptions extends Component {
             if(typeof shortcut.getShortcutGroupName !== 'undefined'){
                 groupName = shortcut.getShortcutGroupName();
             }
-            shortcut.getTriggers(context).forEach((trigger, j) => {
+            shortcut.getStringTriggers(context).forEach((trigger, j) => {
                 if (!showFilter || this.state.searchString.length === 0 || trigger.name.toLowerCase().indexOf(this.state.searchString.toLowerCase()) !== -1) {
                     let triggerDescription = !Lang.isNull(trigger.description) ? trigger.description : '';
                     triggers.push({"name": trigger.name, "description": triggerDescription, "group": i, "groupName": groupName });

--- a/src/noteparser/NoteParser.js
+++ b/src/noteparser/NoteParser.js
@@ -25,7 +25,7 @@ export default class NoteParser {
         let allShortcuts = this.shortcutManager.getAllShortcutClasses();
         let curTriggers;
         allShortcuts.forEach((shortcutC) => {
-            curTriggers = shortcutC.getTriggers().map((obj) => { return obj.name; });;
+            curTriggers = shortcutC.getStringTriggers().map((obj) => { return obj.name; });;
             allTriggers = allTriggers.concat(curTriggers);          
             curTriggers.forEach((item) => {
                 this.triggerMap[item.toLowerCase()] = shortcutC; 

--- a/src/noteparser/NoteParser.js
+++ b/src/noteparser/NoteParser.js
@@ -2,7 +2,7 @@ import Patient from '../patient/Patient';
 import ShortcutManager from '../shortcuts/ShortcutManager';
 import ContextManager from '../context/ContextManager';
 import Lang from 'lodash'
-import util from 'util';
+//import util from 'util';
 
 export default class NoteParser {
     constructor(shortcutManager = undefined, contextManager = undefined) {
@@ -20,6 +20,7 @@ export default class NoteParser {
         this.allTriggersRegExp = undefined;
         this.triggerMap = {};
         
+        // build up all trigger string regular expression
         let allTriggers = [];
         let allShortcuts = this.shortcutManager.getAllShortcutClasses();
         let curTriggers;
@@ -30,7 +31,18 @@ export default class NoteParser {
                 this.triggerMap[item.toLowerCase()] = shortcutC; 
             });
         });
-        this.allTriggersRegExp = new RegExp("(" + allTriggers.join("|") + ")", 'gi');
+        this.allTriggersRegExp = new RegExp("(" + allTriggers.join("|") + ")", 'i');
+        
+        // build list of regular expression triggers
+        this.allTriggersRegExps = [];
+        let regexp;
+        allShortcuts.forEach((shortcutC) => {
+           regexp = shortcutC.getTriggerRegExp(); 
+           if (!Lang.isNull(regexp)) {
+               this.allTriggersRegExps.push({ regexp: regexp, shortcut: shortcutC});
+           }
+        });
+        
         this.patientRecord = [];
     }
     
@@ -39,36 +51,104 @@ export default class NoteParser {
     }
     
     createShortcut(trigger) {
-        const shortcutC = this.triggerMap[trigger.toLowerCase()];
+        let shortcutC;
+        if (!Lang.isNull(trigger.shortcut)) {
+            shortcutC = trigger.shortcut;
+        } else {
+            shortcutC = this.triggerMap[trigger.trigger.toLowerCase()];
+            
+        }
         const shortcut = new shortcutC();
-        shortcut.initialize(this.contextManager, trigger);
+        shortcut.initialize(this.contextManager, trigger.trigger);
         shortcut.setKey(null);
         return shortcut;
     }
-    
+        
     getListOfTriggersFromText(note) {
-        const matches =  note.match(this.allTriggersRegExp);
+        let unrecognizedTriggers = [];
+        const triggerChars = [ '#', '@' ];
+        let pos = 0;
+        let matches = [];
+        let match, substr, nextPos, found;
+        let hashPos = this.getNextTriggerIndex(note, triggerChars, pos);
+        let checkForTriggerRegExpMatch = (tocheck) => {
+            //console.log(tocheck.regexp + " against '" + substr + "'");
+            match = substr.match(tocheck.regexp);
+            if (!Lang.isNull(match)) {
+                //console.log("matched " + tocheck.regexp);
+                matches.push({trigger: match[0], shortcut: tocheck.shortcut});
+                found = true;
+            }
+        }
+        while (hashPos !== -1) {
+            //console.log(hashPos);
+            nextPos = this.getNextTriggerIndex(note, triggerChars, hashPos + 1);
+            if (nextPos === -1) {
+                substr = note.substring(hashPos);
+            } else {
+                substr = note.substring(hashPos, nextPos);
+            }
+            match = substr.match(this.allTriggersRegExp);
+            if (Lang.isNull(match)) {
+                found = false;
+                this.allTriggersRegExps.forEach(checkForTriggerRegExpMatch);
+                if (!found) {
+                    //console.log("not a recognized structured phrase: " + substr);
+                    unrecognizedTriggers.push(substr);
+                }
+            } else {
+                //console.log(match[0]);
+                matches.push({trigger: match[0], shortcut: null});
+            }
+            pos = hashPos + 1;
+            hashPos = nextPos;
+        }
+        return [ matches, unrecognizedTriggers ];
+// if putting below code back in, add global flag to allTriggersRegExp in constructor
+/*        const matches =  note.match(this.allTriggersRegExp);
         if (Lang.isNull(matches)) { 
             return [];
         } else { 
             return matches;
-        }
+        }*/
+    }
+    
+    getNextTriggerIndex(note, triggerPrefixes, pos) {
+        let indexes = triggerPrefixes.map((triggerPrefix) => {
+            return note.indexOf(triggerPrefix, pos);
+        });
+        let triggerPos = -1;
+        indexes.forEach((i) => {
+            if (i >= 0) {
+                if (triggerPos === -1) {
+                    triggerPos = i;
+                } else {
+                    triggerPos = Math.min(triggerPos, i);
+                }
+            }
+        });
+/*        let triggerPos = note.indexOf('#', pos);
+        let triggerPos2 = note.indexOf('@', pos);
+        if (atPos != -1 && atPos < hashPos) hashPos = atPos;
+ */       
+        return triggerPos;
     }
     
     parse(note) {
         this.patientRecord = [];
         // console.log("parse: " + note);
-        const structuredPhrases = this.getListOfTriggersFromText(note);
+        const result = this.getListOfTriggersFromText(note);
+        const structuredPhrases = result[0];
         //console.log(structuredPhrases);
         let data = structuredPhrases.map(this.createShortcut.bind(this));
         let dataObj;
         data.forEach((item) => {
             dataObj = item.getValueObject();
             if (!Lang.isUndefined(dataObj)) {
-                console.log(util.inspect(dataObj, false, null));
+                //console.log(util.inspect(dataObj, false, null));
                 this.patientRecord.push(dataObj);
             }
         });
-        return this.patientRecord;
+        return [ this.patientRecord, result[1] ];
     }
 }

--- a/src/noteparser/app.js
+++ b/src/noteparser/app.js
@@ -32,13 +32,17 @@ let noteParser = new NoteParser();
 
 let perFileFunc = (file) => {
     let content;
+    let result;
     //console.log(content);
     fs.readFile(file, 'utf8', function (err,data) {
         if (err) {
             return console.error(err);
         }
         content = util.format(data);
-        noteParser.parse(content);
+        result = noteParser.parse(content);
+        console.log(util.inspect(result[0], false, null));
+        console.log("Unrecognized structured phrases:");
+        console.log(result[1]);
     });
 };
 

--- a/src/noteparser/samples/note7.txt
+++ b/src/noteparser/samples/note7.txt
@@ -1,0 +1,1 @@
+#toxicity of #not a valid phrase #Grade 3 #Blood and lymphatic system disorders - Other, specify related to #Unrelated

--- a/src/noteparser/samples/note8.txt
+++ b/src/noteparser/samples/note8.txt
@@ -1,0 +1,5 @@
+testing. unknown patient.
+
+#disease status is #Complete Response  based on #Physical exam, #Markers, #Pathology #as of #10/5/2017 #reference date #5/2/2017
+
+more text. more stuff. no extra hash tags!

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -258,8 +258,10 @@ class FluxNotesEditor extends React.Component {
     }
     
     insertStructuredFieldTransform(transform, shortcut) {
+        //console.log(shortcut);
         if (Lang.isNull(shortcut)) return transform.focus();
         let result = this.structuredFieldPlugin.transforms.insertStructuredField(transform, shortcut); //2nd param needs to be Shortcut Object, how to create?
+        //console.log(result[0]);
         return result[0];
     }
 
@@ -324,16 +326,18 @@ class FluxNotesEditor extends React.Component {
         let remainder = itemToBeInserted;
         let start, before, end, after;
         
-        const triggers = this.noteParser.getListOfTriggersFromText(itemToBeInserted);
+        const triggers = this.noteParser.getListOfTriggersFromText(itemToBeInserted)[0];
+        //console.log(triggers);
         if (!Lang.isNull(triggers)) {
             triggers.forEach((trigger) => {
-                start = remainder.indexOf(trigger);
+                //console.log(trigger);
+                start = remainder.indexOf(trigger.trigger);
                 if (start > 0) {
                     before = remainder.substring(0, start);
                     //transform = transform.insertText(before);
                     transform = this.insertPlainText(transform, before);
                 }
-                remainder = remainder.substring(start + trigger.length);
+                remainder = remainder.substring(start + trigger.trigger.length);
                 if (remainder.startsWith("[[")) {
                     end = remainder.indexOf("]]");
                     after = remainder.substring(2, end);
@@ -341,7 +345,8 @@ class FluxNotesEditor extends React.Component {
                 } else {
                     after = "";
                 }
-                transform = this.insertShortcut(null, trigger, after, transform);
+                //console.log(remainder);
+                transform = this.insertShortcut(trigger.shortcut, trigger.trigger, after, transform);
             });
         }
 
@@ -351,6 +356,7 @@ class FluxNotesEditor extends React.Component {
         }
         state = transform.focus().apply();
         this.setState({state: state});
+        //return state;
     }
 
     /**

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -109,7 +109,7 @@ class FluxNotesEditor extends React.Component {
         let autoReplaceAfters = [];
         let allShortcuts = this.props.shortcutManager.getAllShortcutClasses();
         allShortcuts.forEach((shortcutC) => {
-            const shortcutNamesList = shortcutC.getTriggers().map(trigger => trigger.name);
+            const shortcutNamesList = shortcutC.getStringTriggers().map(trigger => trigger.name);
             autoReplaceAfters = autoReplaceAfters.concat(shortcutNamesList);
         });
         this.autoReplaceBeforeRegExp = new RegExp("(" + autoReplaceAfters.join("|") + ")", 'i');
@@ -141,7 +141,7 @@ class FluxNotesEditor extends React.Component {
         let suggestionsShortcuts = [];
         const textLowercase = text.toLowerCase();
         shortcuts.forEach((shortcut) => {
-            const triggers = shortcut.getTriggers();
+            const triggers = shortcut.getStringTriggers();
             triggers.forEach((trigger) => {
                 const triggerNoPrefix = trigger.name.substring(1);
                 if (trigger.name.substring(0, 1) === initialChar && triggerNoPrefix.toLowerCase().includes(textLowercase)) {

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -147,7 +147,11 @@ function StructuredFieldPlugin(opts) {
             } else if (blk.kind === 'inline' && blk.type === 'structured_field') {
                 let shortcut = blk.data.get("shortcut");
                 if (shortcut instanceof InserterShortcut || Lang.isArray(shortcut.determineText(contextManager))) {
-                    result += `${shortcut.getShortcutType()}[[${shortcut.getText()}]]`;
+                    let text = shortcut.getText();
+                    if (text.startsWith(shortcut.getPrefixCharacter())) {
+                        text = text.substring(1);
+                    }
+                    result += `${shortcut.getShortcutType()}[[${text}]]`;
                 } else {
                     result += shortcut.getText();
                 }
@@ -197,7 +201,7 @@ function StructuredFieldPlugin(opts) {
     }
 
     function onCopy(event, data, state, editor) {
-        // console.log("onCopy");
+        //console.log("onCopy");
         let { selection } = state;
    
         const window = getWindow(event.target);
@@ -212,7 +216,7 @@ function StructuredFieldPlugin(opts) {
 
         //console.log(state.document);
         let fluxString = convertToText(state, selection);
-        // console.log("copy: " + fluxString);
+        //console.log("copy: " + fluxString);
         const encoded = window.btoa(window.encodeURIComponent(fluxString));
         const range = native.getRangeAt(0);
         let contents = range.cloneContents();
@@ -258,7 +262,7 @@ function StructuredFieldPlugin(opts) {
         if (contents.childNodes.length > 1) {
             contents.childNodes[1].setAttribute('flux-string', encoded);
         }
-        // console.log(attach);
+        //console.log(attach);
 
         // Add the phony content to the DOM, and select it, so it will be copied.
         const body = window.document.querySelector('body');

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -82,7 +82,6 @@ function StructuredFieldPlugin(opts) {
     function onPaste(event, data, state, editor) {
         //console.log("onPaste");
         const html = data.html || null; //event.clipboardData.getData('text/html') || null;
-        
         //console.log(html);
         let fragment = null;
         if (
@@ -106,6 +105,10 @@ function StructuredFieldPlugin(opts) {
             insertText(decoded);
             contextManager.setIsBlock1BeforeBlock2(saveIsBlock1BeforeBlock2);
             event.preventDefault();
+            return state;
+        } else if (data.text) {
+            event.preventDefault();
+            insertText(data.text);
             return state;
         }
     }
@@ -317,7 +320,7 @@ function insertStructuredField(opts, transform, shortcut) {
     const sf = createStructuredField(opts, shortcut);
 
     shortcut.setKey(sf.key);
-	if (sf.kind === 'block') {
+    if (sf.kind === 'block') {
 		return [transform.insertBlock(sf), sf.key];
 	} else {
 		return [transform.insertInline(sf), sf.key];

--- a/src/shortcuts/AgeInserter.jsx
+++ b/src/shortcuts/AgeInserter.jsx
@@ -7,7 +7,7 @@ export default class AgeInserter extends InserterShortcut {
     getShortcutType() { 
         return "@age";
     }
-	static getTriggers() {
+	static getStringTriggers() {
 		return [ {name:"@age", description: "Patient's age in years as of today"} ];
 	}
 }

--- a/src/shortcuts/ConditionInserter.jsx
+++ b/src/shortcuts/ConditionInserter.jsx
@@ -26,7 +26,7 @@ export default class ConditionInserter extends InserterShortcut {
         });
 	}
     
-	static getTriggers() {
+	static getStringTriggers() {
 		return [ {name: "@condition", description: "Prompts you to choose an active condition from the patient’s record"} ];
 	}
     getShortcutType() { 

--- a/src/shortcuts/DateCreator.jsx
+++ b/src/shortcuts/DateCreator.jsx
@@ -8,9 +8,13 @@ export default class DateCreator extends CreatorShortcut {
     
     initialize(contextManager, trigger) {
         super.initialize(contextManager, trigger);
-        this.text = trigger;
+        //this.text = trigger;
         this.parentContext = contextManager.getCurrentContext();
         this.parentContext.addChild(this);
+        if (trigger !== "#date") {
+            this.setText(trigger);
+            this.clearValueSelectionOptions();
+        }
     }
     
     onBeforeDeleted() {
@@ -52,6 +56,10 @@ export default class DateCreator extends CreatorShortcut {
     static getTriggers() {
         let result = [{name: `#date`, description: "A date."}];
         return result;
+    }
+    
+    static getTriggerRegExp() {
+        return /^(#\d{1,2}\/\d{1,2}\/\d{4})$/;
     }
     
     static getDescription() {

--- a/src/shortcuts/DateCreator.jsx
+++ b/src/shortcuts/DateCreator.jsx
@@ -1,5 +1,6 @@
 import CreatorShortcut from './CreatorShortcut';
 import moment from 'moment';
+import Lang from 'lodash';
 
 export default class DateCreator extends CreatorShortcut {
     constructor(onUpdate, obj) {
@@ -10,7 +11,9 @@ export default class DateCreator extends CreatorShortcut {
         super.initialize(contextManager, trigger);
         //this.text = trigger;
         this.parentContext = contextManager.getCurrentContext();
-        this.parentContext.addChild(this);
+        if (!Lang.isUndefined(this.parentContext)) {
+            this.parentContext.addChild(this);
+        }
         if (trigger !== "#date") {
             this.setText(trigger);
             this.clearValueSelectionOptions();
@@ -37,7 +40,9 @@ export default class DateCreator extends CreatorShortcut {
         }
         super.setText(text);
         const formattedDate = moment(text, 'MM-DD-YYYY').format('D MMM YYYY');
-        this.parentContext.setAttributeValue("date", formattedDate, false);
+        if (!Lang.isUndefined(this.parentContext)) {
+            this.parentContext.setAttributeValue("date", formattedDate, false);
+        }
     }
     
     getText() {

--- a/src/shortcuts/DateCreator.jsx
+++ b/src/shortcuts/DateCreator.jsx
@@ -64,7 +64,8 @@ export default class DateCreator extends CreatorShortcut {
     }
     
     static getTriggerRegExp() {
-        return /^(#\d{1,2}\/\d{1,2}\/\d{4})$/;
+        //return /^(#\d{1,2}\/\d{1,2}\/\d{4})$/;
+        return /(#\d{1,2}\/\d{1,2}\/\d{4})/;
     }
     
     static getDescription() {

--- a/src/shortcuts/DateCreator.jsx
+++ b/src/shortcuts/DateCreator.jsx
@@ -22,7 +22,7 @@ export default class DateCreator extends CreatorShortcut {
     
     onBeforeDeleted() {
         let result = super.onBeforeDeleted();
-        if(result) {
+        if(result && !Lang.isUndefined(this.parentContext)) {
             this.parentContext.setAttributeValue("date", null, false);
             this.parentContext.removeChild(this);
         }

--- a/src/shortcuts/DateCreator.jsx
+++ b/src/shortcuts/DateCreator.jsx
@@ -58,13 +58,12 @@ export default class DateCreator extends CreatorShortcut {
         return errors;
     }
     
-    static getTriggers() {
+    static getStringTriggers() {
         let result = [{name: `#date`, description: "A date."}];
         return result;
     }
     
     static getTriggerRegExp() {
-        //return /^(#\d{1,2}\/\d{1,2}\/\d{4})$/;
         return /(#\d{1,2}\/\d{1,2}\/\d{4})/;
     }
     

--- a/src/shortcuts/DateOfBirthInserter.jsx
+++ b/src/shortcuts/DateOfBirthInserter.jsx
@@ -9,7 +9,7 @@ export default class DateOfBirthInserter extends InserterShortcut {
     getShortcutType() { 
         return "@dateOfbirth";
     }
-	static getTriggers() {
+	static getStringTriggers() {
 		return [{name: "@dateofbirth", description: "Patient's date of birth in DD.MMM.YYYY format (e.g., 5 APR 1966)"}];
 	}
 }

--- a/src/shortcuts/GenderInserter.jsx
+++ b/src/shortcuts/GenderInserter.jsx
@@ -7,7 +7,7 @@ export default class GenderInserter extends InserterShortcut {
     getShortcutType() { 
         return "@gender";
     }
-	static getTriggers() {
+	static getStringTriggers() {
 		return [{name: "@gender", description: "Patient’s gender classification for administrative purposes (may differ from biological, clinical, or gender identity)"} ];
 	}
 }

--- a/src/shortcuts/NameInserter.jsx
+++ b/src/shortcuts/NameInserter.jsx
@@ -9,7 +9,7 @@ export default class NameInserter extends InserterShortcut {
         return "@name";
     }
 
-	static getTriggers() {
+	static getStringTriggers() {
 		return [ {name:"@name", description: "Patient's given and family name"} ];
 	}
 }

--- a/src/shortcuts/PatientInserter.jsx
+++ b/src/shortcuts/PatientInserter.jsx
@@ -9,7 +9,7 @@ export default class PatientInserter extends InserterShortcut {
     getShortcutType() { 
         return "@patient";
     }
-	static getTriggers() {
+	static getStringTriggers() {
 		return [ {name:"@patient", description: "Basic patient information (e.g. Debra Hernandez672 is a 51 year old female)"} ];
 	}
 }

--- a/src/shortcuts/ProgressionAsOfDateCreator.jsx
+++ b/src/shortcuts/ProgressionAsOfDateCreator.jsx
@@ -73,7 +73,7 @@ export default class ProgressionAsOfDateCreator extends CreatorShortcut {
         return this.getShortcutType();
     }
     
-    static getTriggers() {
+    static getStringTriggers() {
         return [{name: "#as of", description: 'Used to reference the date of the current note.'}];
     }
     

--- a/src/shortcuts/ProgressionCreator.jsx
+++ b/src/shortcuts/ProgressionCreator.jsx
@@ -230,7 +230,7 @@ class ProgressionCreator extends CreatorShortcut {
 	getLabel() {
 		return this.getShortcutType();
 	}
-	static getTriggers() {
+	static getStringTriggers() {
         return [{ name: "#disease status", description: lookup.getDescription('progression') }];
 	}
     static getDescription() {

--- a/src/shortcuts/ProgressionReasonsCreator.jsx
+++ b/src/shortcuts/ProgressionReasonsCreator.jsx
@@ -51,7 +51,7 @@ export default class ProgressionReasonsCreator extends CreatorShortcut {
 		return errors;
 	}
 	
-    static getTriggers(parentContext = undefined) {
+    static getStringTriggers(parentContext = undefined) {
         let currentReasons = [];
         if (!Lang.isUndefined(parentContext)) {
             currentReasons = parentContext.getAttributeValue("reasons");

--- a/src/shortcuts/ProgressionReferenceDateCreator.jsx
+++ b/src/shortcuts/ProgressionReferenceDateCreator.jsx
@@ -73,7 +73,7 @@ export default class ProgressionReferenceDateCreator extends CreatorShortcut {
         return this.getShortcutType();
     }
     
-    static getTriggers() {
+    static getStringTriggers() {
         return [{name: "#reference date", description: 'Used to reference the date of a past clinical note.'}];
     }
     

--- a/src/shortcuts/ProgressionStatusCreator.jsx
+++ b/src/shortcuts/ProgressionStatusCreator.jsx
@@ -45,7 +45,7 @@ export default class ProgressionStatusCreator extends CreatorShortcut {
 		return errors;
 	}
 	
-	static getTriggers() {
+	static getStringTriggers() {
 		const statusOptions = lookup.getStatusOptions();
 		let result = [];
 		statusOptions.forEach((val) => {

--- a/src/shortcuts/Shortcut.jsx
+++ b/src/shortcuts/Shortcut.jsx
@@ -84,6 +84,9 @@ class Shortcut extends Context {
         }
         return true;
     }
+    static getTriggerRegExp() {
+        return null;
+    }
 }
 
 export default Shortcut;

--- a/src/shortcuts/ShortcutManager.js
+++ b/src/shortcuts/ShortcutManager.js
@@ -20,6 +20,7 @@ import DateCreator from './DateCreator';
 import ToxicityAdverseEventCreator from './ToxicityAdverseEventCreator';
 import ToxicityGradeCreator from './ToxicityGradeCreator';
 import ToxicityAttributionCreator from './ToxicityAttributionCreator';
+import Lang from 'lodash';
 
 function addTriggerForKey(trigger) {
     this.shortcutMap[trigger.name.toLowerCase()] = this.shortcuts[this.currentShortcut];
@@ -71,11 +72,16 @@ class ShortcutManager {
         return this.shortcutsToSupportList;
     }
     
-    createShortcut(trigger, onUpdate, object) {
+    createShortcut(shortcutC, trigger, onUpdate, object) {
 /*        if (!Lang.includes(this.shortcutsToSupportList, shortcutType.toLowerCase())) {
             throw new Error("Invalid shortcut type: " + shortcutType);
         }*/
-        let className = this.shortcutMap[trigger.toLowerCase()];
+        let className;
+        if (!Lang.isNull(shortcutC)) {
+            className = shortcutC;
+        } else {
+            className = this.shortcutMap[trigger.toLowerCase()];
+        }
         return new className(onUpdate, object);
     }
 }

--- a/src/shortcuts/ShortcutManager.js
+++ b/src/shortcuts/ShortcutManager.js
@@ -62,7 +62,7 @@ class ShortcutManager {
         this.shortcutsToSupportList = shortcutList;
         for (var key in this.shortcuts) {
             this.shortcutClasses.push(this.shortcuts[key]);
-            const triggers = this.shortcuts[key].getTriggers();
+            const triggers = this.shortcuts[key].getStringTriggers();
             this.currentShortcut = key;
             triggers.forEach(addTriggerForKey, this);
         }        

--- a/src/shortcuts/StageInserter.jsx
+++ b/src/shortcuts/StageInserter.jsx
@@ -24,7 +24,7 @@ export default class StageInserter extends InserterShortcut {
         return "@stage";
     }
 	
-	static getTriggers() {
+	static getStringTriggers() {
 		return [{name: "@stage", description: "Patient's stage"}];
 	}
 }

--- a/src/shortcuts/StagingCreator.jsx
+++ b/src/shortcuts/StagingCreator.jsx
@@ -194,7 +194,7 @@ class StagingCreator extends CreatorShortcut {
 	getLabel() {
 		return this.getShortcutType();
 	}
-	static getTriggers() {
+	static getStringTriggers() {
 		return [{ name: "#staging", description: lookup.getDescription("TNMStage")}];
 	}
     

--- a/src/shortcuts/StagingMCreator.jsx
+++ b/src/shortcuts/StagingMCreator.jsx
@@ -45,7 +45,7 @@ export default class StagingMCreator extends CreatorShortcut {
 		return errors;
 	}
 	
-	static getTriggers() {
+	static getStringTriggers() {
 		const ms = lookup.getMsForEdition(7);
 		let result = [];
 		ms.forEach((val) => {

--- a/src/shortcuts/StagingNCreator.jsx
+++ b/src/shortcuts/StagingNCreator.jsx
@@ -44,7 +44,7 @@ export default class StagingNCreator extends CreatorShortcut {
 		}
 		return errors;
 	}
-	static getTriggers() {
+	static getStringTriggers() {
 		const ns = lookup.getNsForEdition(7);
 		let result = [];
 		ns.forEach((val) => {

--- a/src/shortcuts/StagingTCreator.jsx
+++ b/src/shortcuts/StagingTCreator.jsx
@@ -44,7 +44,7 @@ export default class StagingTCreator extends CreatorShortcut {
 		return errors;
 	}
 
-	static getTriggers() {
+	static getStringTriggers() {
 		const ts = lookup.getTsForEdition(7);
 		let result = [];
 		ts.forEach((val) => {

--- a/src/shortcuts/ToxicityAdverseEventCreator.jsx
+++ b/src/shortcuts/ToxicityAdverseEventCreator.jsx
@@ -46,7 +46,7 @@ export default class ToxicityAdverseEventCreator extends CreatorShortcut {
 		return errors;
 	}
 	
-	static getTriggers(parentContext = undefined) {
+	static getStringTriggers(parentContext = undefined) {
         let currentGrade = "", adverseEvents;
         if (!Lang.isUndefined(parentContext)) {
             currentGrade = parentContext.getAttributeValue("grade");

--- a/src/shortcuts/ToxicityAttributionCreator.jsx
+++ b/src/shortcuts/ToxicityAttributionCreator.jsx
@@ -47,7 +47,7 @@ export default class ToxicityAttributionCreator extends CreatorShortcut {
         return errors;
     }
     
-    static getTriggers(parentContext = undefined) {
+    static getStringTriggers(parentContext = undefined) {
         let attributionOptions = lookup.getAttributionOptions();
         let result = [];
         attributionOptions.forEach(attribution => result.push({name: "#" + attribution.name, description: attribution.description}));

--- a/src/shortcuts/ToxicityCreator.jsx
+++ b/src/shortcuts/ToxicityCreator.jsx
@@ -200,7 +200,7 @@ class ToxicityCreator extends CreatorShortcut {
     getLabel() {
         return this.getShortcutType();
     }
-    static getTriggers() {
+    static getStringTriggers() {
         return [{name: "#toxicity", description: lookup.getDescription('toxicity')}];
     }
      static getDescription() {

--- a/src/shortcuts/ToxicityGradeCreator.jsx
+++ b/src/shortcuts/ToxicityGradeCreator.jsx
@@ -46,7 +46,7 @@ export default class ToxicityGradeCreator extends CreatorShortcut {
 		return errors;
 	}
 	
-	static getTriggers(parentContext = undefined) {
+	static getStringTriggers(parentContext = undefined) {
         let currentAdverseEvent = "", gradeOptions;
         if (!Lang.isUndefined(parentContext)) {
             currentAdverseEvent = parentContext.getAttributeValue("adverseEvent");

--- a/src/views/FullApp.jsx
+++ b/src/views/FullApp.jsx
@@ -46,8 +46,8 @@ class FullApp extends Component {
         this.setState({SummaryItemToInsert: ''});
     }
     
-    newCurrentShortcut = (shortcutType, obj) => {
-        let newShortcut = this.shortcutManager.createShortcut(shortcutType, this.handleShortcutUpdate, obj);
+    newCurrentShortcut = (shortcutC, shortcutType, obj) => {
+        let newShortcut = this.shortcutManager.createShortcut(shortcutC, shortcutType, this.handleShortcutUpdate, obj);
         const errors = newShortcut.validateInCurrentContext(this.contextManager);
         if (errors.length > 0) {
             errors.forEach((error) => {

--- a/src/views/SlimApp.jsx
+++ b/src/views/SlimApp.jsx
@@ -24,7 +24,7 @@ class SlimApp extends Component {
      * Change the current shortcut to be the new type of shortcut  
      */
     changeShortcut = (shortcutType) => {
-        const newShortcut = (Lang.isNull(shortcutType)) ? null : this.shortcutManager.createShortcut("#" + shortcutType.toLowerCase(), this.handleShortcutUpdate);
+        const newShortcut = (Lang.isNull(shortcutType)) ? null : this.shortcutManager.createShortcut(null, "#" + shortcutType.toLowerCase(), this.handleShortcutUpdate);
         if (newShortcut) {
             newShortcut.setConfiguration((this.props.shortcutConfigurations) ? 
                     this.props.shortcutConfigurations[shortcutType] : {});

--- a/test/backend/noteparser/NoteParser.test.js
+++ b/test/backend/noteparser/NoteParser.test.js
@@ -11,12 +11,13 @@ const sampleTextPlain = "Nothing of substance here";
 const sampleTextNonsense = "#nonsense is in the structured phrase";
 const sampleTextStaging = "Debra Hernandez672 is presenting with carcinoma of the breast. #staging assessed as tumor size #T2 and #N0 + #M0.";
 const sampleTextDiseaseStatus = "Debra Hernandez672 is presenting with carcinoma of the breast.\n\n #disease status #stable based on #imaging and #physical exam";
+const sampleTextDiseaseStatus2 = "Debra Hernandez672 is presenting with carcinoma of the breast.\n\n #disease status #stable based on #imaging and #physical exam #as of #10/5/2017 #reference date #6/7/2017";
 const sampleTextToxicity = "Debra Hernandez672 is presenting with carcinoma of the breast.\n\n #toxicity #nausea #grade 2 #treatment";
 
-const expectedOutputEmpty = [];
-const expectedOutputPlain = [];
-const expectedOutputNonsense = [];
-const expectedOutputStaging = [{ 
+const expectedOutputEmpty = [[], []];
+const expectedOutputPlain = [[], []];
+const expectedOutputNonsense = [[], [ sampleTextNonsense] ];
+const expectedOutputStaging = [ [{ 
     entryType:
       [ 'http://standardhealthrecord.org/oncology/TNMStage',
          'http://standardhealthrecord.org/observation/Observation',
@@ -48,8 +49,8 @@ const expectedOutputStaging = [{
         { value: '433581000124101',
           codeSystem: 'urn:oid:2.16.840.1.113883.6.96',
           displayText: 'M0' } } 
-}];
-const expectedOutputDiseaseStatus = [{
+}], []];
+const expectedOutputDiseaseStatus = [[{
     entryType:
       [ 'http://standardhealthrecord.org/oncology/Progression',
          'http://standardhealthrecord.org/assessment/Assessment' ],
@@ -73,8 +74,33 @@ const expectedOutputDiseaseStatus = [{
     originalCreationDate: today,
     asOfDate: null,
     lastUpdateDate: today 
-}];
-const expectedOutputToxicity = [{ 
+}], []];
+const expectedOutputDiseaseStatus2 = [[{
+    entryType:
+      [ 'http://standardhealthrecord.org/oncology/Progression',
+         'http://standardhealthrecord.org/assessment/Assessment' ],
+    value:
+     { coding:
+        { value: 'C0205360',
+          codeSystem: 'http://ncimeta.nci.nih.gov',
+          displayText: 'Stable' } },
+    clinicallyRelevantTime: '7 Jun 2017',
+    evidence:
+     [ { coding:
+          { value: 'C0011923',
+            codeSystem: 'http://ncimeta.nci.nih.gov',
+            displayText: 'Imaging' } },
+       { coding:
+          { value: 'C0031809',
+            codeSystem: 'http://ncimeta.nci.nih.gov',
+            displayText: 'Physical exam' } } ],
+    assessmentType: { coding: { value: '#disease status' } },
+    status: 'unknown',
+    originalCreationDate: today,
+    asOfDate: '5 Oct 2017',
+    lastUpdateDate: today 
+}], []];
+const expectedOutputToxicity = [[{ 
     entryType:
       [ 'http://standardhealthrecord.org/oncology/ToxicReaction',
          'http://standardhealthrecord.org/adverse/AdverseReaction',
@@ -96,7 +122,7 @@ const expectedOutputToxicity = [{
           displayText: 'Treatment' } },
     originalCreationDate: today,
     lastUpdateDate: today 
-}];
+}], []];
 
 
 describe('getAllTriggersRegularExpression', function () { 
@@ -144,6 +170,12 @@ describe('parse', function() {
         expect(record)
             .to.be.an('array')
             .and.to.eql(expectedOutputDiseaseStatus);
+    });
+    it('should return a patient record with disease status data when parsing a note with disease status phrases including dates', function () {
+        const record = noteParser.parse(sampleTextDiseaseStatus2);
+        expect(record)
+            .to.be.an('array')
+            .and.to.eql(expectedOutputDiseaseStatus2);
     });
     it('should return a patient record with toxicity data when parsing a note with toxicity phrases', function () {
         const record = noteParser.parse(sampleTextToxicity);

--- a/test/ui/FullApp.js
+++ b/test/ui/FullApp.js
@@ -21,6 +21,15 @@ test('Typing an inserterShortcut in the editor results in a structured data inse
         .contains(new Patient().getName());
 });
 
+test('Typing a date in the editor results in a structured data insertion ', async t => { 
+    const editor = Selector("div[data-slate-editor='true']");
+    await t
+        .typeText(editor, "#12/20/2015 ")
+    const structuredField = editor.find("span[class='structured-field']");
+    await t
+        .expect(structuredField.innerText)
+        .contains("#12/20/2015");
+});
 
 fixture('Patient Mode - Data Summary Panel') 
     .page(startPage);


### PR DESCRIPTION
[JIRA 554] #12/22/2014 being entered into editor is now supported. #date still works to pop up date selector as well. Only #date appears in right panel. Now infrastructure supports regular expression specified value shortcuts through new getTriggerRegExp. A shortcut can provide both string triggers (#date) and a regular expression trigger (actual date). I added a UI test case for entering an actual date into the editor.

[JIRA 519,526] Parsing of notes containing structured dates is now supported. Parser was refactored to support the string triggers and regular expressions as well as provided by shortcuts. Test cases were added for parsing notes with dates.

[JIRA 555] Parsing now also detects unexpected # or @ expressions and returns a list of them from the parse method in addition to the SHR patient. An existing test case already tested for this already so once all test cases were updated for parser API changing to return both the SHR entries and the unexpected structured phrases, that test case passed and verifies that the unexpected tag is returned.

[JIRA 575, 595] Pasting of plain text structured phrases now works as well; however, @condition and #date cause issues due to the portal pop-up. @condition[[Lobular Carcinoma...]] can be used but I left the issue open for this so we can revisit how those are handled. I think 595 can be marked fixed but 575 should stay open. Also, test cases need to be added for pasting which can be done as part of 575.