### PR TITLE
Dictation initial implementation

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+src/lib/slate/*
+src/lib/slate-suggestions-dist/*

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,15 +4,15 @@ Pull requests into Flux require the following. Submitter and reviewer should :wh
 
 **Documentation**
 
-- [ ] This pull request describes why these changes were made.
+- [ ] This pull request describes why these changes were made
 - [ ] Cheat sheet is updated
 - [ ] Demo script is updated 
 - [ ] Documentation on Wiki has been updated 
-- [ ] Additional technical components and libraries are documented and added to wiki as needed. 
+- [ ] Additional technical components and libraries are documented and added to wiki as needed
 
 **NoteParser**
 
-- [ ] Note parser has been updated if structured phrases change.
+- [ ] Note parser has been updated if structured phrases change
 
 **Code Quality**
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:.
 
-##Submitter:
+## Submitter:
 
 **Documentation**
 
@@ -29,7 +29,7 @@ Pull requests into Flux require the following. Submitter and reviewer should :wh
 - [ ] Added note parser examples to test new functionality
 
 
-##Reviewer 1:
+## Reviewer 1:
 
 **Name:**
 
@@ -38,7 +38,7 @@ Pull requests into Flux require the following. Submitter and reviewer should :wh
 - [ ] You have tried to break the code
 
 
-##Reviewer 2:
+## Reviewer 2:
 
 **Name:**
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,47 @@
+Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:.
+
+##Submitter:##
+
+**Documentation**
+
+- [ ] This pull request describes why these changes were made.
+- [ ] Cheat sheet is updated
+- [ ] Demo script is updated 
+- [ ] Documentation on Wiki has been updated 
+- [ ] Additional technical components and libraries are documented and added to wiki as needed. 
+
+**NoteParser**
+
+- [ ] Note parser has been updated if structured phrases change.
+
+**Code Quality**
+
+- [ ] 4-space indents - convert any tabs to spaces
+- [ ] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
+- [ ] Code is commented
+
+**Tests**
+
+- [ ] Existing tests passed
+- [ ] Added UI tests for slim mode 
+- [ ] Added UI tests for full mode
+- [ ] Added backend tests for fluxNotes code
+- [ ] Added note parser examples to test new functionality
+
+
+##Reviewer 1:##
+
+**Name:**
+
+- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
+- [ ] The tests appropriately test the new code, including edge cases
+- [ ] You have tried to break the code
+
+
+##Reviewer 2:##
+
+**Name:**
+
+- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
+- [ ] The tests appropriately test the new code, including edge cases
+- [ ] You have tried to break the code

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:.
 
-##Submitter:##
+##Submitter:
 
 **Documentation**
 
@@ -29,7 +29,7 @@ Pull requests into Flux require the following. Submitter and reviewer should :wh
 - [ ] Added note parser examples to test new functionality
 
 
-##Reviewer 1:##
+##Reviewer 1:
 
 **Name:**
 
@@ -38,7 +38,7 @@ Pull requests into Flux require the following. Submitter and reviewer should :wh
 - [ ] You have tried to break the code
 
 
-##Reviewer 2:##
+##Reviewer 2:
 
 **Name:**
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,12 @@
-Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:.
+_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._
+
 
 ## Submitter:
 
 **Documentation**
 
 - [ ] This pull request describes why these changes were made
+- [ ] Recognizes any potential shortcomings/bugs in the description 
 - [ ] Cheat sheet is updated
 - [ ] Demo script is updated 
 - [ ] Documentation on Wiki has been updated 
@@ -29,18 +31,14 @@ Pull requests into Flux require the following. Submitter and reviewer should :wh
 - [ ] Added note parser examples to test new functionality
 
 
-## Reviewer 1:
-
-**Name:**
+## Reviewer 1: Name
 
 - [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
 - [ ] The tests appropriately test the new code, including edge cases
 - [ ] You have tried to break the code
 
 
-## Reviewer 2:
-
-**Name:**
+## Reviewer 2: Name
 
 - [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
 - [ ] The tests appropriately test the new code, including edge cases

--- a/src/lib/slate-suggestions-dist/suggestion-portal.js
+++ b/src/lib/slate-suggestions-dist/suggestion-portal.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import Portal from 'react-portal'
-import Slate from 'slate'
+import Slate from '../slate'
 import position from './caret-position'
 import SuggestionItem from './suggestion-item'
 import getCurrentWord from './current-word'

--- a/src/lib/slate/Readme.md
+++ b/src/lib/slate/Readme.md
@@ -1,0 +1,13 @@
+
+This directory contains the core logic of Slate. It's separated further into a series of directories:
+
+- [**Components**](./components) — containing the React components Slate renders.
+- [**Constants**](./constants) — containing constants that are used in Slate's codebase.
+- [**Models**](./models) — containing the models that define Slate's internal data structure.
+- [**Plugins**](./plugins) — containing the plugins that ship with Slate by default.
+- [**Schemas**](./schemas) - containing the schemas that ship with Slate by default.
+- [**Serializers**](./serializers) — containing the serializers that ship with Slate by default.
+- [**Transforms**](./transforms) — containing the transforms that are used to alter a Slate document.
+- [**Utils**](./utils) — containing a few private convenience modules.
+
+Feel free to poke around in each of them to learn more!

--- a/src/lib/slate/components/Readme.md
+++ b/src/lib/slate/components/Readme.md
@@ -1,0 +1,49 @@
+
+This directory contains the React components that Slate renders. Here's what they all do:
+
+- [Content](#content)
+- [Editor](#editor)
+- [Leaf](#leaf)
+- [Placeholder](#placeholder)
+- [Text](#text)
+- [Void](#void)
+
+
+#### Content
+
+`Content` is rendered by the [`Editor`](#editor). Its goal is to encapsulate all of the `contenteditable` logic, so that the [`Editor`](#editor) doesn't have to be aware of it.
+
+`Content` handles things attaching event listeners to the DOM and triggering updates based on events. However, it does not have any awareness of "plugins" as a concept, bubbling all of that logic up to the [`Editor`](#editor) itself.
+
+You'll notice there are **no** `Block` or `Inline` components. That's because those rendering components are provided by the user, and rendered directly by the `Content` component. You can find the default renderers in the [`Core`](../plugins/core.js) plugin's logic.
+
+
+#### Editor
+
+The `Editor` is the highest-level component that you render from inside your application. Its goal is to present a very clean API for the user, and to encapsulate all of the plugin-level logic. 
+
+Many of the properties passed into the editor are combined to create a plugin of its own, that is given the highest priority. This makes overriding core logic super simple, without having to write a separate plugin.
+
+
+#### Leaf
+
+The `Leaf` component is the lowest-level component in the React tree. Its goal is to encapsulate the logic that works at the lowest level, on the actual strings of text in the DOM.
+
+One `Leaf` component is rendered for each range of text with a unique set of [`Marks`](../models#mark). It handles both applying the mark styles to the text, and translating the current [`Selection`](../models#selection) into a real DOM selection, since it knows about the string offsets.
+
+
+#### Placeholder
+
+A `Placeholder` component is just a convenience for rendering placeholders on top of empty nodes. It's used in the core plugin's default block renderer, but is also exposed to provide the convenient API for custom blocks as well.
+
+
+#### Text
+
+A `Text` component is rendered for each [`Text`](../models#text) model in the document tree. This component handles grouping the characters of the text node into ranges that have the same set of [`Marks`](../models#mark), and then delegates rendering each range to...
+
+
+#### Void
+
+The `Void` component is a wrapper that gets rendered around [`Block`](../models#block) and [`Inline`](../models#inline) nodes that have `isVoid: true`. Its goal is to encapsule the logic needed to ensure that void nodes function as expected.
+
+To achieve this, `Void` renders a few extra elements that are required to keep selections and keyboard shortcuts on void nodes functioning like you'd expect them two. It also ensures that everything inside the void node is not editable, so that it doesn't get the editor into an unknown state.

--- a/src/lib/slate/components/content.js
+++ b/src/lib/slate/components/content.js
@@ -592,7 +592,6 @@ class Content extends React.Component {
     const after = selection.collapseToEnd().move(delta)
 
     if (this.props.onInput !== undefined) {
-      console.log('we have oninput passed')
       let data = {};
       data.anchorKey = key;
       data.anchorOffset = start;

--- a/src/lib/slate/components/content.js
+++ b/src/lib/slate/components/content.js
@@ -1,0 +1,927 @@
+
+import Debug from 'debug'
+import React from 'react'
+import Types from 'prop-types'
+import getWindow from 'get-window'
+import keycode from 'keycode'
+
+import TYPES from '../constants/types'
+import Base64 from '../serializers/base-64'
+import Node from './node'
+import Selection from '../models/selection'
+import extendSelection from '../utils/extend-selection'
+import findClosestNode from '../utils/find-closest-node'
+import findDeepestNode from '../utils/find-deepest-node'
+import getPoint from '../utils/get-point'
+import getTransferData from '../utils/get-transfer-data'
+import { IS_FIREFOX, IS_MAC } from '../constants/environment'
+
+/**
+ * Debug.
+ *
+ * @type {Function}
+ */
+
+const debug = Debug('slate:content')
+
+/**
+ * Content.
+ *
+ * @type {Component}
+ */
+
+class Content extends React.Component {
+
+  /**
+   * Property types.
+   *
+   * @type {Object}
+   */
+
+  static propTypes = {
+    autoCorrect: Types.bool.isRequired,
+    autoFocus: Types.bool.isRequired,
+    children: Types.array.isRequired,
+    className: Types.string,
+    editor: Types.object.isRequired,
+    onBeforeInput: Types.func.isRequired,
+    onBlur: Types.func.isRequired,
+    onChange: Types.func.isRequired,
+    onCopy: Types.func.isRequired,
+    onCut: Types.func.isRequired,
+    onDrop: Types.func.isRequired,
+    onFocus: Types.func.isRequired,
+    onKeyDown: Types.func.isRequired,
+    onPaste: Types.func.isRequired,
+    onSelect: Types.func.isRequired,
+    readOnly: Types.bool.isRequired,
+    role: Types.string,
+    schema: Types.object,
+    spellCheck: Types.bool.isRequired,
+    state: Types.object.isRequired,
+    style: Types.object,
+    tabIndex: Types.number
+  }
+
+  /**
+   * Default properties.
+   *
+   * @type {Object}
+   */
+
+  static defaultProps = {
+    style: {}
+  }
+
+  /**
+   * Constructor.
+   *
+   * @param {Object} props
+   */
+
+  constructor(props) {
+    super(props)
+    this.tmp = {}
+    this.tmp.compositions = 0
+    this.tmp.forces = 0
+  }
+
+  /**
+   * Should the component update?
+   *
+   * @param {Object} props
+   * @param {Object} state
+   * @return {Boolean}
+   */
+
+  shouldComponentUpdate = (props, state) => {
+    // If the readOnly state has changed, we need to re-render so that
+    // the cursor will be added or removed again.
+    if (props.readOnly !== this.props.readOnly) return true
+
+    // If the state has been transformed natively, never re-render, or else we
+    // will end up duplicating content.
+    if (props.state.isNative) return false
+
+    return (
+      props.className !== this.props.className ||
+      props.schema !== this.props.schema ||
+      props.autoCorrect !== this.props.autoCorrect ||
+      props.spellCheck !== this.props.spellCheck ||
+      props.state !== this.props.state ||
+      props.style !== this.props.style
+    )
+  }
+
+  /**
+   * When the editor first mounts in the DOM we need to:
+   *
+   *   - Update the selection, in case it starts focused.
+   *   - Focus the editor if `autoFocus` is set.
+   */
+
+  componentDidMount = () => {
+    this.updateSelection()
+
+    if (this.props.autoFocus) {
+      this.element.focus()
+    }
+  }
+
+  /**
+   * On update, update the selection.
+   */
+
+  componentDidUpdate = () => {
+    this.updateSelection()
+  }
+
+  /**
+   * Update the native DOM selection to reflect the internal model.
+   */
+
+  updateSelection = () => {
+    const { editor, state } = this.props
+    const { document, selection } = state
+    const window = getWindow(this.element)
+    const native = window.getSelection()
+
+    // If both selections are blurred, do nothing.
+    if (!native.rangeCount && selection.isBlurred) return
+
+    // If the selection has been blurred, but is still inside the editor in the
+    // DOM, blur it manually.
+    if (selection.isBlurred) {
+      if (!this.isInEditor(native.anchorNode)) return
+      native.removeAllRanges()
+      this.element.blur()
+      debug('updateSelection', { selection, native })
+      return
+    }
+
+    // Otherwise, figure out which DOM nodes should be selected...
+    const { anchorText, focusText } = state
+    const { anchorKey, anchorOffset, focusKey, focusOffset } = selection
+    const schema = editor.getSchema()
+    const anchorDecorators = document.getDescendantDecorators(anchorKey, schema)
+    const focusDecorators = document.getDescendantDecorators(focusKey, schema)
+    const anchorRanges = anchorText.getRanges(anchorDecorators)
+    const focusRanges = focusText.getRanges(focusDecorators)
+    let a = 0
+    let f = 0
+    let anchorIndex
+    let focusIndex
+    let anchorOff
+    let focusOff
+
+    anchorRanges.forEach((range, i, ranges) => {
+      const { length } = range.text
+      a += length
+      if (a < anchorOffset) return
+      anchorIndex = i
+      anchorOff = anchorOffset - (a - length)
+      return false
+    })
+
+    focusRanges.forEach((range, i, ranges) => {
+      const { length } = range.text
+      f += length
+      if (f < focusOffset) return
+      focusIndex = i
+      focusOff = focusOffset - (f - length)
+      return false
+    })
+
+    const anchorSpan = this.element.querySelector(`[data-offset-key="${anchorKey}-${anchorIndex}"]`)
+    const focusSpan = this.element.querySelector(`[data-offset-key="${focusKey}-${focusIndex}"]`)
+    const anchorEl = findDeepestNode(anchorSpan)
+    const focusEl = findDeepestNode(focusSpan)
+
+    // If they are already selected, do nothing.
+    if (
+      anchorEl === native.anchorNode &&
+      anchorOff === native.anchorOffset &&
+      focusEl === native.focusNode &&
+      focusOff === native.focusOffset
+    ) {
+      return
+    }
+
+    // Otherwise, set the `isSelecting` flag and update the selection.
+    this.tmp.isSelecting = true
+    native.removeAllRanges()
+    const range = window.document.createRange()
+    range.setStart(anchorEl, anchorOff)
+    native.addRange(range)
+    extendSelection(native, focusEl, focusOff)
+
+    // Then unset the `isSelecting` flag after a delay.
+    setTimeout(() => {
+      // COMPAT: In Firefox, it's not enough to create a range, you also need to
+      // focus the contenteditable element too. (2016/11/16)
+      if (IS_FIREFOX) this.element.focus()
+      this.tmp.isSelecting = false
+    })
+
+    debug('updateSelection', { selection, native })
+  }
+
+  /**
+   * The React ref method to set the root content element locally.
+   *
+   * @param {Element} n
+   */
+
+  ref = (element) => {
+    this.element = element
+  }
+
+  /**
+   * Check if an event `target` is fired from within the contenteditable
+   * element. This should be false for edits happening in non-contenteditable
+   * children, such as void nodes and other nested Slate editors.
+   *
+   * @param {Element} target
+   * @return {Boolean}
+   */
+
+  isInEditor = (target) => {
+    const { element } = this
+    return (
+      (target.isContentEditable) &&
+      (target === element || findClosestNode(target, '[data-slate-editor]') === element)
+    )
+  }
+
+  /**
+   * On before input, bubble up.
+   *
+   * @param {Event} event
+   */
+
+  onBeforeInput = (event) => {
+    if (this.props.readOnly) return
+    if (!this.isInEditor(event.target)) return
+
+    const data = {}
+
+    debug('onBeforeInput', { event, data })
+    this.props.onBeforeInput(event, data)
+  }
+
+  /**
+   * On blur, update the selection to be not focused.
+   *
+   * @param {Event} event
+   */
+
+  onBlur = (event) => {
+    if (this.props.readOnly) return
+    if (this.tmp.isCopying) return
+    if (!this.isInEditor(event.target)) return
+
+    // If the active element is still the editor, the blur event is due to the
+    // window itself being blurred (eg. when changing tabs) so we should ignore
+    // the event, since we want to maintain focus when returning.
+    const window = getWindow(this.element)
+    if (window.document.activeElement === this.element) return
+
+    const data = {}
+
+    debug('onBlur', { event, data })
+    this.props.onBlur(event, data)
+  }
+
+  /**
+   * On focus, update the selection to be focused.
+   *
+   * @param {Event} event
+   */
+
+  onFocus = (event) => {
+    if (this.props.readOnly) return
+    if (this.tmp.isCopying) return
+    if (!this.isInEditor(event.target)) return
+
+    // COMPAT: If the editor has nested editable elements, the focus can go to
+    // those elements. In Firefox, this must be prevented because it results in
+    // issues with keyboard navigation. (2017/03/30)
+    if (IS_FIREFOX && event.target !== this.element) {
+      this.element.focus()
+      return
+    }
+
+    const data = {}
+
+    debug('onFocus', { event, data })
+    this.props.onFocus(event, data)
+  }
+
+  /**
+   * On change, bubble up.
+   *
+   * @param {State} state
+   */
+
+  onChange = (state) => {
+    debug('onChange', state)
+    this.props.onChange(state)
+  }
+
+  /**
+   * On composition start, set the `isComposing` flag.
+   *
+   * @param {Event} event
+   */
+
+  onCompositionStart = (event) => {
+    if (!this.isInEditor(event.target)) return
+
+    this.tmp.isComposing = true
+    this.tmp.compositions++
+
+    debug('onCompositionStart', { event })
+  }
+
+  /**
+   * On composition end, remove the `isComposing` flag on the next tick. Also
+   * increment the `forces` key, which will force the contenteditable element
+   * to completely re-render, since IME puts React in an unreconcilable state.
+   *
+   * @param {Event} event
+   */
+
+  onCompositionEnd = (event) => {
+    if (!this.isInEditor(event.target)) return
+
+    this.tmp.forces++
+    const count = this.tmp.compositions
+
+    // The `count` check here ensures that if another composition starts
+    // before the timeout has closed out this one, we will abort unsetting the
+    // `isComposing` flag, since a composition in still in affect.
+    setTimeout(() => {
+      if (this.tmp.compositions > count) return
+      this.tmp.isComposing = false
+    })
+
+    debug('onCompositionEnd', { event })
+  }
+
+  /**
+   * On copy, defer to `onCutCopy`, then bubble up.
+   *
+   * @param {Event} event
+   */
+
+  onCopy = (event) => {
+    if (!this.isInEditor(event.target)) return
+    const window = getWindow(event.target)
+
+    this.tmp.isCopying = true
+    window.requestAnimationFrame(() => {
+      this.tmp.isCopying = false
+    })
+
+    const { state } = this.props
+    const data = {}
+    data.type = 'fragment'
+    data.fragment = state.fragment
+
+    debug('onCopy', { event, data })
+    this.props.onCopy(event, data)
+  }
+
+  /**
+   * On cut, defer to `onCutCopy`, then bubble up.
+   *
+   * @param {Event} event
+   */
+
+  onCut = (event) => {
+    if (this.props.readOnly) return
+    if (!this.isInEditor(event.target)) return
+    const window = getWindow(event.target)
+
+    this.tmp.isCopying = true
+    window.requestAnimationFrame(() => {
+      this.tmp.isCopying = false
+    })
+
+    const { state } = this.props
+    const data = {}
+    data.type = 'fragment'
+    data.fragment = state.fragment
+
+    debug('onCut', { event, data })
+    this.props.onCut(event, data)
+  }
+
+  /**
+   * On drag end, unset the `isDragging` flag.
+   *
+   * @param {Event} event
+   */
+
+  onDragEnd = (event) => {
+    if (!this.isInEditor(event.target)) return
+
+    this.tmp.isDragging = false
+    this.tmp.isInternalDrag = null
+
+    debug('onDragEnd', { event })
+  }
+
+  /**
+   * On drag over, set the `isDragging` flag and the `isInternalDrag` flag.
+   *
+   * @param {Event} event
+   */
+
+  onDragOver = (event) => {
+    if (!this.isInEditor(event.target)) return
+
+    const { dataTransfer } = event.nativeEvent
+    const data = getTransferData(dataTransfer)
+
+    // Prevent default when nodes are dragged to allow dropping.
+    if (data.type === 'node') {
+      event.preventDefault()
+    }
+
+    if (this.tmp.isDragging) return
+    this.tmp.isDragging = true
+    this.tmp.isInternalDrag = false
+
+    debug('onDragOver', { event })
+  }
+
+  /**
+   * On drag start, set the `isDragging` flag and the `isInternalDrag` flag.
+   *
+   * @param {Event} event
+   */
+
+  onDragStart = (event) => {
+    if (!this.isInEditor(event.target)) return
+
+    this.tmp.isDragging = true
+    this.tmp.isInternalDrag = true
+    const { dataTransfer } = event.nativeEvent
+    const data = getTransferData(dataTransfer)
+
+    // If it's a node being dragged, the data type is already set.
+    if (data.type === 'node') return
+
+    const { state } = this.props
+    const { fragment } = state
+    const encoded = Base64.serializeNode(fragment)
+    dataTransfer.setData(TYPES.FRAGMENT, encoded)
+
+    debug('onDragStart', { event })
+  }
+
+  /**
+   * On drop.
+   *
+   * @param {Event} event
+   */
+
+  onDrop = (event) => {
+    if (this.props.readOnly) return
+    if (!this.isInEditor(event.target)) return
+
+    event.preventDefault()
+
+    const window = getWindow(event.target)
+    const { state, editor } = this.props
+    const { nativeEvent } = event
+    const { dataTransfer, x, y } = nativeEvent
+    const data = getTransferData(dataTransfer)
+
+    // Resolve the point where the drop occured.
+    let range
+
+    // COMPAT: In Firefox, `caretRangeFromPoint` doesn't exist. (2016/07/25)
+    if (window.document.caretRangeFromPoint) {
+      range = window.document.caretRangeFromPoint(x, y)
+    } else {
+      range = window.document.createRange()
+      range.setStart(nativeEvent.rangeParent, nativeEvent.rangeOffset)
+    }
+
+    const { startContainer, startOffset } = range
+    const point = getPoint(startContainer, startOffset, state, editor)
+    if (!point) return
+
+    const target = Selection.create({
+      anchorKey: point.key,
+      anchorOffset: point.offset,
+      focusKey: point.key,
+      focusOffset: point.offset,
+      isFocused: true
+    })
+
+    // If the target is inside a void node, abort.
+    if (state.document.hasVoidParent(point.key)) return
+
+    // Add drop-specific information to the data.
+    data.target = target
+    data.effect = dataTransfer.dropEffect
+
+    if (data.type === 'fragment' || data.type === 'node') {
+      data.isInternal = this.tmp.isInternalDrag
+    }
+
+    debug('onDrop', { event, data })
+    this.props.onDrop(event, data)
+  }
+
+  /**
+   * On input, handle spellcheck and other similar edits that don't go trigger
+   * the `onBeforeInput` and instead update the DOM directly.
+   *
+   * @param {Event} event
+   */
+
+  onInput = (event) => {
+    if (this.tmp.isComposing) return
+    if (this.props.state.isBlurred) return
+    if (!this.isInEditor(event.target)) return
+    debug('onInput', { event })
+
+    const window = getWindow(event.target)
+    const { state, editor } = this.props
+
+    // Get the selection point.
+    const native = window.getSelection()
+    const { anchorNode, anchorOffset } = native
+    const point = getPoint(anchorNode, anchorOffset, state, editor)
+    if (!point) return
+
+    // Get the range in question.
+    const { key, index, start, end } = point
+    const { document, selection } = state
+    const schema = editor.getSchema()
+    const decorators = document.getDescendantDecorators(key, schema)
+    const node = document.getDescendant(key)
+    const block = document.getClosestBlock(node.key)
+    const ranges = node.getRanges(decorators)
+    const lastText = block.getLastText()
+
+    // Get the text information.
+    let { textContent } = anchorNode
+    const lastChar = textContent.charAt(textContent.length - 1)
+    const isLastText = node === lastText
+    const isLastRange = index === ranges.size - 1
+
+    // If we're dealing with the last leaf, and the DOM text ends in a new line,
+    // we will have added another new line in <Leaf>'s render method to account
+    // for browsers collapsing a single trailing new lines, so remove it.
+    if (isLastText && isLastRange && lastChar === '\n') {
+      textContent = textContent.slice(0, -1)
+    }
+
+    // If the text is no different, abort.
+    const range = ranges.get(index)
+    const { text, marks } = range
+    if (textContent === text) return
+
+    // Determine what the selection should be after changing the text.
+    const delta = textContent.length - text.length
+    const after = selection.collapseToEnd().move(delta)
+
+    if (this.props.onInput !== undefined) {
+      console.log('we have oninput passed')
+      let data = {};
+      data.anchorKey = key;
+      data.anchorOffset = start;
+      data.focusKey = key;
+      data.focusOffset = end;
+      data.delta = delta;
+      data.after = after;
+      data.oldText = text;
+      data.newText = textContent;
+      data.marks = marks;
+      this.props.onInput(event, data);
+    } else { 
+      // Create an updated state with the text replaced.
+      const next = state
+        .transform()
+        .select({
+          anchorKey: key,
+          anchorOffset: start,
+          focusKey: key,
+          focusOffset: end
+        })
+        .delete()
+        .insertText(textContent, marks)
+        .select(after)
+        .apply()
+
+      // Change the current state.
+      this.onChange(next)
+    }
+  }
+
+  /**
+   * On key down, prevent the default behavior of certain commands that will
+   * leave the editor in an out-of-sync state, then bubble up.
+   *
+   * @param {Event} event
+   */
+
+  onKeyDown = (event) => {
+    if (this.props.readOnly) return
+    if (!this.isInEditor(event.target)) return
+
+    const { altKey, ctrlKey, metaKey, shiftKey, which } = event
+    const key = keycode(which)
+    const data = {}
+
+    // Keep track of an `isShifting` flag, because it's often used to trigger
+    // "Paste and Match Style" commands, but isn't available on the event in a
+    // normal paste event.
+    if (key === 'shift') {
+      this.tmp.isShifting = true
+    }
+
+    // When composing, these characters commit the composition but also move the
+    // selection before we're able to handle it, so prevent their default,
+    // selection-moving behavior.
+    if (
+      this.tmp.isComposing &&
+      (key === 'left' || key === 'right' || key === 'up' || key === 'down')
+    ) {
+      event.preventDefault()
+      return
+    }
+
+    // Add helpful properties for handling hotkeys to the data object.
+    data.code = which
+    data.key = key
+    data.isAlt = altKey
+    data.isCmd = IS_MAC ? metaKey && !altKey : false
+    data.isCtrl = ctrlKey && !altKey
+    data.isLine = IS_MAC ? metaKey : false
+    data.isMeta = metaKey
+    data.isMod = IS_MAC ? metaKey && !altKey : ctrlKey && !altKey
+    data.isModAlt = IS_MAC ? metaKey && altKey : ctrlKey && altKey
+    data.isShift = shiftKey
+    data.isWord = IS_MAC ? altKey : ctrlKey
+
+    // These key commands have native behavior in contenteditable elements which
+    // will cause our state to be out of sync, so prevent them.
+    if (
+      (key === 'enter') ||
+      (key === 'backspace') ||
+      (key === 'delete') ||
+      (key === 'b' && data.isMod) ||
+      (key === 'i' && data.isMod) ||
+      (key === 'y' && data.isMod) ||
+      (key === 'z' && data.isMod)
+    ) {
+      event.preventDefault()
+    }
+
+    debug('onKeyDown', { event, data })
+    this.props.onKeyDown(event, data)
+  }
+
+  /**
+   * On key up, unset the `isShifting` flag.
+   *
+   * @param {Event} event
+   */
+
+  onKeyUp = (event) => {
+    const { which } = event
+    const key = keycode(which)
+
+    if (key === 'shift') {
+      this.tmp.isShifting = false
+    }
+  }
+
+  /**
+   * On paste, determine the type and bubble up.
+   *
+   * @param {Event} event
+   */
+
+  onPaste = (event) => {
+    if (this.props.readOnly) return
+    if (!this.isInEditor(event.target)) return
+
+    event.preventDefault()
+    const data = getTransferData(event.clipboardData)
+
+    // Attach the `isShift` flag, so that people can use it to trigger "Paste
+    // and Match Style" logic.
+    data.isShift = !!this.tmp.isShifting
+
+    debug('onPaste', { event, data })
+    this.props.onPaste(event, data)
+  }
+
+  /**
+   * On select, update the current state's selection.
+   *
+   * @param {Event} event
+   */
+
+  onSelect = (event) => {
+    if (this.props.readOnly) return
+    if (this.tmp.isCopying) return
+    if (this.tmp.isComposing) return
+    if (this.tmp.isSelecting) return
+    if (!this.isInEditor(event.target)) return
+
+    const window = getWindow(event.target)
+    const { state, editor } = this.props
+    const { document, selection } = state
+    const native = window.getSelection()
+    const data = {}
+
+    // If there are no ranges, the editor was blurred natively.
+    if (!native.rangeCount) {
+      data.selection = selection.set('isFocused', false)
+      data.isNative = true
+    }
+
+    // Otherwise, determine the Slate selection from the native one.
+    else {
+      const { anchorNode, anchorOffset, focusNode, focusOffset } = native
+      const anchor = getPoint(anchorNode, anchorOffset, state, editor)
+      const focus = getPoint(focusNode, focusOffset, state, editor)
+      if (!anchor || !focus) return
+
+      // There are situations where a select event will fire with a new native
+      // selection that resolves to the same internal position. In those cases
+      // we don't need to trigger any changes, since our internal model is
+      // already up to date, but we do want to update the native selection again
+      // to make sure it is in sync.
+      if (
+        anchor.key === selection.anchorKey &&
+        anchor.offset === selection.anchorOffset &&
+        focus.key === selection.focusKey &&
+        focus.offset === selection.focusOffset &&
+        selection.isFocused
+      ) {
+        this.updateSelection()
+        return
+      }
+
+      const properties = {
+        anchorKey: anchor.key,
+        anchorOffset: anchor.offset,
+        focusKey: focus.key,
+        focusOffset: focus.offset,
+        isFocused: true,
+        isBackward: null
+      }
+
+      // If the selection is at the end of a non-void inline node, and there is
+      // a node after it, put it in the node after instead.
+      const anchorText = document.getNode(anchor.key)
+      const focusText = document.getNode(focus.key)
+      const anchorInline = document.getClosestInline(anchor.key)
+      const focusInline = document.getClosestInline(focus.key)
+
+      if (anchorInline && !anchorInline.isVoid && anchor.offset === anchorText.length) {
+        const block = document.getClosestBlock(anchor.key)
+        const next = block.getNextText(anchor.key)
+        if (next) {
+          properties.anchorKey = next.key
+          properties.anchorOffset = 0
+        }
+      }
+
+      if (focusInline && !focusInline.isVoid && focus.offset === focusText.length) {
+        const block = document.getClosestBlock(focus.key)
+        const next = block.getNextText(focus.key)
+        if (next) {
+          properties.focusKey = next.key
+          properties.focusOffset = 0
+        }
+      }
+
+      data.selection = selection
+        .merge(properties)
+        .normalize(document)
+    }
+
+    debug('onSelect', { event, data })
+    this.props.onSelect(event, data)
+  }
+
+  /**
+   * Render the editor content.
+   *
+   * @return {Element}
+   */
+
+  render = () => {
+    const { props } = this
+    const { className, readOnly, state, tabIndex, role } = props
+    const { document } = state
+    const children = document.nodes
+      .map(node => this.renderNode(node))
+      .toArray()
+
+    const style = {
+      // Prevent the default outline styles.
+      outline: 'none',
+      // Preserve adjacent whitespace and new lines.
+      whiteSpace: 'pre-wrap',
+      // Allow words to break if they are too long.
+      wordWrap: 'break-word',
+      // COMPAT: In iOS, a formatting menu with bold, italic and underline
+      // buttons is shown which causes our internal state to get out of sync in
+      // weird ways. This hides that. (2016/06/21)
+      ...(readOnly ? {} : { WebkitUserModify: 'read-write-plaintext-only' }),
+      // Allow for passed-in styles to override anything.
+      ...props.style,
+    }
+
+    // COMPAT: In Firefox, spellchecking can remove entire wrapping elements
+    // including inline ones like `<a>`, which is jarring for the user but also
+    // causes the DOM to get into an irreconcilable state. (2016/09/01)
+    const spellCheck = IS_FIREFOX ? false : props.spellCheck
+
+    debug('render', { props })
+
+    return (
+      <div
+        data-slate-editor
+        key={this.tmp.forces}
+        ref={this.ref}
+        data-key={document.key}
+        contentEditable={!readOnly}
+        suppressContentEditableWarning
+        className={className}
+        onBeforeInput={this.onBeforeInput}
+        onBlur={this.onBlur}
+        onFocus={this.onFocus}
+        onCompositionEnd={this.onCompositionEnd}
+        onCompositionStart={this.onCompositionStart}
+        onCopy={this.onCopy}
+        onCut={this.onCut}
+        onDragEnd={this.onDragEnd}
+        onDragOver={this.onDragOver}
+        onDragStart={this.onDragStart}
+        onDrop={this.onDrop}
+        onInput={this.onInput}
+        onKeyDown={this.onKeyDown}
+        onKeyUp={this.onKeyUp}
+        onPaste={this.onPaste}
+        onSelect={this.onSelect}
+        autoCorrect={props.autoCorrect}
+        spellCheck={spellCheck}
+        style={style}
+        role={readOnly ? null : (role || 'textbox')}
+        tabIndex={tabIndex}
+        // COMPAT: The Grammarly Chrome extension works by changing the DOM out
+        // from under `contenteditable` elements, which leads to weird behaviors
+        // so we have to disable it like this. (2017/04/24)
+        data-gramm={false}
+      >
+        {children}
+        {this.props.children}
+      </div>
+    )
+  }
+
+  /**
+   * Render a `node`.
+   *
+   * @param {Node} node
+   * @return {Element}
+   */
+
+  renderNode = (node) => {
+    const { editor, readOnly, schema, state } = this.props
+
+    return (
+      <Node
+        key={node.key}
+        block={null}
+        node={node}
+        parent={state.document}
+        schema={schema}
+        state={state}
+        editor={editor}
+        readOnly={readOnly}
+      />
+    )
+  }
+
+}
+
+/**
+ * Export.
+ *
+ * @type {Component}
+ */
+
+export default Content

--- a/src/lib/slate/components/editor.js
+++ b/src/lib/slate/components/editor.js
@@ -1,0 +1,273 @@
+
+import Debug from 'debug'
+import Portal from 'react-portal'
+import React from 'react'
+import Types from 'prop-types'
+
+import Stack from '../models/stack'
+import State from '../models/state'
+import noop from '../utils/noop'
+
+/**
+ * Debug.
+ *
+ * @type {Function}
+ */
+
+const debug = Debug('slate:editor')
+
+/**
+ * Event handlers to mix in to the editor.
+ *
+ * @type {Array}
+ */
+
+const EVENT_HANDLERS = [
+  'onBeforeInput',
+  'onBlur',
+  'onFocus',
+  'onCopy',
+  'onCut',
+  'onDrop',
+  'onInput', 
+  'onKeyDown',
+  'onPaste',
+  'onSelect',
+]
+
+/**
+ * Plugin-related properties of the editor.
+ *
+ * @type {Array}
+ */
+
+const PLUGINS_PROPS = [
+  ...EVENT_HANDLERS,
+  'placeholder',
+  'placeholderClassName',
+  'placeholderStyle',
+  'plugins',
+  'schema',
+]
+
+/**
+ * Editor.
+ *
+ * @type {Component}
+ */
+
+class Editor extends React.Component {
+
+  /**
+   * Property types.
+   *
+   * @type {Object}
+   */
+
+  static propTypes = {
+    autoCorrect: Types.bool,
+    autoFocus: Types.bool,
+    className: Types.string,
+    onBeforeChange: Types.func,
+    onChange: Types.func,
+    onDocumentChange: Types.func,
+    onSelectionChange: Types.func,
+    placeholder: Types.any,
+    placeholderClassName: Types.string,
+    placeholderStyle: Types.object,
+    plugins: Types.array,
+    readOnly: Types.bool,
+    role: Types.string,
+    schema: Types.object,
+    spellCheck: Types.bool,
+    state: Types.instanceOf(State).isRequired,
+    style: Types.object,
+    tabIndex: Types.number,
+  }
+
+  /**
+   * Default properties.
+   *
+   * @type {Object}
+   */
+
+  static defaultProps = {
+    autoFocus: false,
+    autoCorrect: true,
+    onChange: noop,
+    onDocumentChange: noop,
+    onSelectionChange: noop,
+    plugins: [],
+    readOnly: false,
+    schema: {},
+    spellCheck: true,
+  }
+
+  /**
+   * When constructed, create a new `Stack` and run `onBeforeChange`.
+   *
+   * @param {Object} props
+   */
+
+  constructor(props) {
+    super(props)
+    this.tmp = {}
+    this.state = {}
+
+    // Create a new `Stack`, omitting the `onChange` property since that has
+    // special significance on the editor itself.
+    const { onChange, ...rest } = props // eslint-disable-line no-unused-vars
+    const stack = Stack.create(rest)
+    this.state.stack = stack
+
+    // Resolve the state, running `onBeforeChange` first.
+    const state = stack.onBeforeChange(props.state, this)
+    this.cacheState(state)
+    this.state.state = state
+
+    // Create a bound event handler for each event.
+    for (const method of EVENT_HANDLERS) {
+      this[method] = (...args) => {
+        const next = this.state.stack[method](this.state.state, this, ...args)
+        this.onChange(next)
+      }
+    }
+  }
+
+  /**
+   * When the `props` are updated, create a new `Stack` if necessary, and
+   * run `onBeforeChange`.
+   *
+   * @param {Object} props
+   */
+
+  componentWillReceiveProps = (props) => {
+    let { stack } = this.state
+
+    // If any plugin-related properties will change, create a new `Stack`.
+    for (const prop of PLUGINS_PROPS) {
+      if (props[prop] == this.props[prop]) continue
+      const { onChange, ...rest } = props // eslint-disable-line no-unused-vars
+      stack = Stack.create(rest)
+      this.setState({ stack })
+    }
+
+    // Resolve the state, running the before change handler of the stack.
+    const state = stack.onBeforeChange(props.state, this)
+    this.cacheState(state)
+    this.setState({ state })
+  }
+
+  /**
+   * Cache a `state` in memory to be able to compare against it later, for
+   * things like `onDocumentChange`.
+   *
+   * @param {State} state
+   */
+
+  cacheState = (state) => {
+    this.tmp.document = state.document
+    this.tmp.selection = state.selection
+  }
+
+  /**
+   * Programmatically blur the editor.
+   */
+
+  blur = () => {
+    const state = this.state.state
+      .transform()
+      .blur()
+      .apply()
+
+    this.onChange(state)
+  }
+
+  /**
+   * Programmatically focus the editor.
+   */
+
+  focus = () => {
+    const state = this.state.state
+      .transform()
+      .focus()
+      .apply()
+
+    this.onChange(state)
+  }
+
+  /**
+   * Get the editor's current schema.
+   *
+   * @return {Schema}
+   */
+
+  getSchema = () => {
+    return this.state.stack.schema
+  }
+
+  /**
+   * Get the editor's current state.
+   *
+   * @return {State}
+   */
+
+  getState = () => {
+    return this.state.state
+  }
+
+  /**
+   * When the `state` changes, pass through plugins, then bubble up.
+   *
+   * @param {State} state
+   */
+
+  onChange = (state) => {
+    if (state == this.state.state) return
+    const { tmp, props } = this
+    const { stack } = this.state
+    const { onChange, onDocumentChange, onSelectionChange } = props
+    const { document, selection } = tmp
+
+    state = stack.onChange(state, this)
+    onChange(state)
+    if (state.document != document) onDocumentChange(state.document, state)
+    if (state.selection != selection) onSelectionChange(state.selection, state)
+  }
+
+  /**
+   * Render the editor.
+   *
+   * @return {Element}
+   */
+
+  render = () => {
+    const { props, state } = this
+    const { stack } = state
+    const children = stack
+      .renderPortal(state.state, this)
+      .map((child, i) => <Portal key={i} isOpened>{child}</Portal>)
+
+    debug('render', { props, state })
+
+    const tree = stack.render(state.state, this, { ...props, children })
+    return tree
+  }
+
+}
+
+/**
+ * Mix in the property types for the event handlers.
+ */
+
+for (const property of EVENT_HANDLERS) {
+  Editor.propTypes[property] = Types.func
+}
+
+/**
+ * Export.
+ *
+ * @type {Component}
+ */
+
+export default Editor

--- a/src/lib/slate/components/leaf.js
+++ b/src/lib/slate/components/leaf.js
@@ -1,0 +1,202 @@
+
+import Debug from 'debug'
+import React from 'react'
+import ReactDOM from 'react-dom'
+import Types from 'prop-types'
+
+import OffsetKey from '../utils/offset-key'
+import findDeepestNode from '../utils/find-deepest-node'
+import { IS_FIREFOX } from '../constants/environment'
+
+/**
+ * Debugger.
+ *
+ * @type {Function}
+ */
+
+const debug = Debug('slate:leaf')
+
+/**
+ * Leaf.
+ *
+ * @type {Component}
+ */
+
+class Leaf extends React.Component {
+
+  /**
+   * Property types.
+   *
+   * @type {Object}
+   */
+
+  static propTypes = {
+    block: Types.object.isRequired,
+    editor: Types.object.isRequired,
+    index: Types.number.isRequired,
+    marks: Types.object.isRequired,
+    node: Types.object.isRequired,
+    offset: Types.number.isRequired,
+    parent: Types.object.isRequired,
+    ranges: Types.object.isRequired,
+    schema: Types.object.isRequired,
+    state: Types.object.isRequired,
+    text: Types.string.isRequired
+  }
+
+  /**
+   * Constructor.
+   *
+   * @param {Object} props
+   */
+
+  constructor(props) {
+    super(props)
+    this.tmp = {}
+    this.tmp.renders = 0
+  }
+
+  /**
+   * Debug.
+   *
+   * @param {String} message
+   * @param {Mixed} ...args
+   */
+
+  debug = (message, ...args) => {
+    debug(message, `${this.props.node.key}-${this.props.index}`, ...args)
+  }
+
+  /**
+   * Should component update?
+   *
+   * @param {Object} props
+   * @return {Boolean}
+   */
+
+  shouldComponentUpdate(props) {
+    // If any of the regular properties have changed, re-render.
+    if (
+      props.index != this.props.index ||
+      props.marks != this.props.marks ||
+      props.schema != this.props.schema ||
+      props.text != this.props.text
+    ) {
+      return true
+    }
+
+    // If the DOM text does not equal the `text` property, re-render, this can
+    // happen because React gets out of sync when previously natively rendered.
+    const el = findDeepestNode(ReactDOM.findDOMNode(this))
+    const text = this.renderText(props)
+    if (el.textContent != text) return true
+
+    // Otherwise, don't update.
+    return false
+  }
+
+  /**
+   * Render the leaf.
+   *
+   * @return {Element}
+   */
+
+  render() {
+    const { props } = this
+    const { node, index } = props
+    const offsetKey = OffsetKey.stringify({
+      key: node.key,
+      index
+    })
+
+    // Increment the renders key, which forces a re-render whenever this
+    // component is told it should update. This is required because "native"
+    // renders where we don't update the leaves cause React's internal state to
+    // get out of sync, causing it to not realize the DOM needs updating.
+    this.tmp.renders++
+
+    this.debug('render', { props })
+
+    return (
+      <span key={this.tmp.renders} data-offset-key={offsetKey}>
+        {this.renderMarks(props)}
+      </span>
+    )
+  }
+
+  /**
+   * Render the text content of the leaf, accounting for browsers.
+   *
+   * @param {Object} props
+   * @return {Element}
+   */
+
+  renderText(props) {
+    const { block, node, parent, text, index, ranges } = props
+
+    // COMPAT: If the text is empty and it's the only child, we need to render a
+    // <br/> to get the block to have the proper height.
+    if (text == '' && parent.kind == 'block' && parent.text == '') return <br />
+
+    // COMPAT: If the text is empty otherwise, it's because it's on the edge of
+    // an inline void node, so we render a zero-width space so that the
+    // selection can be inserted next to it still.
+    if (text == '') {
+      // COMPAT: In Chrome, zero-width space produces graphics glitches, so use
+      // hair space in place of it. (2017/02/12)
+      const space = IS_FIREFOX ? '\u200B' : '\u200A'
+      return <span data-slate-zero-width>{space}</span>
+    }
+
+    // COMPAT: Browsers will collapse trailing new lines at the end of blocks,
+    // so we need to add an extra trailing new lines to prevent that.
+    const lastText = block.getLastText()
+    const lastChar = text.charAt(text.length - 1)
+    const isLastText = node == lastText
+    const isLastRange = index == ranges.size - 1
+    if (isLastText && isLastRange && lastChar == '\n') return `${text}\n`
+
+    // Otherwise, just return the text.
+    return text
+  }
+
+  /**
+   * Render all of the leaf's mark components.
+   *
+   * @param {Object} props
+   * @return {Element}
+   */
+
+  renderMarks(props) {
+    const { marks, schema, node, offset, text, state, editor } = props
+    const children = this.renderText(props)
+
+    return marks.reduce((memo, mark) => {
+      const Component = mark.getComponent(schema)
+      if (!Component) return memo
+      return (
+        <Component
+          editor={editor}
+          mark={mark}
+          marks={marks}
+          node={node}
+          offset={offset}
+          schema={schema}
+          state={state}
+          text={text}
+        >
+          {memo}
+        </Component>
+      )
+    }, children)
+  }
+
+}
+
+/**
+ * Export.
+ *
+ * @type {Component}
+ */
+
+export default Leaf

--- a/src/lib/slate/components/node.js
+++ b/src/lib/slate/components/node.js
@@ -1,0 +1,360 @@
+
+import Debug from 'debug'
+import React from 'react'
+import ReactDOM from 'react-dom'
+import Types from 'prop-types'
+
+import TYPES from '../constants/types'
+import Base64 from '../serializers/base-64'
+import Leaf from './leaf'
+import Void from './void'
+import getWindow from 'get-window'
+import scrollToSelection from '../utils/scroll-to-selection'
+
+/**
+ * Debug.
+ *
+ * @type {Function}
+ */
+
+const debug = Debug('slate:node')
+
+/**
+ * Node.
+ *
+ * @type {Component}
+ */
+
+class Node extends React.Component {
+
+  /**
+   * Property types.
+   *
+   * @type {Object}
+   */
+
+  static propTypes = {
+    block: Types.object,
+    editor: Types.object.isRequired,
+    node: Types.object.isRequired,
+    parent: Types.object.isRequired,
+    readOnly: Types.bool.isRequired,
+    schema: Types.object.isRequired,
+    state: Types.object.isRequired
+  }
+
+  /**
+   * Constructor.
+   *
+   * @param {Object} props
+   */
+
+  constructor(props) {
+    super(props)
+    const { node, schema } = props
+    this.state = {}
+    this.state.Component = node.kind == 'text' ? null : node.getComponent(schema)
+  }
+
+  /**
+   * Debug.
+   *
+   * @param {String} message
+   * @param {Mixed} ...args
+   */
+
+  debug = (message, ...args) => {
+    const { node } = this.props
+    const { key, kind, type } = node
+    const id = kind == 'text' ? `${key} (${kind})` : `${key} (${type})`
+    debug(message, `${id}`, ...args)
+  }
+
+  /**
+   * On receiving new props, update the `Component` renderer.
+   *
+   * @param {Object} props
+   */
+
+  componentWillReceiveProps = (props) => {
+    if (props.node.kind == 'text') return
+    if (props.node == this.props.node) return
+    const Component = props.node.getComponent(props.schema)
+    this.setState({ Component })
+  }
+
+  /**
+   * Should the node update?
+   *
+   * @param {Object} nextProps
+   * @param {Object} state
+   * @return {Boolean}
+   */
+
+  shouldComponentUpdate = (nextProps) => {
+    const { props } = this
+    const { Component } = this.state
+
+    // If the `Component` has enabled suppression of update checking, always
+    // return true so that it can deal with update checking itself.
+    if (Component && Component.suppressShouldComponentUpdate) return true
+
+    // If the `readOnly` status has changed, re-render in case there is any
+    // user-land logic that depends on it, like nested editable contents.
+    if (nextProps.readOnly != props.readOnly) return true
+
+    // If the node has changed, update. PERF: There are cases where it will have
+    // changed, but it's properties will be exactly the same (eg. copy-paste)
+    // which this won't catch. But that's rare and not a drag on performance, so
+    // for simplicity we just let them through.
+    if (nextProps.node != props.node) return true
+
+    // If the node is a block or inline, which can have custom renderers, we
+    // include an extra check to re-render if the node's focus changes, to make
+    // it simple for users to show a node's "selected" state.
+    if (nextProps.node.kind != 'text') {
+      const hasEdgeIn = props.state.selection.hasEdgeIn(props.node)
+      const nextHasEdgeIn = nextProps.state.selection.hasEdgeIn(nextProps.node)
+      const hasFocus = props.state.isFocused || nextProps.state.isFocused
+      const hasEdge = hasEdgeIn || nextHasEdgeIn
+      if (hasFocus && hasEdge) return true
+    }
+
+    // If the node is a text node, re-render if the current decorations have
+    // changed, even if the content of the text node itself hasn't.
+    if (nextProps.node.kind == 'text' && nextProps.schema.hasDecorators) {
+      const nextDecorators = nextProps.state.document.getDescendantDecorators(nextProps.node.key, nextProps.schema)
+      const decorators = props.state.document.getDescendantDecorators(props.node.key, props.schema)
+      const nextRanges = nextProps.node.getRanges(nextDecorators)
+      const ranges = props.node.getRanges(decorators)
+      if (!nextRanges.equals(ranges)) return true
+    }
+
+    // If the node is a text node, and its parent is a block node, and it was
+    // the last child of the block, re-render to cleanup extra `<br/>` or `\n`.
+    if (nextProps.node.kind == 'text' && nextProps.parent.kind == 'block') {
+      const last = props.parent.nodes.last()
+      const nextLast = nextProps.parent.nodes.last()
+      if (props.node == last && nextProps.node != nextLast) return true
+    }
+
+    // Otherwise, don't update.
+    return false
+  }
+
+  /**
+   * On mount, update the scroll position.
+   */
+
+  componentDidMount = () => {
+    this.updateScroll()
+  }
+
+  /**
+   * After update, update the scroll position if the node's content changed.
+   *
+   * @param {Object} prevProps
+   * @param {Object} prevState
+   */
+
+  componentDidUpdate = (prevProps, prevState) => {
+    if (this.props.node != prevProps.node) this.updateScroll()
+  }
+
+  /**
+   * Update the scroll position after a change as occured if this is a leaf
+   * block and it has the selection's ending edge. This ensures that scrolling
+   * matches native `contenteditable` behavior even for cases where the edit is
+   * not applied natively, like when enter is pressed.
+   */
+
+  updateScroll = () => {
+    const { node, state } = this.props
+    const { selection } = state
+
+    // If this isn't a block, or it's a wrapping block, abort.
+    if (node.kind != 'block') return
+    if (node.nodes.first().kind == 'block') return
+
+    // If the selection is blurred, or this block doesn't contain it, abort.
+    if (selection.isBlurred) return
+    if (!selection.hasEndIn(node)) return
+
+    // The native selection will be updated after componentDidMount or componentDidUpdate.
+    // Use setTimeout to queue scrolling to the last when the native selection has been updated to the correct value.
+    setTimeout(() => {
+      const el = ReactDOM.findDOMNode(this)
+      const window = getWindow(el)
+      const native = window.getSelection()
+      scrollToSelection(native)
+
+      this.debug('updateScroll', el)
+    })
+  }
+
+  /**
+   * On drag start, add a serialized representation of the node to the data.
+   *
+   * @param {Event} e
+   */
+
+  onDragStart = (e) => {
+    const { node } = this.props
+    const encoded = Base64.serializeNode(node, { preserveKeys: true })
+    const data = e.nativeEvent.dataTransfer
+    data.setData(TYPES.NODE, encoded)
+
+    this.debug('onDragStart', e)
+  }
+
+  /**
+   * Render.
+   *
+   * @return {Element}
+   */
+
+  render = () => {
+    const { props } = this
+    const { node } = this.props
+
+    this.debug('render', { props })
+
+    return node.kind == 'text'
+      ? this.renderText()
+      : this.renderElement()
+  }
+
+  /**
+   * Render a `child` node.
+   *
+   * @param {Node} child
+   * @return {Element}
+   */
+
+  renderNode = (child) => {
+    const { block, editor, node, readOnly, schema, state } = this.props
+    return (
+      <Node
+        key={child.key}
+        node={child}
+        block={node.kind == 'block' ? node : block}
+        parent={node}
+        editor={editor}
+        readOnly={readOnly}
+        schema={schema}
+        state={state}
+      />
+    )
+  }
+
+  /**
+   * Render an element `node`.
+   *
+   * @return {Element}
+   */
+
+  renderElement = () => {
+    const { editor, node, parent, readOnly, state } = this.props
+    const { Component } = this.state
+    const children = node.nodes.map(this.renderNode).toArray()
+
+    // Attributes that the developer must to mix into the element in their
+    // custom node renderer component.
+    const attributes = {
+      'data-key': node.key,
+      'onDragStart': this.onDragStart
+    }
+
+    // If it's a block node with inline children, add the proper `dir` attribute
+    // for text direction.
+    if (node.kind == 'block' && node.nodes.first().kind != 'block') {
+      const direction = node.getTextDirection()
+      if (direction == 'rtl') attributes.dir = 'rtl'
+    }
+
+    const element = (
+      <Component
+        attributes={attributes}
+        key={node.key}
+        editor={editor}
+        parent={parent}
+        node={node}
+        readOnly={readOnly}
+        state={state}
+      >
+        {children}
+      </Component>
+    )
+
+    return node.isVoid
+      ? <Void {...this.props}>{element}</Void>
+      : element
+  }
+
+  /**
+   * Render a text node.
+   *
+   * @return {Element}
+   */
+
+  renderText = () => {
+    const { node, schema, state } = this.props
+    const { document } = state
+    const decorators = schema.hasDecorators ? document.getDescendantDecorators(node.key, schema) : []
+    const ranges = node.getRanges(decorators)
+    let offset = 0
+
+    const leaves = ranges.map((range, i) => {
+      const leaf = this.renderLeaf(ranges, range, i, offset)
+      offset += range.text.length
+      return leaf
+    })
+
+    return (
+      <span data-key={node.key}>
+        {leaves}
+      </span>
+    )
+  }
+
+  /**
+   * Render a single leaf node given a `range` and `offset`.
+   *
+   * @param {List<Range>} ranges
+   * @param {Range} range
+   * @param {Number} index
+   * @param {Number} offset
+   * @return {Element} leaf
+   */
+
+  renderLeaf = (ranges, range, index, offset) => {
+    const { block, node, parent, schema, state, editor } = this.props
+    const { text, marks } = range
+
+    return (
+      <Leaf
+        key={`${node.key}-${index}`}
+        block={block}
+        editor={editor}
+        index={index}
+        marks={marks}
+        node={node}
+        offset={offset}
+        parent={parent}
+        ranges={ranges}
+        schema={schema}
+        state={state}
+        text={text}
+      />
+    )
+  }
+
+}
+
+/**
+ * Export.
+ *
+ * @type {Component}
+ */
+
+export default Node

--- a/src/lib/slate/components/placeholder.js
+++ b/src/lib/slate/components/placeholder.js
@@ -1,0 +1,124 @@
+
+import React from 'react'
+import Types from 'prop-types'
+
+/**
+ * Placeholder.
+ *
+ * @type {Component}
+ */
+
+class Placeholder extends React.Component {
+
+  /**
+   * Property types.
+   *
+   * @type {Object}
+   */
+
+  static propTypes = {
+    children: Types.any.isRequired,
+    className: Types.string,
+    firstOnly: Types.bool,
+    node: Types.object.isRequired,
+    parent: Types.object,
+    state: Types.object.isRequired,
+    style: Types.object
+  }
+
+  /**
+   * Default properties.
+   *
+   * @type {Object}
+   */
+
+  static defaultProps = {
+    firstOnly: true
+  }
+
+  /**
+   * Should the placeholder update?
+   *
+   * @param {Object} props
+   * @param {Object} state
+   * @return {Boolean}
+   */
+
+  shouldComponentUpdate = (props, state) => {
+    return (
+      props.children != this.props.children ||
+      props.className != this.props.className ||
+      props.firstOnly != this.props.firstOnly ||
+      props.parent != this.props.parent ||
+      props.node != this.props.node ||
+      props.style != this.props.style
+    )
+  }
+
+  /**
+   * Is the placeholder visible?
+   *
+   * @return {Boolean}
+   */
+
+  isVisible = () => {
+    const { firstOnly, node, parent } = this.props
+    if (node.text) return false
+
+    if (firstOnly) {
+      if (parent.nodes.size > 1) return false
+      if (parent.nodes.first() === node) return true
+      return false
+    } else {
+      return true
+    }
+  }
+
+  /**
+   * Render.
+   *
+   * If the placeholder is a string, and no `className` or `style` has been
+   * passed, give it a default style of lowered opacity.
+   *
+   * @return {Element}
+   */
+
+  render = () => {
+    const isVisible = this.isVisible()
+    if (!isVisible) return null
+
+    const { children, className } = this.props
+    let { style } = this.props
+
+    if (typeof children === 'string' && style == null && className == null) {
+      style = { opacity: '0.333' }
+    } else if (style == null) {
+      style = {}
+    }
+
+    const styles = {
+      position: 'absolute',
+      top: '0px',
+      right: '0px',
+      bottom: '0px',
+      left: '0px',
+      pointerEvents: 'none',
+      ...style
+    }
+
+    return (
+      <span contentEditable={false} className={className} style={styles}>
+        {children}
+      </span>
+    )
+  }
+
+}
+
+/**
+ * Export.
+ *
+ * @type {Component}
+ */
+
+export default Placeholder

--- a/src/lib/slate/components/void.js
+++ b/src/lib/slate/components/void.js
@@ -1,0 +1,196 @@
+
+import Debug from 'debug'
+import React from 'react'
+import Types from 'prop-types'
+
+import Leaf from './leaf'
+import Mark from '../models/mark'
+import OffsetKey from '../utils/offset-key'
+import { IS_FIREFOX } from '../constants/environment'
+
+/**
+ * Debug.
+ *
+ * @type {Function}
+ */
+
+const debug = Debug('slate:void')
+
+/**
+ * Void.
+ *
+ * @type {Component}
+ */
+
+class Void extends React.Component {
+
+  /**
+   * Property types.
+   *
+   * @type {Object}
+   */
+
+  static propTypes = {
+    block: Types.object,
+    children: Types.any.isRequired,
+    editor: Types.object.isRequired,
+    node: Types.object.isRequired,
+    parent: Types.object.isRequired,
+    schema: Types.object.isRequired,
+    state: Types.object.isRequired,
+  }
+
+  /**
+   * Debug.
+   *
+   * @param {String} message
+   * @param {Mixed} ...args
+   */
+
+  debug = (message, ...args) => {
+    const { node } = this.props
+    const { key, type } = node
+    const id = `${key} (${type})`
+    debug(message, `${id}`, ...args)
+  }
+
+  /**
+   * When one of the wrapper elements it clicked, select the void node.
+   *
+   * @param {Event} event
+   */
+
+  onClick = (event) => {
+    this.debug('onClick', { event })
+
+    const { node, editor } = this.props
+    const next = editor
+      .getState()
+      .transform()
+      // COMPAT: In Chrome & Safari, selections that are at the zero offset of
+      // an inline node will be automatically replaced to be at the last offset
+      // of a previous inline node, which screws us up, so we always want to set
+      // it to the end of the node. (2016/11/29)
+      .collapseToEndOf(node)
+      .focus()
+      .apply()
+
+    editor.onChange(next)
+  }
+
+  /**
+   * Render.
+   *
+   * @return {Element}
+   */
+
+  render = () => {
+    const { props } = this
+    const { children, node } = props
+    let Tag, style
+
+    // Make the outer wrapper relative, so the spacer can overlay it.
+    if (node.kind === 'block') {
+      Tag = 'div'
+      style = { position: 'relative' }
+    } else {
+      Tag = 'span'
+    }
+
+    this.debug('render', { props })
+
+    return (
+      <Tag data-slate-void style={style} onClick={this.onClick}>
+        {this.renderSpacer()}
+        <Tag contentEditable={false}>
+          {children}
+        </Tag>
+      </Tag>
+    )
+  }
+
+  /**
+   * Render a fake spacer leaf, which will catch the cursor when it the void
+   * node is navigated to with the arrow keys. Having this spacer there means
+   * the browser continues to manage the selection natively, so it keeps track
+   * of the right offset when moving across the block.
+   *
+   * @return {Element}
+   */
+
+  renderSpacer = () => {
+    const { node } = this.props
+    let style
+
+    if (node.kind === 'block') {
+      style = IS_FIREFOX
+        ? {
+          pointerEvents: 'none',
+          width: '0px',
+          height: '0px',
+          lineHeight: '0px',
+          visibility: 'hidden'
+        }
+        : {
+          position: 'absolute',
+          top: '0px',
+          left: '-9999px',
+          textIndent: '-9999px'
+        }
+    } else {
+      style = {
+        color: 'transparent'
+      }
+    }
+
+    return (
+      <span style={style}>{this.renderLeaf()}</span>
+    )
+  }
+
+  /**
+   * Render a fake leaf.
+   *
+   * @return {Element}
+   */
+
+  renderLeaf = () => {
+    const { block, node, schema, state, editor } = this.props
+    const child = node.getFirstText()
+    const ranges = child.getRanges()
+    const text = ''
+    const offset = 0
+    const marks = Mark.createSet()
+    const index = 0
+    const offsetKey = OffsetKey.stringify({
+      key: child.key,
+      index
+    })
+
+    return (
+      <Leaf
+        key={offsetKey}
+        block={node.kind === 'block' ? node : block}
+        editor={editor}
+        index={index}
+        marks={marks}
+        node={child}
+        offset={offset}
+        parent={node}
+        ranges={ranges}
+        schema={schema}
+        state={state}
+        text={text}
+      />
+    )
+  }
+
+}
+
+/**
+ * Export.
+ *
+ * @type {Component}
+ */
+
+export default Void

--- a/src/lib/slate/constants/Readme.md
+++ b/src/lib/slate/constants/Readme.md
@@ -1,0 +1,2 @@
+
+This directory contains constants that are referenced elsewhere in Slate's codebase. They are kept here for consistency.

--- a/src/lib/slate/constants/environment.js
+++ b/src/lib/slate/constants/environment.js
@@ -1,0 +1,79 @@
+
+import browser from 'is-in-browser'
+
+/**
+ * Browser matching rules.
+ *
+ * @type {Array}
+ */
+
+const BROWSER_RULES = [
+  ['edge', /Edge\/([0-9\._]+)/],
+  ['chrome', /(?!Chrom.*OPR)Chrom(?:e|ium)\/([0-9\.]+)(:?\s|$)/],
+  ['firefox', /Firefox\/([0-9\.]+)(?:\s|$)/],
+  ['opera', /Opera\/([0-9\.]+)(?:\s|$)/],
+  ['opera', /OPR\/([0-9\.]+)(:?\s|$)$/],
+  ['ie', /Trident\/7\.0.*rv\:([0-9\.]+)\).*Gecko$/],
+  ['ie', /MSIE\s([0-9\.]+);.*Trident\/[4-7].0/],
+  ['ie', /MSIE\s(7\.0)/],
+  ['android', /Android\s([0-9\.]+)/],
+  ['safari', /Version\/([0-9\._]+).*Safari/],
+]
+
+/**
+ * Operating system matching rules.
+ *
+ * @type {Array}
+ */
+
+const OS_RULES = [
+  ['macos', /mac os x/i],
+  ['ios', /os ([\.\_\d]+) like mac os/i],
+  ['android', /android/i],
+  ['firefoxos', /mozilla\/[a-z\.\_\d]+ \((?:mobile)|(?:tablet)/i],
+  ['windows', /windows\s*(?:nt)?\s*([\.\_\d]+)/i],
+]
+
+/**
+ * Define variables to store the result.
+ */
+
+let BROWSER
+let OS
+
+/**
+ * Run the matchers when in browser.
+ */
+
+if (browser) {
+  const { userAgent } = window.navigator
+
+  for (const rule of BROWSER_RULES) {
+    const [ name, regexp ] = rule
+    if (regexp.test(userAgent)) {
+      BROWSER = name
+      break
+    }
+  }
+
+  for (const rule of OS_RULES) {
+    const [ name, regexp ] = rule
+    if (regexp.test(userAgent)) {
+      OS = name
+      break
+    }
+  }
+}
+
+/**
+ * Export.
+ *
+ * @type {Object}
+ */
+
+export const IS_CHROME = BROWSER === 'chrome'
+export const IS_FIREFOX = BROWSER === 'firefox'
+export const IS_SAFARI = BROWSER === 'safari'
+
+export const IS_MAC = OS === 'macos'
+export const IS_WINDOWS = OS === 'windows'

--- a/src/lib/slate/constants/is-dev.js
+++ b/src/lib/slate/constants/is-dev.js
@@ -1,0 +1,20 @@
+
+/**
+ * Is in development?
+ *
+ * @type {Boolean}
+ */
+
+const IS_DEV = (
+  typeof process !== 'undefined' &&
+  process.env &&
+  process.env.NODE_ENV !== 'production'
+)
+
+/**
+ * Export.
+ *
+ * @type {Boolean}
+ */
+
+export default IS_DEV

--- a/src/lib/slate/constants/types.js
+++ b/src/lib/slate/constants/types.js
@@ -1,0 +1,19 @@
+
+/**
+ * Slate-specific data transfer types.
+ *
+ * @type {Object}
+ */
+
+const TYPES = {
+  FRAGMENT: 'application/x-slate-fragment',
+  NODE: 'application/x-slate-node',
+}
+
+/**
+ * Export.
+ *
+ * @type {Object}
+ */
+
+export default TYPES

--- a/src/lib/slate/index.js
+++ b/src/lib/slate/index.js
@@ -1,0 +1,99 @@
+
+/**
+ * Components.
+ */
+
+import Editor from './components/editor'
+import Placeholder from './components/placeholder'
+
+/**
+ * Models.
+ */
+
+import Block from './models/block'
+import Character from './models/character'
+import Data from './models/data'
+import Document from './models/document'
+import Inline from './models/inline'
+import Mark from './models/mark'
+import Schema from './models/schema'
+import Selection from './models/selection'
+import Stack from './models/stack'
+import State from './models/state'
+import Text from './models/text'
+import Range from './models/range'
+
+/**
+ * Serializers.
+ */
+
+import Html from './serializers/html'
+import Plain from './serializers/plain'
+import Raw from './serializers/raw'
+
+/**
+ * Transforms.
+ */
+
+import Transforms from './transforms'
+
+/**
+ * Utils.
+ */
+
+import findDOMNode from './utils/find-dom-node'
+import { resetKeyGenerator, setKeyGenerator } from './utils/generate-key'
+
+/**
+ * Export.
+ *
+ * @type {Object}
+ */
+
+export {
+  Block,
+  Character,
+  Data,
+  Document,
+  Editor,
+  Html,
+  Inline,
+  Mark,
+  Placeholder,
+  Plain,
+  Range,
+  Raw,
+  Schema,
+  Selection,
+  Stack,
+  State,
+  Text,
+  Transforms,
+  findDOMNode,
+  resetKeyGenerator,
+  setKeyGenerator
+}
+
+export default {
+  Block,
+  Character,
+  Data,
+  Document,
+  Editor,
+  Html,
+  Inline,
+  Mark,
+  Placeholder,
+  Plain,
+  Range,
+  Raw,
+  Schema,
+  Selection,
+  Stack,
+  State,
+  Text,
+  Transforms,
+  findDOMNode,
+  resetKeyGenerator,
+  setKeyGenerator
+}

--- a/src/lib/slate/models/Readme.md
+++ b/src/lib/slate/models/Readme.md
@@ -1,0 +1,73 @@
+
+This directory contains all of the immutable models that contain the data that powers Slate. They are built using [Immutable.js](https://facebook.github.io/immutable-js/). Here's what each of them does:
+
+- [Block](#block)
+- [Character](#character)
+- [Data](#data)
+- [Document](#document)
+- [Inline](#inline)
+- [Mark](#mark)
+- [Node](#node)
+- [Selection](#selection)
+- [State](#state)
+- [Text](#text)
+- [Transform](#transform)
+
+
+#### Block
+
+Just like in the DOM, `Block` nodes are one that contain other inline content. They can be split apart, and wrapped in other blocks, but they will always contain at least a single [`Text`](#text) node of inline content. They can also contain associated [`Data`](#data)
+
+
+#### Character
+
+The content of each [`Text`](#text) node is modeled as a `Character` list. Each character contains a single character string, and any associated [`Marks`](#mark) that are applied to it.
+
+
+#### Data
+
+`Data` is just a thin wrapper around [`Immutable.Map`](https://facebook.github.io/immutable-js/docs/#/Map), which allows for more easily creating maps without having to require [`Immutable`](https://facebook.github.io/immutable-js/) itself.
+
+
+#### Document
+
+The `Document` is where all of the content in the editor is stored. It is a recursively nested tree of [`Nodes`](#node), just like the DOM itself. Which can either be [`Block`](#block), [`Inline`](#inline), or [`Text`](#text) nodes.
+
+
+#### Inline
+
+Similar to [`Block`](#block) nodes, but containing inline content instead of block-level content. They too can be nested to any depth, but at the lowest level will always contain a single [`Text`](#text) node.
+
+
+#### Mark
+
+Marks are the pieces of "formatting" that can be applied to strings of text in the editor. Unlike [`Nodes`](#nodes), `Marks` are modeled as a flat set, such that each character can have multiple marks associated with it. This allows for cases where a link (ie. an inline node) can also have bold (ie. a mark) formatting attached to part of it.
+
+
+#### Node
+
+`Node` isn't actually a model that is exposed, but instead it's an interface full of convenience methods that [`Document`](#document), [`Block`](#block), [`Inline`](#inline) all implement.
+
+
+#### Selection
+
+The `Selection` keeps track of where the user's cursor is. It's modeled after the [DOM Selection API](https://developer.mozilla.org/en-US/docs/Web/API/Selection), using terms like "anchor", "focus" and "collapsed".
+
+
+#### State
+
+The `State` is the highest-level model. It is really just a convenient wrapper around a few other models: [`Document`](#document), [`Selection`](#selection), and a `History` which is not publicly exposed.
+
+Since `State` has knowledge of both the [`Document`](#document) and the [`Selection`](#selection), it provides a handful of convenience methods for updating the both at the same time. For example, when inserting a new content fragment, it inserts the fragment and then moves the selection to the end of the newly inserted content.
+
+The `State` is the object that lets you apply "transforms" that change the current document or selection. By having them all be applied through the top-level state, it can keep track of changes in the `History`, allowing for undoing and redoing changes.
+
+
+#### Text
+
+`Text` is the lowest-level [`Node`](#node) in the tree. Each `Text` node contains a list of [`Characters`](#characters), which can optionally be dynamically decorated.
+
+
+#### Transform
+
+`Transform` is not publicly exposed; you access it by calling the `transform()` method on a [`State`](#state) model. It's simply a wrapper around the somewhat-complex transformation logic that allows for a state's history to be populated correctly.

--- a/src/lib/slate/models/block.js
+++ b/src/lib/slate/models/block.js
@@ -1,0 +1,136 @@
+
+/**
+ * Prevent circular dependencies.
+ */
+
+import './document'
+import './inline'
+
+/**
+ * Dependencies.
+ */
+
+import Data from './data'
+import Inline from './inline'
+import Node from './node'
+import Text from './text'
+import generateKey from '../utils/generate-key'
+import { Map, List, Record } from 'immutable'
+
+/**
+ * Default properties.
+ *
+ * @type {Object}
+ */
+
+const DEFAULTS = {
+  data: new Map(),
+  isVoid: false,
+  key: null,
+  nodes: new List(),
+  type: null
+}
+
+/**
+ * Block.
+ *
+ * @type {Block}
+ */
+
+class Block extends new Record(DEFAULTS) {
+
+  /**
+   * Create a new `Block` with `properties`.
+   *
+   * @param {Object|Block} properties
+   * @return {Block}
+   */
+
+  static create(properties = {}) {
+    if (properties instanceof Block) return properties
+    if (properties instanceof Inline) return properties
+    if (properties instanceof Text) return properties
+    if (!properties.type) throw new Error('You must pass a block `type`.')
+
+    properties.key = properties.key || generateKey()
+    properties.data = Data.create(properties.data)
+    properties.isVoid = !!properties.isVoid
+    properties.nodes = Block.createList(properties.nodes)
+
+    if (properties.nodes.size == 0) {
+      properties.nodes = properties.nodes.push(Text.create())
+    }
+
+    return new Block(properties)
+  }
+
+  /**
+   * Create a list of `Blocks` from an array.
+   *
+   * @param {Array<Object|Block>} elements
+   * @return {List<Block>}
+   */
+
+  static createList(elements = []) {
+    if (List.isList(elements)) return elements
+    return new List(elements.map(Block.create))
+  }
+
+  /**
+   * Get the node's kind.
+   *
+   * @return {String}
+   */
+
+  get kind() {
+    return 'block'
+  }
+
+  /**
+   * Is the node empty?
+   *
+   * @return {Boolean}
+   */
+
+  get isEmpty() {
+    return this.text == ''
+  }
+
+  /**
+   * Get the length of the concatenated text of the node.
+   *
+   * @return {Number}
+   */
+
+  get length() {
+    return this.text.length
+  }
+
+  /**
+   * Get the concatenated text `string` of all child nodes.
+   *
+   * @return {String}
+   */
+
+  get text() {
+    return this.getText()
+  }
+
+}
+
+/**
+ * Mix in `Node` methods.
+ */
+
+for (const method in Node) {
+  Block.prototype[method] = Node[method]
+}
+
+
+/**
+ * Export.
+ *
+ * @type {Block}
+ */
+
+export default Block

--- a/src/lib/slate/models/character.js
+++ b/src/lib/slate/models/character.js
@@ -1,0 +1,81 @@
+
+import Mark from './mark'
+import { List, Record, Set } from 'immutable'
+
+/**
+ * Default properties.
+ *
+ * @type {Object}
+ */
+
+const DEFAULTS = {
+  marks: new Set(),
+  text: ''
+}
+
+/**
+ * Character.
+ *
+ * @type {Character}
+ */
+
+class Character extends new Record(DEFAULTS) {
+
+  /**
+   * Create a character record with `properties`.
+   *
+   * @param {Object|Character} properties
+   * @return {Character}
+   */
+
+  static create(properties = {}) {
+    if (properties instanceof Character) return properties
+    properties.marks = Mark.createSet(properties.marks)
+    return new Character(properties)
+  }
+
+  /**
+   * Create a characters list from an array of characters.
+   *
+   * @param {Array<Object|Character>} array
+   * @return {List<Character>}
+   */
+
+  static createList(array = []) {
+    if (List.isList(array)) return array
+    return new List(array.map(Character.create))
+  }
+
+  /**
+   * Create a characters list from a `string` and optional `marks`.
+   *
+   * @param {String} string
+   * @param {Set<Mark>} marks (optional)
+   * @return {List<Character>}
+   */
+
+  static createListFromText(string, marks) {
+    const chars = string.split('').map((text) => { return { text, marks } })
+    const list = Character.createList(chars)
+    return list
+  }
+
+  /**
+   * Get the kind.
+   *
+   * @return {String}
+   */
+
+  get kind() {
+    return 'character'
+  }
+
+}
+
+/**
+ * Export.
+ *
+ * @type {Character}
+ */
+
+export default Character

--- a/src/lib/slate/models/data.js
+++ b/src/lib/slate/models/data.js
@@ -1,0 +1,36 @@
+
+import { Map } from 'immutable'
+
+/**
+ * Data.
+ *
+ * This isn't an immutable record, it's just a thin wrapper around `Map` so that
+ * we can allow for more convenient creation.
+ *
+ * @type {Object}
+ */
+
+const Data = {
+
+  /**
+   * Create a new `Data` with `properties`.
+   *
+   * @param {Object} properties
+   * @return {Data} data
+   */
+
+  create(properties = {}) {
+    return Map.isMap(properties)
+      ? properties
+      : new Map(properties)
+  }
+
+}
+
+/**
+ * Export.
+ *
+ * @type {Object}
+ */
+
+export default Data

--- a/src/lib/slate/models/document.js
+++ b/src/lib/slate/models/document.js
@@ -1,0 +1,112 @@
+
+/**
+ * Prevent circular dependencies.
+ */
+
+import './block'
+import './inline'
+
+/**
+ * Dependencies.
+ */
+
+import Data from './data'
+import Block from './block'
+import Node from './node'
+import generateKey from '../utils/generate-key'
+import { List, Map, Record } from 'immutable'
+
+/**
+ * Default properties.
+ *
+ * @type {Object}
+ */
+
+const DEFAULTS = {
+  data: new Map(),
+  key: null,
+  nodes: new List(),
+}
+
+/**
+ * Document.
+ *
+ * @type {Document}
+ */
+
+class Document extends new Record(DEFAULTS) {
+
+  /**
+   * Create a new `Document` with `properties`.
+   *
+   * @param {Object|Document} properties
+   * @return {Document}
+   */
+
+  static create(properties = {}) {
+    if (properties instanceof Document) return properties
+
+    properties.key = properties.key || generateKey()
+    properties.data = Data.create(properties.data)
+    properties.nodes = Block.createList(properties.nodes)
+
+    return new Document(properties)
+  }
+
+  /**
+   * Get the node's kind.
+   *
+   * @return {String}
+   */
+
+  get kind() {
+    return 'document'
+  }
+
+  /**
+   * Is the document empty?
+   *
+   * @return {Boolean}
+   */
+
+  get isEmpty() {
+    return this.text == ''
+  }
+
+  /**
+   * Get the length of the concatenated text of the document.
+   *
+   * @return {Number}
+   */
+
+  get length() {
+    return this.text.length
+  }
+
+  /**
+   * Get the concatenated text `string` of all child nodes.
+   *
+   * @return {String}
+   */
+
+  get text() {
+    return this.getText()
+  }
+
+}
+
+/**
+ * Mix in `Node` methods.
+ */
+
+for (const method in Node) {
+  Document.prototype[method] = Node[method]
+}
+
+/**
+ * Export.
+ *
+ * @type {Document}
+ */
+
+export default Document

--- a/src/lib/slate/models/inline.js
+++ b/src/lib/slate/models/inline.js
@@ -1,0 +1,135 @@
+
+/**
+ * Prevent circular dependencies.
+ */
+
+import './block'
+import './document'
+
+/**
+ * Dependencies.
+ */
+
+import Block from './block'
+import Data from './data'
+import Node from './node'
+import Text from './text'
+import generateKey from '../utils/generate-key'
+import { List, Map, Record } from 'immutable'
+
+/**
+ * Default properties.
+ *
+ * @type {Object}
+ */
+
+const DEFAULTS = {
+  data: new Map(),
+  isVoid: false,
+  key: null,
+  nodes: new List(),
+  type: null
+}
+
+/**
+ * Inline.
+ *
+ * @type {Inline}
+ */
+
+class Inline extends new Record(DEFAULTS) {
+
+  /**
+   * Create a new `Inline` with `properties`.
+   *
+   * @param {Object|Inline} properties
+   * @return {Inline}
+   */
+
+  static create(properties = {}) {
+    if (properties instanceof Block) return properties
+    if (properties instanceof Inline) return properties
+    if (properties instanceof Text) return properties
+    if (!properties.type) throw new Error('You must pass an inline `type`.')
+
+    properties.key = properties.key || generateKey()
+    properties.data = Data.create(properties.data)
+    properties.isVoid = !!properties.isVoid
+    properties.nodes = Inline.createList(properties.nodes)
+
+    if (properties.nodes.size == 0) {
+      properties.nodes = properties.nodes.push(Text.create())
+    }
+
+    return new Inline(properties)
+  }
+
+  /**
+   * Create a list of `Inlines` from an array.
+   *
+   * @param {Array<Object|Inline>} elements
+   * @return {List<Inline>}
+   */
+
+  static createList(elements = []) {
+    if (List.isList(elements)) return elements
+    return new List(elements.map(Inline.create))
+  }
+
+  /**
+   * Get the node's kind.
+   *
+   * @return {String}
+   */
+
+  get kind() {
+    return 'inline'
+  }
+
+  /**
+   * Is the node empty?
+   *
+   * @return {Boolean}
+   */
+
+  get isEmpty() {
+    return this.text == ''
+  }
+
+  /**
+   * Get the length of the concatenated text of the node.
+   *
+   * @return {Number}
+   */
+
+  get length() {
+    return this.text.length
+  }
+
+  /**
+   * Get the concatenated text `string` of all child nodes.
+   *
+   * @return {String}
+   */
+
+  get text() {
+    return this.getText()
+  }
+
+}
+
+/**
+ * Mix in `Node` methods.
+ */
+
+for (const method in Node) {
+  Inline.prototype[method] = Node[method]
+}
+
+/**
+ * Export.
+ *
+ * @type {Inline}
+ */
+
+export default Inline

--- a/src/lib/slate/models/mark.js
+++ b/src/lib/slate/models/mark.js
@@ -1,0 +1,90 @@
+
+import Data from './data'
+import memoize from '../utils/memoize'
+import { Map, Record, Set } from 'immutable'
+
+/**
+ * Default properties.
+ *
+ * @type {Object}
+ */
+
+const DEFAULTS = {
+  data: new Map(),
+  type: null
+}
+
+/**
+ * Mark.
+ *
+ * @type {Mark}
+ */
+
+class Mark extends new Record(DEFAULTS) {
+
+  /**
+   * Create a new `Mark` with `properties`.
+   *
+   * @param {Object|Mark} properties
+   * @return {Mark}
+   */
+
+  static create(properties = {}) {
+    if (properties instanceof Mark) return properties
+    if (!properties.type) throw new Error('You must provide a `type` for the mark.')
+    properties.data = Data.create(properties.data)
+    return new Mark(properties)
+  }
+
+  /**
+   * Create a marks set from an array of marks.
+   *
+   * @param {Array<Object|Mark>} array
+   * @return {Set<Mark>}
+   */
+
+  static createSet(array = []) {
+    if (Set.isSet(array)) return array
+    return new Set(array.map(Mark.create))
+  }
+
+  /**
+   * Get the kind.
+   *
+   * @return {String}
+   */
+
+  get kind() {
+    return 'mark'
+  }
+
+  /**
+   * Get the component for the node from a `schema`.
+   *
+   * @param {Schema} schema
+   * @return {Component|Void}
+   */
+
+  getComponent(schema) {
+    return schema.__getComponent(this)
+  }
+
+}
+
+/**
+ * Memoize read methods.
+ */
+
+memoize(Mark.prototype, [
+  'getComponent',
+], {
+  takesArguments: true,
+})
+
+/**
+ * Export.
+ *
+ * @type {Mark}
+ */
+
+export default Mark

--- a/src/lib/slate/models/node.js
+++ b/src/lib/slate/models/node.js
@@ -1,0 +1,1908 @@
+
+import Document from './document'
+import Normalize from '../utils/normalize'
+import direction from 'direction'
+import generateKey from '../utils/generate-key'
+import isInRange from '../utils/is-in-range'
+import memoize from '../utils/memoize'
+import warn from '../utils/warn'
+import { List, OrderedSet, Set } from 'immutable'
+
+/**
+ * Node.
+ *
+ * And interface that `Document`, `Block` and `Inline` all implement, to make
+ * working with the recursive node tree easier.
+ *
+ * @type {Object}
+ */
+
+const Node = {
+
+  /**
+   * True if the node has both descendants in that order, false otherwise. The
+   * order is depth-first, post-order.
+   *
+   * @param {String} first
+   * @param {String} second
+   * @return {Boolean}
+   */
+
+  areDescendantsSorted(first, second) {
+    first = Normalize.key(first)
+    second = Normalize.key(second)
+
+    let sorted
+
+    this.forEachDescendant((n) => {
+      if (n.key === first) {
+        sorted = true
+        return false
+      } else if (n.key === second) {
+        sorted = false
+        return false
+      }
+    })
+
+    return sorted
+  },
+
+  /**
+   * Assert that a node has a child by `key` and return it.
+   *
+   * @param {String} key
+   * @return {Node}
+   */
+
+  assertChild(key) {
+    const child = this.getChild(key)
+
+    if (!child) {
+      key = Normalize.key(key)
+      throw new Error(`Could not find a child node with key "${key}".`)
+    }
+
+    return child
+  },
+
+  /**
+   * Assert that a node has a descendant by `key` and return it.
+   *
+   * @param {String} key
+   * @return {Node}
+   */
+
+  assertDescendant(key) {
+    const descendant = this.getDescendant(key)
+
+    if (!descendant) {
+      key = Normalize.key(key)
+      throw new Error(`Could not find a descendant node with key "${key}".`)
+    }
+
+    return descendant
+  },
+
+  /**
+   * Assert that a node's tree has a node by `key` and return it.
+   *
+   * @param {String} key
+   * @return {Node}
+   */
+
+  assertNode(key) {
+    const node = this.getNode(key)
+
+    if (!node) {
+      key = Normalize.key(key)
+      throw new Error(`Could not find a node with key "${key}".`)
+    }
+
+    return node
+  },
+
+  /**
+   * Assert that a node exists at `path` and return it.
+   *
+   * @param {Array} path
+   * @return {Node}
+   */
+
+  assertPath(path) {
+    const descendant = this.getDescendantAtPath(path)
+
+    if (!descendant) {
+      throw new Error(`Could not find a descendant at path "${path}".`)
+    }
+
+    return descendant
+  },
+
+  /**
+   * Recursively filter all descendant nodes with `iterator`.
+   *
+   * @param {Function} iterator
+   * @return {List<Node>}
+   */
+
+  filterDescendants(iterator) {
+    const matches = []
+
+    this.forEachDescendant((node, i, nodes) => {
+      if (iterator(node, i, nodes)) matches.push(node)
+    })
+
+    return List(matches)
+  },
+
+  /**
+   * Recursively find all descendant nodes by `iterator`.
+   *
+   * @param {Function} iterator
+   * @return {Node|Null}
+   */
+
+  findDescendant(iterator) {
+    let found = null
+
+    this.forEachDescendant((node, i, nodes) => {
+      if (iterator(node, i, nodes)) {
+        found = node
+        return false
+      }
+    })
+
+    return found
+  },
+
+  /**
+   * Recursively iterate over all descendant nodes with `iterator`. If the
+   * iterator returns false it will break the loop.
+   *
+   * @param {Function} iterator
+   */
+
+  forEachDescendant(iterator) {
+    let ret
+
+    this.nodes.forEach((child, i, nodes) => {
+      if (iterator(child, i, nodes) === false) {
+        ret = false
+        return false
+      }
+
+      if (child.kind != 'text') {
+        ret = child.forEachDescendant(iterator)
+        return ret
+      }
+    })
+
+    return ret
+  },
+
+  /**
+   * Get the path of ancestors of a descendant node by `key`.
+   *
+   * @param {String|Node} key
+   * @return {List<Node>|Null}
+   */
+
+  getAncestors(key) {
+    key = Normalize.key(key)
+
+    if (key == this.key) return List()
+    if (this.hasChild(key)) return List([this])
+
+    let ancestors
+    this.nodes.find((node) => {
+      if (node.kind == 'text') return false
+      ancestors = node.getAncestors(key)
+      return ancestors
+    })
+
+    if (ancestors) {
+      return ancestors.unshift(this)
+    } else {
+      return null
+    }
+  },
+
+  /**
+   * Get the leaf block descendants of the node.
+   *
+   * @return {List<Node>}
+   */
+
+  getBlocks() {
+    const array = this.getBlocksAsArray()
+    return new List(array)
+  },
+
+  /**
+   * Get the leaf block descendants of the node.
+   *
+   * @return {List<Node>}
+   */
+
+  getBlocksAsArray() {
+    return this.nodes.reduce((array, child) => {
+      if (child.kind != 'block') return array
+      if (!child.isLeafBlock()) return array.concat(child.getBlocksAsArray())
+      array.push(child)
+      return array
+    }, [])
+  },
+
+  /**
+   * Get the leaf block descendants in a `range`.
+   *
+   * @param {Selection} range
+   * @return {List<Node>}
+   */
+
+  getBlocksAtRange(range) {
+    const array = this.getBlocksAtRangeAsArray(range)
+    // Eliminate duplicates by converting to an `OrderedSet` first.
+    return new List(new OrderedSet(array))
+  },
+
+  /**
+   * Get the leaf block descendants in a `range` as an array
+   *
+   * @param {Selection} range
+   * @return {Array}
+   */
+
+  getBlocksAtRangeAsArray(range) {
+    return this
+      .getTextsAtRangeAsArray(range)
+      .map(text => this.getClosestBlock(text.key))
+  },
+
+  /**
+   * Get all of the leaf blocks that match a `type`.
+   *
+   * @param {String} type
+   * @return {List<Node>}
+   */
+
+  getBlocksByType(type) {
+    const array = this.getBlocksByTypeAsArray(type)
+    return new List(array)
+  },
+
+  /**
+   * Get all of the leaf blocks that match a `type` as an array
+   *
+   * @param {String} type
+   * @return {Array}
+   */
+
+  getBlocksByTypeAsArray(type) {
+    return this.nodes.reduce((array, node) => {
+      if (node.kind != 'block') {
+        return array
+      } else if (node.isLeafBlock() && node.type == type) {
+        array.push(node)
+        return array
+      } else {
+        return array.concat(node.getBlocksByTypeAsArray(type))
+      }
+    }, [])
+  },
+
+  /**
+   * Get all of the characters for every text node.
+   *
+   * @return {List<Character>}
+   */
+
+  getCharacters() {
+    const array = this.getCharactersAsArray()
+    return new List(array)
+  },
+
+  /**
+   * Get all of the characters for every text node as an array
+   *
+   * @return {Array}
+   */
+
+  getCharactersAsArray() {
+    return this.nodes.reduce((arr, node) => {
+      return node.kind == 'text'
+        ? arr.concat(node.characters.toArray())
+        : arr.concat(node.getCharactersAsArray())
+    }, [])
+  },
+
+  /**
+   * Get a list of the characters in a `range`.
+   *
+   * @param {Selection} range
+   * @return {List<Character>}
+   */
+
+  getCharactersAtRange(range) {
+    const array = this.getCharactersAtRangeAsArray(range)
+    return new List(array)
+  },
+
+  /**
+   * Get a list of the characters in a `range` as an array.
+   *
+   * @param {Selection} range
+   * @return {Array}
+   */
+
+  getCharactersAtRangeAsArray(range) {
+    return this
+      .getTextsAtRange(range)
+      .reduce((arr, text) => {
+        const chars = text.characters
+          .filter((char, i) => isInRange(i, text, range))
+          .toArray()
+
+        return arr.concat(chars)
+      }, [])
+  },
+
+  /**
+   * Get a child node by `key`.
+   *
+   * @param {String} key
+   * @return {Node|Null}
+   */
+
+  getChild(key) {
+    key = Normalize.key(key)
+    return this.nodes.find(node => node.key == key)
+  },
+
+  /**
+   * Get closest parent of node by `key` that matches `iterator`.
+   *
+   * @param {String} key
+   * @param {Function} iterator
+   * @return {Node|Null}
+   */
+
+  getClosest(key, iterator) {
+    key = Normalize.key(key)
+    const ancestors = this.getAncestors(key)
+    if (!ancestors) {
+      throw new Error(`Could not find a descendant node with key "${key}".`)
+    }
+
+    // Exclude this node itself.
+    return ancestors.rest().findLast(iterator)
+  },
+
+  /**
+   * Get the closest block parent of a `node`.
+   *
+   * @param {String} key
+   * @return {Node|Null}
+   */
+
+  getClosestBlock(key) {
+    return this.getClosest(key, parent => parent.kind == 'block')
+  },
+
+  /**
+   * Get the closest inline parent of a `node`.
+   *
+   * @param {String} key
+   * @return {Node|Null}
+   */
+
+  getClosestInline(key) {
+    return this.getClosest(key, parent => parent.kind == 'inline')
+  },
+
+  /**
+   * Get the closest void parent of a `node`.
+   *
+   * @param {String} key
+   * @return {Node|Null}
+   */
+
+  getClosestVoid(key) {
+    return this.getClosest(key, parent => parent.isVoid)
+  },
+
+  /**
+   * Get the common ancestor of nodes `one` and `two` by keys.
+   *
+   * @param {String} one
+   * @param {String} two
+   * @return {Node}
+   */
+
+  getCommonAncestor(one, two) {
+    one = Normalize.key(one)
+    two = Normalize.key(two)
+
+    if (one == this.key) return this
+    if (two == this.key) return this
+
+    this.assertDescendant(one)
+    this.assertDescendant(two)
+    let ancestors = new List()
+    let oneParent = this.getParent(one)
+    let twoParent = this.getParent(two)
+
+    while (oneParent) {
+      ancestors = ancestors.push(oneParent)
+      oneParent = this.getParent(oneParent.key)
+    }
+
+    while (twoParent) {
+      if (ancestors.includes(twoParent)) return twoParent
+      twoParent = this.getParent(twoParent.key)
+    }
+  },
+
+  /**
+   * Get the component for the node from a `schema`.
+   *
+   * @param {Schema} schema
+   * @return {Component|Void}
+   */
+
+  getComponent(schema) {
+    return schema.__getComponent(this)
+  },
+
+  /**
+   * Get the decorations for the node from a `schema`.
+   *
+   * @param {Schema} schema
+   * @return {Array}
+   */
+
+  getDecorators(schema) {
+    return schema.__getDecorators(this)
+  },
+
+  /**
+   * Get the depth of a child node by `key`, with optional `startAt`.
+   *
+   * @param {String} key
+   * @param {Number} startAt (optional)
+   * @return {Number} depth
+   */
+
+  getDepth(key, startAt = 1) {
+    this.assertDescendant(key)
+    if (this.hasChild(key)) return startAt
+    return this
+      .getFurthestAncestor(key)
+      .getDepth(key, startAt + 1)
+  },
+
+  /**
+   * Get a descendant node by `key`.
+   *
+   * @param {String} key
+   * @return {Node|Null}
+   */
+
+  getDescendant(key) {
+    key = Normalize.key(key)
+    let descendantFound = null
+
+    const found = this.nodes.find((node) => {
+      if (node.key === key) {
+        return node
+      } else if (node.kind !== 'text') {
+        descendantFound = node.getDescendant(key)
+        return descendantFound
+      } else {
+        return false
+      }
+    })
+
+    return descendantFound || found
+  },
+
+  /**
+   * Get a descendant by `path`.
+   *
+   * @param {Array} path
+   * @return {Node|Null}
+   */
+
+  getDescendantAtPath(path) {
+    let descendant = this
+
+    for (const index of path) {
+      if (!descendant) return
+      if (!descendant.nodes) return
+      descendant = descendant.nodes.get(index)
+    }
+
+    return descendant
+  },
+
+  /**
+   * Get the decorators for a descendant by `key` given a `schema`.
+   *
+   * @param {String} key
+   * @param {Schema} schema
+   * @return {Array}
+   */
+
+  getDescendantDecorators(key, schema) {
+    if (!schema.hasDecorators) {
+      return []
+    }
+
+    const descendant = this.assertDescendant(key)
+    let child = this.getFurthestAncestor(key)
+    let decorators = []
+
+    while (child != descendant) {
+      decorators = decorators.concat(child.getDecorators(schema))
+      child = child.getFurthestAncestor(key)
+    }
+
+    decorators = decorators.concat(descendant.getDecorators(schema))
+    return decorators
+  },
+
+  /**
+   * Get the first child text node.
+   *
+   * @return {Node|Null}
+   */
+
+  getFirstText() {
+    let descendantFound = null
+
+    const found = this.nodes.find((node) => {
+      if (node.kind == 'text') return true
+      descendantFound = node.getFirstText()
+      return descendantFound
+    })
+
+    return descendantFound || found
+  },
+
+  /**
+   * Get a fragment of the node at a `range`.
+   *
+   * @param {Selection} range
+   * @return {List<Node>}
+   */
+
+  getFragmentAtRange(range) {
+    let node = this
+    let nodes = new List()
+
+    // Make sure the children exist.
+    const { startKey, startOffset, endKey, endOffset } = range
+    node.assertDescendant(startKey)
+    node.assertDescendant(endKey)
+
+    // Split at the start and end.
+    const start = range.collapseToStart()
+    node = node.splitBlockAtRange(start, Infinity)
+
+    const next = node.getNextText(startKey)
+    const end = startKey == endKey
+      ? range.collapseToStartOf(next).move(endOffset - startOffset)
+      : range.collapseToEnd()
+    node = node.splitBlockAtRange(end, Infinity)
+
+    // Get the start and end nodes.
+    const startNode = node.getNextSibling(node.getFurthestAncestor(startKey).key)
+    const endNode = startKey == endKey
+      ? node.getFurthestAncestor(next.key)
+      : node.getFurthestAncestor(endKey)
+
+    // Get children range of nodes from start to end nodes
+    const startIndex = node.nodes.indexOf(startNode)
+    const endIndex = node.nodes.indexOf(endNode)
+    nodes = node.nodes.slice(startIndex, endIndex + 1)
+
+    // Return a new document fragment.
+    return Document.create({ nodes })
+  },
+
+  /**
+   * Get the furthest parent of a node by `key` that matches an `iterator`.
+   *
+   * @param {String} key
+   * @param {Function} iterator
+   * @return {Node|Null}
+   */
+
+  getFurthest(key, iterator) {
+    const ancestors = this.getAncestors(key)
+    if (!ancestors) {
+      key = Normalize.key(key)
+      throw new Error(`Could not find a descendant node with key "${key}".`)
+    }
+
+    // Exclude this node itself
+    return ancestors.rest().find(iterator)
+  },
+
+  /**
+   * Get the furthest block parent of a node by `key`.
+   *
+   * @param {String} key
+   * @return {Node|Null}
+   */
+
+  getFurthestBlock(key) {
+    return this.getFurthest(key, node => node.kind == 'block')
+  },
+
+  /**
+   * Get the furthest inline parent of a node by `key`.
+   *
+   * @param {String} key
+   * @return {Node|Null}
+   */
+
+  getFurthestInline(key) {
+    return this.getFurthest(key, node => node.kind == 'inline')
+  },
+
+  /**
+   * Get the furthest ancestor of a node by `key`.
+   *
+   * @param {String} key
+   * @return {Node|Null}
+   */
+
+  getFurthestAncestor(key) {
+    key = Normalize.key(key)
+    return this.nodes.find((node) => {
+      if (node.key == key) return true
+      if (node.kind == 'text') return false
+      return node.hasDescendant(key)
+    })
+  },
+
+  /**
+   * Get the furthest ancestor of a node by `key` that has only one child.
+   *
+   * @param {String} key
+   * @return {Node|Null}
+   */
+
+  getFurthestOnlyChildAncestor(key) {
+    const ancestors = this.getAncestors(key)
+
+    if (!ancestors) {
+      key = Normalize.key(key)
+      throw new Error(`Could not find a descendant node with key "${key}".`)
+    }
+
+    return ancestors
+      // Skip this node...
+      .skipLast()
+      // Take parents until there are more than one child...
+      .reverse().takeUntil(p => p.nodes.size > 1)
+      // And pick the highest.
+      .last()
+  },
+
+  /**
+   * Get the closest inline nodes for each text node in the node.
+   *
+   * @return {List<Node>}
+   */
+
+  getInlines() {
+    const array = this.getInlinesAsArray()
+    return new List(array)
+  },
+
+  /**
+   * Get the closest inline nodes for each text node in the node, as an array.
+   *
+   * @return {List<Node>}
+   */
+
+  getInlinesAsArray() {
+    let array = []
+
+    this.nodes.forEach((child) => {
+      if (child.kind == 'text') return
+      if (child.isLeafInline()) {
+        array.push(child)
+      } else {
+        array = array.concat(child.getInlinesAsArray())
+      }
+    })
+
+    return array
+  },
+
+  /**
+   * Get the closest inline nodes for each text node in a `range`.
+   *
+   * @param {Selection} range
+   * @return {List<Node>}
+   */
+
+  getInlinesAtRange(range) {
+    const array = this.getInlinesAtRangeAsArray(range)
+    // Remove duplicates by converting it to an `OrderedSet` first.
+    return new List(new OrderedSet(array))
+  },
+
+  /**
+   * Get the closest inline nodes for each text node in a `range` as an array.
+   *
+   * @param {Selection} range
+   * @return {Array}
+   */
+
+  getInlinesAtRangeAsArray(range) {
+    return this
+      .getTextsAtRangeAsArray(range)
+      .map(text => this.getClosestInline(text.key))
+      .filter(exists => exists)
+  },
+
+  /**
+   * Get all of the leaf inline nodes that match a `type`.
+   *
+   * @param {String} type
+   * @return {List<Node>}
+   */
+
+  getInlinesByType(type) {
+    const array = this.getInlinesByTypeAsArray(type)
+    return new List(array)
+  },
+
+  /**
+   * Get all of the leaf inline nodes that match a `type` as an array.
+   *
+   * @param {String} type
+   * @return {Array}
+   */
+
+  getInlinesByTypeAsArray(type) {
+    return this.nodes.reduce((inlines, node) => {
+      if (node.kind == 'text') {
+        return inlines
+      } else if (node.isLeafInline() && node.type == type) {
+        inlines.push(node)
+        return inlines
+      } else {
+        return inlines.concat(node.getInlinesByTypeAsArray(type))
+      }
+    }, [])
+  },
+
+  /**
+   * Return a set of all keys in the node.
+   *
+   * @return {Set<String>}
+   */
+
+  getKeys() {
+    const keys = []
+
+    this.forEachDescendant((desc) => {
+      keys.push(desc.key)
+    })
+
+    return new Set(keys)
+  },
+
+  /**
+   * Get the last child text node.
+   *
+   * @return {Node|Null}
+   */
+
+  getLastText() {
+    let descendantFound = null
+
+    const found = this.nodes.findLast((node) => {
+      if (node.kind == 'text') return true
+      descendantFound = node.getLastText()
+      return descendantFound
+    })
+
+    return descendantFound || found
+  },
+
+  /**
+   * Get all of the marks for all of the characters of every text node.
+   *
+   * @return {Set<Mark>}
+   */
+
+  getMarks() {
+    const array = this.getMarksAsArray()
+    return new Set(array)
+  },
+
+  /**
+   * Get all of the marks for all of the characters of every text node.
+   *
+   * @return {OrderedSet<Mark>}
+   */
+
+  getOrderedMarks() {
+    const array = this.getMarksAsArray()
+    return new OrderedSet(array)
+  },
+
+  /**
+   * Get all of the marks as an array.
+   *
+   * @return {Array}
+   */
+
+  getMarksAsArray() {
+    return this.nodes.reduce((marks, node) => {
+      return marks.concat(node.getMarksAsArray())
+    }, [])
+  },
+
+  /**
+   * Get a set of the marks in a `range`.
+   *
+   * @param {Selection} range
+   * @return {Set<Mark>}
+   */
+
+  getMarksAtRange(range) {
+    const array = this.getMarksAtRangeAsArray(range)
+    return new Set(array)
+  },
+
+  /**
+   * Get a set of the marks in a `range`.
+   *
+   * @param {Selection} range
+   * @return {OrderedSet<Mark>}
+   */
+
+  getOrderedMarksAtRange(range) {
+    const array = this.getMarksAtRangeAsArray(range)
+    return new OrderedSet(array)
+  },
+
+  /**
+   * Get a set of the marks in a `range`.
+   *
+   * @param {Selection} range
+   * @return {Array}
+   */
+
+  getMarksAtRangeAsArray(range) {
+    range = range.normalize(this)
+    const { startKey, startOffset } = range
+
+    // If the range is collapsed at the start of the node, check the previous.
+    if (range.isCollapsed && startOffset == 0) {
+      const previous = this.getPreviousText(startKey)
+      if (!previous || !previous.length) return []
+      const char = previous.characters.get(previous.length - 1)
+      return char.marks.toArray()
+    }
+
+    // If the range is collapsed, check the character before the start.
+    if (range.isCollapsed) {
+      const text = this.getDescendant(startKey)
+      const char = text.characters.get(range.startOffset - 1)
+      return char.marks.toArray()
+    }
+
+    // Otherwise, get a set of the marks for each character in the range.
+    return this
+      .getCharactersAtRange(range)
+      .reduce((memo, char) => {
+        return memo.concat(char.marks.toArray())
+      }, [])
+  },
+
+  /**
+   * Get all of the marks that match a `type`.
+   *
+   * @param {String} type
+   * @return {Set<Mark>}
+   */
+
+  getMarksByType(type) {
+    const array = this.getMarksByTypeAsArray(type)
+    return new Set(array)
+  },
+
+  /**
+   * Get all of the marks that match a `type`.
+   *
+   * @param {String} type
+   * @return {OrderedSet<Mark>}
+   */
+
+  getOrderedMarksByType(type) {
+    const array = this.getMarksByTypeAsArray(type)
+    return new OrderedSet(array)
+  },
+
+  /**
+   * Get all of the marks that match a `type` as an array.
+   *
+   * @param {String} type
+   * @return {Array}
+   */
+
+  getMarksByTypeAsArray(type) {
+    return this.nodes.reduce((array, node) => {
+      return node.kind == 'text'
+        ? array.concat(node.getMarksAsArray().filter(m => m.type == type))
+        : array.concat(node.getMarksByTypeAsArray(type))
+    }, [])
+  },
+
+  /**
+   * Get the block node before a descendant text node by `key`.
+   *
+   * @param {String} key
+   * @return {Node|Null}
+   */
+
+  getNextBlock(key) {
+    const child = this.assertDescendant(key)
+    let last
+
+    if (child.kind == 'block') {
+      last = child.getLastText()
+    } else {
+      const block = this.getClosestBlock(key)
+      last = block.getLastText()
+    }
+
+    const next = this.getNextText(last.key)
+    if (!next) return null
+
+    return this.getClosestBlock(next.key)
+  },
+
+  /**
+   * Get the node after a descendant by `key`.
+   *
+   * @param {String} key
+   * @return {Node|Null}
+   */
+
+  getNextSibling(key) {
+    key = Normalize.key(key)
+
+    const parent = this.getParent(key)
+    const after = parent.nodes
+      .skipUntil(child => child.key == key)
+
+    if (after.size == 0) {
+      throw new Error(`Could not find a child node with key "${key}".`)
+    }
+    return after.get(1)
+  },
+
+  /**
+   * Get the text node after a descendant text node by `key`.
+   *
+   * @param {String} key
+   * @return {Node|Null}
+   */
+
+  getNextText(key) {
+    key = Normalize.key(key)
+    return this.getTexts()
+      .skipUntil(text => text.key == key)
+      .get(1)
+  },
+
+  /**
+   * Get a node in the tree by `key`.
+   *
+   * @param {String} key
+   * @return {Node|Null}
+   */
+
+  getNode(key) {
+    key = Normalize.key(key)
+    return this.key == key ? this : this.getDescendant(key)
+  },
+
+  /**
+   * Get the offset for a descendant text node by `key`.
+   *
+   * @param {String} key
+   * @return {Number}
+   */
+
+  getOffset(key) {
+    this.assertDescendant(key)
+
+    // Calculate the offset of the nodes before the highest child.
+    const child = this.getFurthestAncestor(key)
+    const offset = this.nodes
+      .takeUntil(n => n == child)
+      .reduce((memo, n) => memo + n.length, 0)
+
+    // Recurse if need be.
+    return this.hasChild(key)
+      ? offset
+      : offset + child.getOffset(key)
+  },
+
+  /**
+   * Get the offset from a `range`.
+   *
+   * @param {Selection} range
+   * @return {Number}
+   */
+
+  getOffsetAtRange(range) {
+    range = range.normalize(this)
+
+    if (range.isExpanded) {
+      throw new Error('The range must be collapsed to calculcate its offset.')
+    }
+
+    const { startKey, startOffset } = range
+    return this.getOffset(startKey) + startOffset
+  },
+
+  /**
+   * Get the parent of a child node by `key`.
+   *
+   * @param {String} key
+   * @return {Node|Null}
+   */
+
+  getParent(key) {
+    if (this.hasChild(key)) return this
+
+    let node = null
+
+    this.nodes.find((child) => {
+      if (child.kind == 'text') {
+        return false
+      } else {
+        node = child.getParent(key)
+        return node
+      }
+    })
+
+    return node
+  },
+
+  /**
+   * Get the path of a descendant node by `key`.
+   *
+   * @param {String|Node} key
+   * @return {Array}
+   */
+
+  getPath(key) {
+    let child = this.assertNode(key)
+    const ancestors = this.getAncestors(key)
+    const path = []
+
+    ancestors.reverse().forEach((ancestor) => {
+      const index = ancestor.nodes.indexOf(child)
+      path.unshift(index)
+      child = ancestor
+    })
+
+    return path
+  },
+
+  /**
+   * Get the block node before a descendant text node by `key`.
+   *
+   * @param {String} key
+   * @return {Node|Null}
+   */
+
+  getPreviousBlock(key) {
+    const child = this.assertDescendant(key)
+    let first
+
+    if (child.kind == 'block') {
+      first = child.getFirstText()
+    } else {
+      const block = this.getClosestBlock(key)
+      first = block.getFirstText()
+    }
+
+    const previous = this.getPreviousText(first.key)
+    if (!previous) return null
+
+    return this.getClosestBlock(previous.key)
+  },
+
+  /**
+   * Get the node before a descendant node by `key`.
+   *
+   * @param {String} key
+   * @return {Node|Null}
+   */
+
+  getPreviousSibling(key) {
+    key = Normalize.key(key)
+    const parent = this.getParent(key)
+    const before = parent.nodes
+      .takeUntil(child => child.key == key)
+
+    if (before.size == parent.nodes.size) {
+      throw new Error(`Could not find a child node with key "${key}".`)
+    }
+
+    return before.last()
+  },
+
+  /**
+   * Get the text node before a descendant text node by `key`.
+   *
+   * @param {String} key
+   * @return {Node|Null}
+   */
+
+  getPreviousText(key) {
+    key = Normalize.key(key)
+    return this.getTexts()
+      .takeUntil(text => text.key == key)
+      .last()
+  },
+
+  /**
+   * Get the concatenated text string of all child nodes.
+   *
+   * @return {String}
+   */
+
+  getText() {
+    return this.nodes.reduce((string, node) => {
+      return string + node.text
+    }, '')
+  },
+
+  /**
+   * Get the descendent text node at an `offset`.
+   *
+   * @param {String} offset
+   * @return {Node|Null}
+   */
+
+  getTextAtOffset(offset) {
+    // PERF: Add a few shortcuts for the obvious cases.
+    if (offset == 0) return this.getFirstText()
+    if (offset == this.length) return this.getLastText()
+    if (offset < 0 || offset > this.length) return null
+
+    let length = 0
+
+    return this
+      .getTexts()
+      .find((text, i, texts) => {
+        length += text.length
+        return length > offset
+      })
+  },
+
+  /**
+   * Get the direction of the node's text.
+   *
+   * @return {String}
+   */
+
+  getTextDirection() {
+    const dir = direction(this.text)
+    return dir == 'neutral' ? undefined : dir
+  },
+
+  /**
+   * Recursively get all of the child text nodes in order of appearance.
+   *
+   * @return {List<Node>}
+   */
+
+  getTexts() {
+    const array = this.getTextsAsArray()
+    return new List(array)
+  },
+
+  /**
+   * Recursively get all the leaf text nodes in order of appearance, as array.
+   *
+   * @return {List<Node>}
+   */
+
+  getTextsAsArray() {
+    let array = []
+
+    this.nodes.forEach((node) => {
+      if (node.kind == 'text') {
+        array.push(node)
+      } else {
+        array = array.concat(node.getTextsAsArray())
+      }
+    })
+
+    return array
+  },
+
+  /**
+   * Get all of the text nodes in a `range`.
+   *
+   * @param {Selection} range
+   * @return {List<Node>}
+   */
+
+  getTextsAtRange(range) {
+    const array = this.getTextsAtRangeAsArray(range)
+    return new List(array)
+  },
+
+  /**
+   * Get all of the text nodes in a `range` as an array.
+   *
+   * @param {Selection} range
+   * @return {Array}
+   */
+
+  getTextsAtRangeAsArray(range) {
+    range = range.normalize(this)
+    const { startKey, endKey } = range
+    const startText = this.getDescendant(startKey)
+
+    // PERF: the most common case is when the range is in a single text node,
+    // where we can avoid a lot of iterating of the tree.
+    if (startKey == endKey) return [startText]
+
+    const endText = this.getDescendant(endKey)
+    const texts = this.getTextsAsArray()
+    const start = texts.indexOf(startText)
+    const end = texts.indexOf(endText)
+    return texts.slice(start, end + 1)
+  },
+
+  /**
+   * Check if a child node exists by `key`.
+   *
+   * @param {String} key
+   * @return {Boolean}
+   */
+
+  hasChild(key) {
+    return !!this.getChild(key)
+  },
+
+  /**
+   * Recursively check if a child node exists by `key`.
+   *
+   * @param {String} key
+   * @return {Boolean}
+   */
+
+  hasDescendant(key) {
+    return !!this.getDescendant(key)
+  },
+
+  /**
+   * Recursively check if a node exists by `key`.
+   *
+   * @param {String} key
+   * @return {Boolean}
+   */
+
+  hasNode(key) {
+    return !!this.getNode(key)
+  },
+
+  /**
+   * Check if a node has a void parent by `key`.
+   *
+   * @param {String} key
+   * @return {Boolean}
+   */
+
+  hasVoidParent(key) {
+    return !!this.getClosest(key, parent => parent.isVoid)
+  },
+
+  /**
+   * Insert a `node` at `index`.
+   *
+   * @param {Number} index
+   * @param {Node} node
+   * @return {Node}
+   */
+
+  insertNode(index, node) {
+    const keys = this.getKeys()
+
+    if (keys.contains(node.key)) {
+      node = node.regenerateKey()
+    }
+
+    if (node.kind != 'text') {
+      node = node.mapDescendants((desc) => {
+        return keys.contains(desc.key)
+          ? desc.regenerateKey()
+          : desc
+      })
+    }
+
+    const nodes = this.nodes.insert(index, node)
+    return this.set('nodes', nodes)
+  },
+
+  /**
+   * Check whether the node is a leaf block.
+   *
+   * @return {Boolean}
+   */
+
+  isLeafBlock() {
+    return (
+      this.kind == 'block' &&
+      this.nodes.every(n => n.kind != 'block')
+    )
+  },
+
+  /**
+   * Check whether the node is a leaf inline.
+   *
+   * @return {Boolean}
+   */
+
+  isLeafInline() {
+    return (
+      this.kind == 'inline' &&
+      this.nodes.every(n => n.kind != 'inline')
+    )
+  },
+
+  /**
+   * Join a children node `first` with another children node `second`.
+   * `first` and `second` will be concatenated in that order.
+   * `first` and `second` must be two Nodes or two Text.
+   *
+   * @param {Node} first
+   * @param {Node} second
+   * @param {Boolean} options.deep (optional) Join recursively the
+   * respective last node and first node of the nodes' children. Like a zipper :)
+   * @return {Node}
+   */
+
+  joinNode(first, second, options) {
+    const { deep = false } = options
+    let node = this
+    let parent = node.getParent(second.key)
+    const isParent = node == parent
+    const index = parent.nodes.indexOf(second)
+
+    if (second.kind == 'text') {
+      let { characters } = first
+      characters = characters.concat(second.characters)
+      first = first.set('characters', characters)
+    }
+
+    else {
+      const { size } = first.nodes
+      second.nodes.forEach((child, i) => {
+        first = first.insertNode(size + i, child)
+      })
+
+      if (deep) {
+        // Join recursively
+        first = first.joinNode(first.nodes.get(size - 1), first.nodes.get(size), { deep })
+      }
+    }
+
+    parent = parent.removeNode(index)
+    node = isParent ? parent : node.updateDescendant(parent)
+    node = node.updateDescendant(first)
+    return node
+  },
+
+  /**
+   * Map all child nodes, updating them in their parents. This method is
+   * optimized to not return a new node if no changes are made.
+   *
+   * @param {Function} iterator
+   * @return {Node}
+   */
+
+  mapChildren(iterator) {
+    let { nodes } = this
+
+    nodes.forEach((node, i) => {
+      const ret = iterator(node, i, this.nodes)
+      if (ret != node) nodes = nodes.set(ret.key, ret)
+    })
+
+    return this.set('nodes', nodes)
+  },
+
+  /**
+   * Map all descendant nodes, updating them in their parents. This method is
+   * optimized to not return a new node if no changes are made.
+   *
+   * @param {Function} iterator
+   * @return {Node}
+   */
+
+  mapDescendants(iterator) {
+    let { nodes } = this
+
+    nodes.forEach((node, i) => {
+      let ret = node
+      if (ret.kind != 'text') ret = ret.mapDescendants(iterator)
+      ret = iterator(ret, i, this.nodes)
+      if (ret == node) return
+
+      const index = nodes.indexOf(node)
+      nodes = nodes.set(index, ret)
+    })
+
+    return this.set('nodes', nodes)
+  },
+
+  /**
+   * Regenerate the node's key.
+   *
+   * @return {Node}
+   */
+
+  regenerateKey() {
+    const key = generateKey()
+    return this.set('key', key)
+  },
+
+  /**
+   * Remove a `node` from the children node map.
+   *
+   * @param {String} key
+   * @return {Node}
+   */
+
+  removeDescendant(key) {
+    key = Normalize.key(key)
+
+    let node = this
+    let parent = node.getParent(key)
+    if (!parent) throw new Error(`Could not find a descendant node with key "${key}".`)
+
+    const index = parent.nodes.findIndex(n => n.key === key)
+    const isParent = node == parent
+    const nodes = parent.nodes.splice(index, 1)
+
+    parent = parent.set('nodes', nodes)
+    node = isParent ? parent : node.updateDescendant(parent)
+    return node
+  },
+
+  /**
+   * Remove a node at `index`.
+   *
+   * @param {Number} index
+   * @return {Node}
+   */
+
+  removeNode(index) {
+    const nodes = this.nodes.splice(index, 1)
+    return this.set('nodes', nodes)
+  },
+
+  /**
+   * Split the block nodes at a `range`, to optional `height`.
+   *
+   * @param {Selection} range
+   * @param {Number} height (optional)
+   * @return {Node}
+   */
+
+  splitBlockAtRange(range, height = 1) {
+    const { startKey, startOffset } = range
+    const base = this
+    let node = base.assertDescendant(startKey)
+    let parent = base.getClosestBlock(node.key)
+    let offset = startOffset
+    let h = 0
+
+    while (parent && parent.kind == 'block' && h < height) {
+      offset += parent.getOffset(node.key)
+      node = parent
+      parent = base.getClosestBlock(parent.key)
+      h++
+    }
+
+    const path = base.getPath(node.key)
+    return this.splitNode(path, offset)
+  },
+
+  /**
+   * Split a node by `path` at `offset`.
+   *
+   * @param {Array} path
+   * @param {Number} offset
+   * @return {Node}
+   */
+
+  splitNode(path, offset) {
+    let base = this
+    const node = base.assertPath(path)
+    let parent = base.getParent(node.key)
+    const isParent = base == parent
+    const index = parent.nodes.indexOf(node)
+
+    let child = node
+    let one
+    let two
+
+
+    if (node.kind != 'text') {
+      child = node.getTextAtOffset(offset)
+    }
+
+    while (child && child != parent) {
+      if (child.kind == 'text') {
+        const i = node.kind == 'text' ? offset : offset - node.getOffset(child.key)
+        const { characters } = child
+        const oneChars = characters.take(i)
+        const twoChars = characters.skip(i)
+        one = child.set('characters', oneChars)
+        two = child.set('characters', twoChars).regenerateKey()
+      }
+
+      else {
+        const { nodes } = child
+
+        // Try to preserve the nodes list to preserve reference of one == node to avoid re-render
+        // When spliting at the end of a text node, the first node is preserved
+        let oneNodes = nodes.takeUntil(n => n.key == one.key)
+        oneNodes = (oneNodes.size == (nodes.size - 1) && one == nodes.last()) ? nodes : oneNodes.push(one)
+
+        const twoNodes = nodes.skipUntil(n => n.key == one.key).rest().unshift(two)
+        one = child.set('nodes', oneNodes)
+        two = child.set('nodes', twoNodes).regenerateKey()
+      }
+
+      child = base.getParent(child.key)
+    }
+
+    parent = parent.removeNode(index)
+    parent = parent.insertNode(index, two)
+    parent = parent.insertNode(index, one)
+    base = isParent ? parent : base.updateDescendant(parent)
+    return base
+  },
+
+  /**
+   * Split a node by `path` after 'count' children.
+   * Does not work on Text nodes. Use `Node.splitNode` to split text nodes as well.
+   *
+   * @param {Array} path
+   * @param {Number} count
+   * @return {Node}
+   */
+
+  splitNodeAfter(path, count) {
+    let base = this
+    const node = base.assertPath(path)
+    if (node.kind === 'text') throw new Error('Cannot split text node at index. Use Node.splitNode at offset instead')
+    const { nodes } = node
+
+    let parent = base.getParent(node.key)
+    const isParent = base == parent
+
+    const oneNodes = nodes.take(count)
+    const twoNodes = nodes.skip(count)
+
+    const one = node.set('nodes', oneNodes)
+    const two = node.set('nodes', twoNodes).regenerateKey()
+
+
+    const nodeIndex = parent.nodes.indexOf(node)
+    parent = parent.removeNode(nodeIndex)
+    parent = parent.insertNode(nodeIndex, two)
+    parent = parent.insertNode(nodeIndex, one)
+
+    base = isParent ? parent : base.updateDescendant(parent)
+    return base
+  },
+
+  /**
+   * Set a new value for a child node by `key`.
+   *
+   * @param {Node} node
+   * @return {Node}
+   */
+
+  updateDescendant(node) {
+    let child = this.assertDescendant(node.key)
+    const ancestors = this.getAncestors(node.key)
+
+    ancestors.reverse().forEach((parent) => {
+      let { nodes } = parent
+      const index = nodes.indexOf(child)
+      child = parent
+      nodes = nodes.set(index, node)
+      parent = parent.set('nodes', nodes)
+      node = parent
+    })
+
+    return node
+  },
+
+  /**
+   * Validate the node against a `schema`.
+   *
+   * @param {Schema} schema
+   * @return {Object|Null}
+   */
+
+  validate(schema) {
+    return schema.__validate(this)
+  },
+
+  /**
+   * True if the node has both descendants in that order, false otherwise. The
+   * order is depth-first, post-order.
+   *
+   * @param {String} first
+   * @param {String} second
+   * @return {Boolean}
+   */
+
+  areDescendantSorted(first, second) {
+    warn('The Node.areDescendantSorted(first, second) method is deprecated, please use `Node.areDescendantsSorted(first, second) instead.')
+    return this.areDescendantsSorted(first, second)
+  },
+
+  /**
+   * Concat children `nodes` on to the end of the node.
+   *
+   * @param {List<Node>} nodes
+   * @return {Node}
+   */
+
+  concatChildren(nodes) {
+    warn('The `Node.concatChildren(nodes)` method is deprecated.')
+    nodes = this.nodes.concat(nodes)
+    return this.set('nodes', nodes)
+  },
+
+  /**
+   * Decorate all of the text nodes with a `decorator` function.
+   *
+   * @param {Function} decorator
+   * @return {Node}
+   */
+
+  decorateTexts(decorator) {
+    warn('The `Node.decorateTexts(decorator) method is deprecated.')
+    return this.mapDescendants((child) => {
+      return child.kind == 'text'
+        ? child.decorateCharacters(decorator)
+        : child
+    })
+  },
+
+  /**
+   * Recursively filter all descendant nodes with `iterator`, depth-first.
+   * It is different from `filterDescendants` in regard of the order of results.
+   *
+   * @param {Function} iterator
+   * @return {List<Node>}
+   */
+
+  filterDescendantsDeep(iterator) {
+    warn('The Node.filterDescendantsDeep(iterator) method is deprecated.')
+    return this.nodes.reduce((matches, child, i, nodes) => {
+      if (child.kind != 'text') matches = matches.concat(child.filterDescendantsDeep(iterator))
+      if (iterator(child, i, nodes)) matches = matches.push(child)
+      return matches
+    }, new List())
+  },
+
+  /**
+   * Recursively find all descendant nodes by `iterator`. Depth first.
+   *
+   * @param {Function} iterator
+   * @return {Node|Null}
+   */
+
+  findDescendantDeep(iterator) {
+    warn('The Node.findDescendantDeep(iterator) method is deprecated.')
+    let found
+
+    this.forEachDescendant((node) => {
+      if (iterator(node)) {
+        found = node
+        return false
+      }
+    })
+
+    return found
+  },
+
+  /**
+   * Get children between two child keys.
+   *
+   * @param {String} start
+   * @param {String} end
+   * @return {Node}
+   */
+
+  getChildrenBetween(start, end) {
+    warn('The `Node.getChildrenBetween(start, end)` method is deprecated.')
+    start = this.assertChild(start)
+    start = this.nodes.indexOf(start)
+    end = this.assertChild(end)
+    end = this.nodes.indexOf(end)
+    return this.nodes.slice(start + 1, end)
+  },
+
+  /**
+   * Get children between two child keys, including the two children.
+   *
+   * @param {String} start
+   * @param {String} end
+   * @return {Node}
+   */
+
+  getChildrenBetweenIncluding(start, end) {
+    warn('The `Node.getChildrenBetweenIncluding(start, end)` method is deprecated.')
+    start = this.assertChild(start)
+    start = this.nodes.indexOf(start)
+    end = this.assertChild(end)
+    end = this.nodes.indexOf(end)
+    return this.nodes.slice(start, end + 1)
+  },
+
+  /**
+   * Get the highest child ancestor of a node by `key`.
+   *
+   * @param {String} key
+   * @return {Node|Null}
+   */
+
+  getHighestChild(key) {
+    warn('The `Node.getHighestChild(key) method is deprecated, please use `Node.getFurthestAncestor(key) instead.')
+    return this.getFurthestAncestor(key)
+  },
+
+  /**
+   * Get the highest parent of a node by `key` which has an only child.
+   *
+   * @param {String} key
+   * @return {Node|Null}
+   */
+
+  getHighestOnlyChildParent(key) {
+    warn('The `Node.getHighestOnlyChildParent(key)` method is deprecated, please use `Node.getFurthestOnlyChildAncestor` instead.')
+    return this.getFurthestOnlyChildAncestor(key)
+  },
+
+  /**
+   * Check if the inline nodes are split at a `range`.
+   *
+   * @param {Selection} range
+   * @return {Boolean}
+   */
+
+  isInlineSplitAtRange(range) {
+    warn('The `Node.isInlineSplitAtRange(range)` method is deprecated.')
+    range = range.normalize(this)
+    if (range.isExpanded) throw new Error()
+
+    const { startKey } = range
+    const start = this.getFurthestInline(startKey) || this.getDescendant(startKey)
+    return range.isAtStartOf(start) || range.isAtEndOf(start)
+  },
+
+}
+
+/**
+ * Memoize read methods.
+ */
+
+memoize(Node, [
+  'getBlocks',
+  'getBlocksAsArray',
+  'getCharacters',
+  'getCharactersAsArray',
+  'getFirstText',
+  'getInlines',
+  'getInlinesAsArray',
+  'getKeys',
+  'getLastText',
+  'getMarks',
+  'getOrderedMarks',
+  'getMarksAsArray',
+  'getText',
+  'getTextDirection',
+  'getTexts',
+  'getTextsAsArray',
+  'isLeafBlock',
+  'isLeafInline',
+], {
+  takesArguments: false
+})
+
+memoize(Node, [
+  'areDescendantsSorted',
+  'getAncestors',
+  'getBlocksAtRange',
+  'getBlocksAtRangeAsArray',
+  'getBlocksByType',
+  'getBlocksByTypeAsArray',
+  'getCharactersAtRange',
+  'getCharactersAtRangeAsArray',
+  'getChild',
+  'getChildrenBetween',
+  'getChildrenBetweenIncluding',
+  'getClosestBlock',
+  'getClosestInline',
+  'getClosestVoid',
+  'getCommonAncestor',
+  'getComponent',
+  'getDecorators',
+  'getDepth',
+  'getDescendant',
+  'getDescendantAtPath',
+  'getDescendantDecorators',
+  'getFragmentAtRange',
+  'getFurthestBlock',
+  'getFurthestInline',
+  'getFurthestAncestor',
+  'getFurthestOnlyChildAncestor',
+  'getInlinesAtRange',
+  'getInlinesAtRangeAsArray',
+  'getInlinesByType',
+  'getInlinesByTypeAsArray',
+  'getMarksAtRange',
+  'getOrderedMarksAtRange',
+  'getMarksAtRangeAsArray',
+  'getMarksByType',
+  'getOrderedMarksByType',
+  'getMarksByTypeAsArray',
+  'getNextBlock',
+  'getNextSibling',
+  'getNextText',
+  'getNode',
+  'getOffset',
+  'getOffsetAtRange',
+  'getParent',
+  'getPath',
+  'getPreviousBlock',
+  'getPreviousSibling',
+  'getPreviousText',
+  'getTextAtOffset',
+  'getTextsAtRange',
+  'getTextsAtRangeAsArray',
+  'hasChild',
+  'hasDescendant',
+  'hasNode',
+  'hasVoidParent',
+  'isInlineSplitAtRange',
+  'validate',
+], {
+  takesArguments: true
+})
+
+/**
+ * Export.
+ *
+ * @type {Object}
+ */
+
+export default Node

--- a/src/lib/slate/models/range.js
+++ b/src/lib/slate/models/range.js
@@ -1,0 +1,76 @@
+
+import Character from './character'
+import Mark from './mark'
+import { Record, Set } from 'immutable'
+
+/**
+ * Default properties.
+ *
+ * @type {Object}
+ */
+
+const DEFAULTS = {
+  marks: new Set(),
+  text: '',
+}
+
+/**
+ * Range.
+ *
+ * @type {Range}
+ */
+
+class Range extends new Record(DEFAULTS) {
+
+  /**
+   * Create a new `Range` with `properties`.
+   *
+   * @param {Object|Range} properties
+   * @return {Range}
+   */
+
+  static create(properties = {}) {
+    if (properties instanceof Range) return properties
+    properties.text = properties.text
+    properties.marks = Mark.createSet(properties.marks)
+    return new Range(properties)
+  }
+
+  /**
+   * Get the node's kind.
+   *
+   * @return {String}
+   */
+
+  get kind() {
+    return 'range'
+  }
+
+  /**
+   * Return range as a list of characters
+   *
+   * @return {List<Character>}
+   */
+
+  getCharacters() {
+    const { marks } = this
+
+    return Character.createList(this.text
+      .split('')
+      .map((char) => {
+        return Character.create({
+          text: char,
+          marks
+        })
+      }))
+  }
+
+}
+
+/**
+ * Export.
+ *
+ * @type {Range}
+ */
+
+export default Range

--- a/src/lib/slate/models/schema.js
+++ b/src/lib/slate/models/schema.js
@@ -1,0 +1,244 @@
+
+import React from 'react'
+import isReactComponent from '../utils/is-react-component'
+import typeOf from 'type-of'
+import { Record } from 'immutable'
+
+/**
+ * Default properties.
+ *
+ * @type {Object}
+ */
+
+const DEFAULTS = {
+  rules: [],
+}
+
+/**
+ * Schema.
+ *
+ * @type {Schema}
+ */
+
+class Schema extends new Record(DEFAULTS) {
+
+  /**
+   * Create a new `Schema` with `properties`.
+   *
+   * @param {Object|Schema} properties
+   * @return {Schema}
+   */
+
+  static create(properties = {}) {
+    if (properties instanceof Schema) return properties
+    return new Schema(normalizeProperties(properties))
+  }
+
+  /**
+   * Get the kind.
+   *
+   * @return {String}
+   */
+
+  get kind() {
+    return 'schema'
+  }
+
+  /**
+   * Return true if one rule can normalize the document
+   *
+   * @return {Boolean}
+   */
+
+  get hasValidators() {
+    const { rules } = this
+    return rules.some(rule => rule.validate)
+  }
+
+  /**
+   * Return true if one rule can decorate text nodes
+   *
+   * @return {Boolean}
+   */
+
+  get hasDecorators() {
+    const { rules } = this
+    return rules.some(rule => rule.decorate)
+  }
+
+  /**
+   * Return the renderer for an `object`.
+   *
+   * This method is private, because it should always be called on one of the
+   * often-changing immutable objects instead, since it will be memoized for
+   * much better performance.
+   *
+   * @param {Mixed} object
+   * @return {Component|Void}
+   */
+
+  __getComponent(object) {
+    const match = this.rules.find(rule => rule.render && rule.match(object))
+    if (!match) return
+    return match.render
+  }
+
+  /**
+   * Return the decorators for an `object`.
+   *
+   * This method is private, because it should always be called on one of the
+   * often-changing immutable objects instead, since it will be memoized for
+   * much better performance.
+   *
+   * @param {Mixed} object
+   * @return {Array}
+   */
+
+  __getDecorators(object) {
+    return this.rules
+      .filter(rule => rule.decorate && rule.match(object))
+      .map((rule) => {
+        return (text) => {
+          return rule.decorate(text, object)
+        }
+      })
+  }
+
+  /**
+   * Validate an `object` against the schema, returning the failing rule and
+   * value if the object is invalid, or void if it's valid.
+   *
+   * This method is private, because it should always be called on one of the
+   * often-changing immutable objects instead, since it will be memoized for
+   * much better performance.
+   *
+   * @param {Mixed} object
+   * @return {Object|Void}
+   */
+
+  __validate(object) {
+    let value
+
+    const match = this.rules.find((rule) => {
+      if (!rule.validate) return
+      if (!rule.match(object)) return
+
+      value = rule.validate(object)
+      return value
+    })
+
+    if (!value) return
+
+    return {
+      rule: match,
+      value,
+    }
+  }
+
+}
+
+/**
+ * Normalize the `properties` of a schema.
+ *
+ * @param {Object} properties
+ * @return {Object}
+ */
+
+function normalizeProperties(properties) {
+  let { rules = [], nodes, marks } = properties
+
+  if (nodes) {
+    const array = normalizeNodes(nodes)
+    rules = rules.concat(array)
+  }
+
+  if (marks) {
+    const array = normalizeMarks(marks)
+    rules = rules.concat(array)
+  }
+
+  return { rules }
+}
+
+/**
+ * Normalize a `nodes` shorthand argument.
+ *
+ * @param {Object} nodes
+ * @return {Array}
+ */
+
+function normalizeNodes(nodes) {
+  const rules = []
+
+  for (const key in nodes) {
+    let rule = nodes[key]
+
+    if (typeOf(rule) == 'function' || isReactComponent(rule)) {
+      rule = { render: rule }
+    }
+
+    rule.match = (object) => {
+      return (
+        (object.kind == 'block' || object.kind == 'inline') &&
+        object.type == key
+      )
+    }
+
+    rules.push(rule)
+  }
+
+  return rules
+}
+
+/**
+ * Normalize a `marks` shorthand argument.
+ *
+ * @param {Object} marks
+ * @return {Array}
+ */
+
+function normalizeMarks(marks) {
+  const rules = []
+
+  for (const key in marks) {
+    let rule = marks[key]
+
+    if (!rule.render && !rule.decorator && !rule.validate) {
+      rule = { render: rule }
+    }
+
+    rule.render = normalizeMarkComponent(rule.render)
+    rule.match = object => object.kind == 'mark' && object.type == key
+    rules.push(rule)
+  }
+
+  return rules
+}
+
+/**
+ * Normalize a mark `render` property.
+ *
+ * @param {Component|Function|Object|String} render
+ * @return {Component}
+ */
+
+function normalizeMarkComponent(render) {
+  if (isReactComponent(render)) return render
+
+  switch (typeOf(render)) {
+    case 'function':
+      return render
+    case 'object':
+      return props => <span style={render}>{props.children}</span>
+    case 'string':
+      return props => <span className={render}>{props.children}</span>
+  }
+}
+
+/**
+ * Export.
+ *
+ * @type {Schema}
+ */
+
+export default Schema

--- a/src/lib/slate/models/selection.js
+++ b/src/lib/slate/models/selection.js
@@ -1,0 +1,850 @@
+
+import warn from '../utils/warn'
+import { Record } from 'immutable'
+
+/**
+ * Default properties.
+ *
+ * @type {Object}
+ */
+
+const DEFAULTS = {
+  anchorKey: null,
+  anchorOffset: 0,
+  focusKey: null,
+  focusOffset: 0,
+  isBackward: null,
+  isFocused: false,
+  marks: null,
+}
+
+/**
+ * Selection.
+ *
+ * @type {Selection}
+ */
+
+class Selection extends new Record(DEFAULTS) {
+
+  /**
+   * Create a new `Selection` with `properties`.
+   *
+   * @param {Object|Selection} properties
+   * @return {Selection}
+   */
+
+  static create(properties = {}) {
+    if (properties instanceof Selection) return properties
+    return new Selection(properties)
+  }
+
+  /**
+   * Get the kind.
+   *
+   * @return {String}
+   */
+
+  get kind() {
+    return 'selection'
+  }
+
+  /**
+   * Check whether the selection is blurred.
+   *
+   * @return {Boolean}
+   */
+
+  get isBlurred() {
+    return !this.isFocused
+  }
+
+  /**
+   * Check whether the selection is collapsed.
+   *
+   * @return {Boolean}
+   */
+
+  get isCollapsed() {
+    return (
+      this.anchorKey == this.focusKey &&
+      this.anchorOffset == this.focusOffset
+    )
+  }
+
+  /**
+   * Check whether the selection is expanded.
+   *
+   * @return {Boolean}
+   */
+
+  get isExpanded() {
+    return !this.isCollapsed
+  }
+
+  /**
+   * Check whether the selection is forward.
+   *
+   * @return {Boolean}
+   */
+
+  get isForward() {
+    return this.isBackward == null ? null : !this.isBackward
+  }
+
+  /**
+   * Check whether the selection's keys are set.
+   *
+   * @return {Boolean}
+   */
+
+  get isSet() {
+    return this.anchorKey != null && this.focusKey != null
+  }
+
+  /**
+   * Check whether the selection's keys are not set.
+   *
+   * @return {Boolean}
+   */
+
+  get isUnset() {
+    return !this.isSet
+  }
+
+  /**
+   * Get the start key.
+   *
+   * @return {String}
+   */
+
+  get startKey() {
+    return this.isBackward ? this.focusKey : this.anchorKey
+  }
+
+  /**
+   * Get the start offset.
+   *
+   * @return {String}
+   */
+
+  get startOffset() {
+    return this.isBackward ? this.focusOffset : this.anchorOffset
+  }
+
+  /**
+   * Get the end key.
+   *
+   * @return {String}
+   */
+
+  get endKey() {
+    return this.isBackward ? this.anchorKey : this.focusKey
+  }
+
+  /**
+   * Get the end offset.
+   *
+   * @return {String}
+   */
+
+  get endOffset() {
+    return this.isBackward ? this.anchorOffset : this.focusOffset
+  }
+
+  /**
+   * Check whether anchor point of the selection is at the start of a `node`.
+   *
+   * @param {Node} node
+   * @return {Boolean}
+   */
+
+  hasAnchorAtStartOf(node) {
+    // PERF: Do a check for a `0` offset first since it's quickest.
+    if (this.anchorOffset != 0) return false
+    const first = getFirst(node)
+    return this.anchorKey == first.key
+  }
+
+  /**
+   * Check whether anchor point of the selection is at the end of a `node`.
+   *
+   * @param {Node} node
+   * @return {Boolean}
+   */
+
+  hasAnchorAtEndOf(node) {
+    const last = getLast(node)
+    return this.anchorKey == last.key && this.anchorOffset == last.length
+  }
+
+  /**
+   * Check whether the anchor edge of a selection is in a `node` and at an
+   * offset between `start` and `end`.
+   *
+   * @param {Node} node
+   * @param {Number} start
+   * @param {Number} end
+   * @return {Boolean}
+   */
+
+  hasAnchorBetween(node, start, end) {
+    return (
+      this.anchorOffset <= end &&
+      start <= this.anchorOffset &&
+      this.hasAnchorIn(node)
+    )
+  }
+
+  /**
+   * Check whether the anchor edge of a selection is in a `node`.
+   *
+   * @param {Node} node
+   * @return {Boolean}
+   */
+
+  hasAnchorIn(node) {
+    return node.kind == 'text'
+      ? node.key == this.anchorKey
+      : node.hasDescendant(this.anchorKey)
+  }
+
+  /**
+   * Check whether focus point of the selection is at the end of a `node`.
+   *
+   * @param {Node} node
+   * @return {Boolean}
+   */
+
+  hasFocusAtEndOf(node) {
+    const last = getLast(node)
+    return this.focusKey == last.key && this.focusOffset == last.length
+  }
+
+  /**
+   * Check whether focus point of the selection is at the start of a `node`.
+   *
+   * @param {Node} node
+   * @return {Boolean}
+   */
+
+  hasFocusAtStartOf(node) {
+    if (this.focusOffset != 0) return false
+    const first = getFirst(node)
+    return this.focusKey == first.key
+  }
+
+  /**
+   * Check whether the focus edge of a selection is in a `node` and at an
+   * offset between `start` and `end`.
+   *
+   * @param {Node} node
+   * @param {Number} start
+   * @param {Number} end
+   * @return {Boolean}
+   */
+
+  hasFocusBetween(node, start, end) {
+    return (
+      start <= this.focusOffset &&
+      this.focusOffset <= end &&
+      this.hasFocusIn(node)
+    )
+  }
+
+  /**
+   * Check whether the focus edge of a selection is in a `node`.
+   *
+   * @param {Node} node
+   * @return {Boolean}
+   */
+
+  hasFocusIn(node) {
+    return node.kind == 'text'
+      ? node.key == this.focusKey
+      : node.hasDescendant(this.focusKey)
+  }
+
+  /**
+   * Check whether the selection is at the start of a `node`.
+   *
+   * @param {Node} node
+   * @return {Boolean}
+   */
+
+  isAtStartOf(node) {
+    return this.isCollapsed && this.hasAnchorAtStartOf(node)
+  }
+
+  /**
+   * Check whether the selection is at the end of a `node`.
+   *
+   * @param {Node} node
+   * @return {Boolean}
+   */
+
+  isAtEndOf(node) {
+    return this.isCollapsed && this.hasAnchorAtEndOf(node)
+  }
+
+  /**
+   * Focus the selection.
+   *
+   * @return {Selection}
+   */
+
+  focus() {
+    return this.merge({
+      isFocused: true
+    })
+  }
+
+  /**
+   * Blur the selection.
+   *
+   * @return {Selection}
+   */
+
+  blur() {
+    return this.merge({
+      isFocused: false
+    })
+  }
+
+  /**
+   * Unset the selection.
+   *
+   * @return {Selection}
+   */
+
+  deselect() {
+    return this.merge({
+      anchorKey: null,
+      anchorOffset: 0,
+      focusKey: null,
+      focusOffset: 0,
+      isFocused: false,
+      isBackward: false
+    })
+  }
+
+  /**
+   * Flip the selection.
+   *
+   * @return {Selection}
+   */
+
+  flip() {
+    return this.merge({
+      anchorKey: this.focusKey,
+      anchorOffset: this.focusOffset,
+      focusKey: this.anchorKey,
+      focusOffset: this.anchorOffset,
+      isBackward: this.isBackward == null ? null : !this.isBackward,
+    })
+  }
+
+  /**
+   * Move the anchor offset `n` characters.
+   *
+   * @param {Number} n (optional)
+   * @return {Selection}
+   */
+
+  moveAnchor(n = 1) {
+    const { anchorKey, focusKey, focusOffset, isBackward } = this
+    const anchorOffset = this.anchorOffset + n
+    return this.merge({
+      anchorOffset,
+      isBackward: anchorKey == focusKey
+        ? anchorOffset > focusOffset
+        : isBackward
+    })
+  }
+
+  /**
+   * Move the anchor offset `n` characters.
+   *
+   * @param {Number} n (optional)
+   * @return {Selection}
+   */
+
+  moveFocus(n = 1) {
+    const { anchorKey, anchorOffset, focusKey, isBackward } = this
+    const focusOffset = this.focusOffset + n
+    return this.merge({
+      focusOffset,
+      isBackward: focusKey == anchorKey
+        ? anchorOffset > focusOffset
+        : isBackward
+    })
+  }
+
+  /**
+   * Move the selection's anchor point to a `key` and `offset`.
+   *
+   * @param {String} key
+   * @param {Number} offset
+   * @return {Selection}
+   */
+
+  moveAnchorTo(key, offset) {
+    const { anchorKey, focusKey, focusOffset, isBackward } = this
+    return this.merge({
+      anchorKey: key,
+      anchorOffset: offset,
+      isBackward: key == focusKey
+        ? offset > focusOffset
+        : key == anchorKey ? isBackward : null
+    })
+  }
+
+  /**
+   * Move the selection's focus point to a `key` and `offset`.
+   *
+   * @param {String} key
+   * @param {Number} offset
+   * @return {Selection}
+   */
+
+  moveFocusTo(key, offset) {
+    const { focusKey, anchorKey, anchorOffset, isBackward } = this
+    return this.merge({
+      focusKey: key,
+      focusOffset: offset,
+      isBackward: key == anchorKey
+        ? anchorOffset > offset
+        : key == focusKey ? isBackward : null
+    })
+  }
+
+  /**
+   * Move the selection to `anchorOffset`.
+   *
+   * @param {Number} anchorOffset
+   * @return {Selection}
+   */
+
+  moveAnchorOffsetTo(anchorOffset) {
+    return this.merge({
+      anchorOffset,
+      isBackward: this.anchorKey == this.focusKey
+        ? anchorOffset > this.focusOffset
+        : this.isBackward
+    })
+  }
+
+  /**
+   * Move the selection to `focusOffset`.
+   *
+   * @param {Number} focusOffset
+   * @return {Selection}
+   */
+
+  moveFocusOffsetTo(focusOffset) {
+    return this.merge({
+      focusOffset,
+      isBackward: this.anchorKey == this.focusKey
+        ? this.anchorOffset > focusOffset
+        : this.isBackward
+    })
+  }
+
+  /**
+   * Move the selection to `anchorOffset` and `focusOffset`.
+   *
+   * @param {Number} anchorOffset
+   * @param {Number} focusOffset (optional)
+   * @return {Selection}
+   */
+
+  moveOffsetsTo(anchorOffset, focusOffset = anchorOffset) {
+    return this
+      .moveAnchorOffsetTo(anchorOffset)
+      .moveFocusOffsetTo(focusOffset)
+  }
+
+  /**
+   * Move the focus point to the anchor point.
+   *
+   * @return {Selection}
+   */
+
+  moveToAnchor() {
+    return this.moveFocusTo(this.anchorKey, this.anchorOffset)
+  }
+
+  /**
+   * Move the anchor point to the focus point.
+   *
+   * @return {Selection}
+   */
+
+  moveToFocus() {
+    return this.moveAnchorTo(this.focusKey, this.focusOffset)
+  }
+
+  /**
+   * Move the selection's anchor point to the start of a `node`.
+   *
+   * @param {Node} node
+   * @return {Selection}
+   */
+
+  moveAnchorToStartOf(node) {
+    node = getFirst(node)
+    return this.moveAnchorTo(node.key, 0)
+  }
+
+  /**
+   * Move the selection's anchor point to the end of a `node`.
+   *
+   * @param {Node} node
+   * @return {Selection}
+   */
+
+  moveAnchorToEndOf(node) {
+    node = getLast(node)
+    return this.moveAnchorTo(node.key, node.length)
+  }
+
+  /**
+   * Move the selection's focus point to the start of a `node`.
+   *
+   * @param {Node} node
+   * @return {Selection}
+   */
+
+  moveFocusToStartOf(node) {
+    node = getFirst(node)
+    return this.moveFocusTo(node.key, 0)
+  }
+
+  /**
+   * Move the selection's focus point to the end of a `node`.
+   *
+   * @param {Node} node
+   * @return {Selection}
+   */
+
+  moveFocusToEndOf(node) {
+    node = getLast(node)
+    return this.moveFocusTo(node.key, node.length)
+  }
+
+  /**
+   * Move to the entire range of `start` and `end` nodes.
+   *
+   * @param {Node} start
+   * @param {Node} end (optional)
+   * @return {Selection}
+   */
+
+  moveToRangeOf(start, end = start) {
+    return this
+      .moveAnchorToStartOf(start)
+      .moveFocusToEndOf(end)
+  }
+
+  /**
+   * Normalize the selection, relative to a `node`, ensuring that the anchor
+   * and focus nodes of the selection always refer to leaf text nodes.
+   *
+   * @param {Node} node
+   * @return {Selection}
+   */
+
+  normalize(node) {
+    const selection = this
+    let { anchorKey, anchorOffset, focusKey, focusOffset, isBackward } = selection
+
+    // If the selection isn't formed yet or is malformed, ensure that it is
+    // properly zeroed out.
+    if (
+      anchorKey == null ||
+      focusKey == null ||
+      !node.hasDescendant(anchorKey) ||
+      !node.hasDescendant(focusKey)
+    ) {
+      return selection.merge({
+        anchorKey: null,
+        anchorOffset: 0,
+        focusKey: null,
+        focusOffset: 0,
+        isBackward: false,
+      })
+    }
+
+    // Get the anchor and focus nodes.
+    let anchorNode = node.getDescendant(anchorKey)
+    let focusNode = node.getDescendant(focusKey)
+
+    // If the anchor node isn't a text node, match it to one.
+    if (anchorNode.kind != 'text') {
+      warn('The selection anchor was set to a Node that is not a Text node. This should not happen and can degrade performance. The node in question was:', anchorNode)
+      const anchorText = anchorNode.getTextAtOffset(anchorOffset)
+      const offset = anchorNode.getOffset(anchorText.key)
+      anchorOffset = anchorOffset - offset
+      anchorNode = anchorText
+    }
+
+    // If the focus node isn't a text node, match it to one.
+    if (focusNode.kind != 'text') {
+      warn('The selection focus was set to a Node that is not a Text node. This should not happen and can degrade performance. The node in question was:', focusNode)
+      const focusText = focusNode.getTextAtOffset(focusOffset)
+      const offset = focusNode.getOffset(focusText.key)
+      focusOffset = focusOffset - offset
+      focusNode = focusText
+    }
+
+    // If `isBackward` is not set, derive it.
+    if (isBackward == null) {
+      if (anchorNode.key === focusNode.key) {
+        isBackward = anchorOffset > focusOffset
+      } else {
+        isBackward = !node.areDescendantsSorted(anchorNode.key, focusNode.key)
+      }
+    }
+
+    // Merge in any updated properties.
+    return selection.merge({
+      anchorKey: anchorNode.key,
+      anchorOffset,
+      focusKey: focusNode.key,
+      focusOffset,
+      isBackward
+    })
+  }
+
+  /**
+   * Unset the selection.
+   *
+   * @return {Selection}
+   */
+
+  unset() {
+    warn('The `Selection.unset` method is deprecated, please switch to using `Selection.deselect` instead.')
+    return this.deselect()
+  }
+
+  /**
+   * Move the selection forward `n` characters.
+   *
+   * @param {Number} n (optional)
+   * @return {Selection}
+   */
+
+  moveForward(n = 1) {
+    warn('The `Selection.moveForward(n)` method is deprecated, please switch to using `Selection.move(n)` instead.')
+    return this.move(n)
+  }
+
+  /**
+   * Move the selection backward `n` characters.
+   *
+   * @param {Number} n (optional)
+   * @return {Selection}
+   */
+
+  moveBackward(n = 1) {
+    warn('The `Selection.moveBackward(n)` method is deprecated, please switch to using `Selection.move(-n)` (with a negative number) instead.')
+    return this.move(0 - n)
+  }
+
+  /**
+   * Move the anchor offset `n` characters.
+   *
+   * @param {Number} n (optional)
+   * @return {Selection}
+   */
+
+  moveAnchorOffset(n = 1) {
+    warn('The `Selection.moveAnchorOffset(n)` method is deprecated, please switch to using `Selection.moveAnchor(n)` instead.')
+    return this.moveAnchor(n)
+  }
+
+  /**
+   * Move the focus offset `n` characters.
+   *
+   * @param {Number} n (optional)
+   * @return {Selection}
+   */
+
+  moveFocusOffset(n = 1) {
+    warn('The `Selection.moveFocusOffset(n)` method is deprecated, please switch to using `Selection.moveFocus(n)` instead.')
+    return this.moveFocus(n)
+  }
+
+  /**
+   * Move the start offset `n` characters.
+   *
+   * @param {Number} n (optional)
+   * @return {Selection}
+   */
+
+  moveStartOffset(n = 1) {
+    warn('The `Selection.moveStartOffset(n)` method is deprecated, please switch to using `Selection.moveStart(n)` instead.')
+    return this.moveStart(n)
+  }
+
+  /**
+   * Move the focus offset `n` characters.
+   *
+   * @param {Number} n (optional)
+   * @return {Selection}
+   */
+
+  moveEndOffset(n = 1) {
+    warn('The `Selection.moveEndOffset(n)` method is deprecated, please switch to using `Selection.moveEnd(n)` instead.')
+    return this.moveEnd(n)
+  }
+
+  /**
+   * Extend the focus point forward `n` characters.
+   *
+   * @param {Number} n (optional)
+   * @return {Selection}
+   */
+
+  extendForward(n = 1) {
+    warn('The `Selection.extendForward(n)` method is deprecated, please switch to using `Selection.extend(n)` instead.')
+    return this.extend(n)
+  }
+
+  /**
+   * Extend the focus point backward `n` characters.
+   *
+   * @param {Number} n (optional)
+   * @return {Selection}
+   */
+
+  extendBackward(n = 1) {
+    warn('The `Selection.extendBackward(n)` method is deprecated, please switch to using `Selection.extend(-n)` (with a negative number) instead.')
+    return this.extend(0 - n)
+  }
+
+  /**
+   * Move the selection to `anchorOffset` and `focusOffset`.
+   *
+   * @param {Number} anchorOffset
+   * @param {Number} focusOffset (optional)
+   * @return {Selection}
+   */
+
+  moveToOffsets(anchorOffset, focusOffset = anchorOffset) {
+    warn('The `Selection.moveToOffsets` method is deprecated, please switch to using `Selection.moveOffsetsTo` instead.')
+    return this.moveOffsetsTo(anchorOffset, focusOffset)
+  }
+
+}
+
+/**
+ * Mix in some "move" convenience methods.
+ */
+
+const MOVE_METHODS = [
+  ['move', ''],
+  ['move', 'To'],
+  ['move', 'ToStartOf'],
+  ['move', 'ToEndOf'],
+]
+
+MOVE_METHODS.forEach(([ p, s ]) => {
+  Selection.prototype[`${p}${s}`] = function (...args) {
+    return this
+      [`${p}Anchor${s}`](...args)
+      [`${p}Focus${s}`](...args)
+  }
+})
+
+/**
+ * Mix in the "start", "end" and "edge" convenience methods.
+ */
+
+const EDGE_METHODS = [
+  ['has', 'AtStartOf', true],
+  ['has', 'AtEndOf', true],
+  ['has', 'Between', true],
+  ['has', 'In', true],
+  ['collapseTo', ''],
+  ['move', ''],
+  ['moveTo', ''],
+  ['move', 'To'],
+  ['move', 'OffsetTo'],
+]
+
+EDGE_METHODS.forEach(([ p, s, hasEdge ]) => {
+  const anchor = `${p}Anchor${s}`
+  const focus = `${p}Focus${s}`
+
+  Selection.prototype[`${p}Start${s}`] = function (...args) {
+    return this.isBackward
+      ? this[focus](...args)
+      : this[anchor](...args)
+  }
+
+  Selection.prototype[`${p}End${s}`] = function (...args) {
+    return this.isBackward
+      ? this[anchor](...args)
+      : this[focus](...args)
+  }
+
+  if (hasEdge) {
+    Selection.prototype[`${p}Edge${s}`] = function (...args) {
+      return this[anchor](...args) || this[focus](...args)
+    }
+  }
+})
+
+/**
+ * Mix in some aliases for convenience / parallelism with the browser APIs.
+ */
+
+const ALIAS_METHODS = [
+  ['collapseTo', 'moveTo'],
+  ['collapseToAnchor', 'moveToAnchor'],
+  ['collapseToFocus', 'moveToFocus'],
+  ['collapseToStart', 'moveToStart'],
+  ['collapseToEnd', 'moveToEnd'],
+  ['collapseToStartOf', 'moveToStartOf'],
+  ['collapseToEndOf', 'moveToEndOf'],
+  ['extend', 'moveFocus'],
+  ['extendTo', 'moveFocusTo'],
+  ['extendToStartOf', 'moveFocusToStartOf'],
+  ['extendToEndOf', 'moveFocusToEndOf'],
+]
+
+ALIAS_METHODS.forEach(([ alias, method ]) => {
+  Selection.prototype[alias] = function (...args) {
+    return this[method](...args)
+  }
+})
+
+/**
+ * Get the first text of a `node`.
+ *
+ * @param {Node} node
+ * @return {Text}
+ */
+
+function getFirst(node) {
+  return node.kind == 'text' ? node : node.getFirstText()
+}
+
+/**
+ * Get the last text of a `node`.
+ *
+ * @param {Node} node
+ * @return {Text}
+ */
+
+function getLast(node) {
+  return node.kind == 'text' ? node : node.getLastText()
+}
+
+/**
+ * Export.
+ *
+ * @type {Selection}
+ */
+
+export default Selection

--- a/src/lib/slate/models/stack.js
+++ b/src/lib/slate/models/stack.js
@@ -1,0 +1,257 @@
+
+import CorePlugin from '../plugins/core'
+import Debug from 'debug'
+import Schema from './schema'
+import State from './state'
+import { Record } from 'immutable'
+
+/**
+ * Debug.
+ *
+ * @type {Function}
+ */
+
+const debug = Debug('slate:stack')
+
+/**
+ * Methods that are triggered on events and can change the state.
+ *
+ * @type {Array}
+ */
+
+const EVENT_HANDLER_METHODS = [
+  'onBeforeInput',
+  'onBlur',
+  'onFocus',
+  'onCopy',
+  'onCut',
+  'onDrop',
+  'onInput',
+  'onKeyDown',
+  'onPaste',
+  'onSelect',
+]
+
+/**
+ * Methods that accumulate an updated state.
+ *
+ * @type {Array}
+ */
+
+const STATE_ACCUMULATOR_METHODS = [
+  'onBeforeChange',
+  'onChange',
+]
+
+/**
+ * Default properties.
+ *
+ * @type {Object}
+ */
+
+const DEFAULTS = {
+  plugins: [],
+  schema: new Schema(),
+}
+
+/**
+ * Stack.
+ *
+ * @type {Stack}
+ */
+
+class Stack extends new Record(DEFAULTS) {
+
+  /**
+   * Constructor.
+   *
+   * @param {Object} properties
+   *   @property {Array} plugins
+   *   @property {Schema|Object} schema
+   *   @property {Function} ...handlers
+   */
+
+  static create(properties) {
+    const plugins = resolvePlugins(properties)
+    const schema = resolveSchema(plugins)
+    return new Stack({ plugins, schema })
+  }
+
+  /**
+   * Get the kind.
+   *
+   * @return {String}
+   */
+
+  get kind() {
+    return 'stack'
+  }
+
+  /**
+   * Invoke `render` on all of the plugins in reverse, building up a tree of
+   * higher-order components.
+   *
+   * @param {State} state
+   * @param {Editor} editor
+   * @param {Object} children
+   * @param {Object} props
+   * @return {Component}
+   */
+
+  render = (state, editor, props) => {
+    debug('render')
+    const plugins = this.plugins.slice().reverse()
+    let children
+
+    for (const plugin of plugins) {
+      if (!plugin.render) continue
+      children = plugin.render(props, state, editor)
+      props.children = children
+    }
+
+    return children
+  }
+
+  /**
+   * Invoke `renderPortal` on all of the plugins, building a list of portals.
+   *
+   * @param {State} state
+   * @param {Editor} editor
+   * @return {Array}
+   */
+
+  renderPortal = (state, editor) => {
+    debug('renderPortal')
+    const portals = []
+
+    for (const plugin of this.plugins) {
+      if (!plugin.renderPortal) continue
+      const portal = plugin.renderPortal(state, editor)
+      if (portal == null) continue
+      portals.push(portal)
+    }
+
+    return portals
+  }
+
+}
+
+/**
+ * Mix in the event handler methods.
+ *
+ * @param {State} state
+ * @param {Editor} editor
+ * @param {Mixed} ...args
+ * @return {State|Null}
+ */
+
+for (const method of EVENT_HANDLER_METHODS) {
+  Stack.prototype[method] = function (state, editor, ...args) {
+    debug(method)
+
+    if (method == 'onChange') {
+      state = this.onBeforeChange(state, editor)
+    }
+
+    for (const plugin of this.plugins) {
+      if (!plugin[method]) continue
+      const next = plugin[method](...args, state, editor)
+      if (next == null) continue
+      assertState(next)
+      return next
+    }
+
+    return state
+  }
+}
+
+/**
+ * Mix in the state accumulator methods.
+ *
+ * @param {State} state
+ * @param {Editor} editor
+ * @param {Mixed} ...args
+ * @return {State|Null}
+ */
+
+for (const method of STATE_ACCUMULATOR_METHODS) {
+  Stack.prototype[method] = function (state, editor, ...args) {
+    debug(method)
+
+    for (const plugin of this.plugins) {
+      if (!plugin[method]) continue
+      const next = plugin[method](...args, state, editor)
+      if (next == null) continue
+      assertState(next)
+      state = next
+    }
+
+    return state
+  }
+}
+
+/**
+ * Assert that a `value` is a state object.
+ *
+ * @param {Mixed} value
+ */
+
+function assertState(value) {
+  if (value instanceof State) return
+  throw new Error(`A plugin returned an unexpected state value: ${value}`)
+}
+
+/**
+ * Resolve a schema from a set of `plugins`.
+ *
+ * @param {Array} plugins
+ * @return {Schema}
+ */
+
+function resolveSchema(plugins) {
+  let rules = []
+
+  for (const plugin of plugins) {
+    if (plugin.schema == null) continue
+    const schema = Schema.create(plugin.schema)
+    rules = rules.concat(schema.rules)
+  }
+
+  const schema = Schema.create({ rules })
+  return schema
+}
+
+/**
+ * Resolve an array of plugins from `properties`.
+ *
+ * In addition to the plugins provided in `properties.plugins`, this will
+ * create two other plugins:
+ *
+ * - A plugin made from the top-level `properties` themselves, which are
+ * placed at the beginning of the stack. That way, you can add a `onKeyDown`
+ * handler, and it will override all of the existing plugins.
+ *
+ * - A "core" functionality plugin that handles the most basic events in Slate,
+ * like deleting characters, splitting blocks, etc.
+ *
+ * @param {Object} props
+ * @return {Array}
+ */
+
+function resolvePlugins(props) {
+  const { plugins = [], ...overridePlugin } = props
+  const corePlugin = CorePlugin(props)
+  return [
+    overridePlugin,
+    ...plugins,
+    corePlugin
+  ]
+}
+
+/**
+ * Export.
+ *
+ * @type {Stack}
+ */
+
+export default Stack

--- a/src/lib/slate/models/state.js
+++ b/src/lib/slate/models/state.js
@@ -1,0 +1,449 @@
+
+
+import Document from './document'
+import SCHEMA from '../schemas/core'
+import Selection from './selection'
+import Transform from './transform'
+import { Record, Set, Stack, List } from 'immutable'
+
+/**
+ * History.
+ *
+ * @type {History}
+ */
+
+const History = new Record({
+  undos: new Stack(),
+  redos: new Stack()
+})
+
+/**
+ * Default properties.
+ *
+ * @type {Object}
+ */
+
+const DEFAULTS = {
+  document: new Document(),
+  selection: new Selection(),
+  history: new History(),
+  isNative: false
+}
+
+/**
+ * State.
+ *
+ * @type {State}
+ */
+
+class State extends new Record(DEFAULTS) {
+
+  /**
+   * Create a new `State` with `properties`.
+   *
+   * @param {Object|State} properties
+   * @param {Object} options
+   *   @property {Boolean} normalize
+   * @return {State}
+   */
+
+  static create(properties = {}, options = {}) {
+    if (properties instanceof State) return properties
+
+    const document = Document.create(properties.document)
+    let selection = Selection.create(properties.selection)
+
+    if (selection.isUnset) {
+      const text = document.getFirstText()
+      selection = selection.collapseToStartOf(text)
+    }
+
+    const state = new State({ document, selection })
+
+    return options.normalize === false
+      ? state
+      : state.transform().normalize(SCHEMA).apply({ save: false })
+  }
+
+  /**
+   * Get the kind.
+   *
+   * @return {String}
+   */
+
+  get kind() {
+    return 'state'
+  }
+
+  /**
+   * Are there undoable events?
+   *
+   * @return {Boolean}
+   */
+
+  get hasUndos() {
+    return this.history.undos.size > 0
+  }
+
+  /**
+   * Are there redoable events?
+   *
+   * @return {Boolean}
+   */
+
+  get hasRedos() {
+    return this.history.redos.size > 0
+  }
+
+  /**
+   * Is the current selection blurred?
+   *
+   * @return {Boolean}
+   */
+
+  get isBlurred() {
+    return this.selection.isBlurred
+  }
+
+  /**
+   * Is the current selection focused?
+   *
+   * @return {Boolean}
+   */
+
+  get isFocused() {
+    return this.selection.isFocused
+  }
+
+  /**
+   * Is the current selection collapsed?
+   *
+   * @return {Boolean}
+   */
+
+  get isCollapsed() {
+    return this.selection.isCollapsed
+  }
+
+  /**
+   * Is the current selection expanded?
+   *
+   * @return {Boolean}
+   */
+
+  get isExpanded() {
+    return this.selection.isExpanded
+  }
+
+  /**
+   * Is the current selection backward?
+   *
+   * @return {Boolean} isBackward
+   */
+
+  get isBackward() {
+    return this.selection.isBackward
+  }
+
+  /**
+   * Is the current selection forward?
+   *
+   * @return {Boolean}
+   */
+
+  get isForward() {
+    return this.selection.isForward
+  }
+
+  /**
+   * Get the current start key.
+   *
+   * @return {String}
+   */
+
+  get startKey() {
+    return this.selection.startKey
+  }
+
+  /**
+   * Get the current end key.
+   *
+   * @return {String}
+   */
+
+  get endKey() {
+    return this.selection.endKey
+  }
+
+  /**
+   * Get the current start offset.
+   *
+   * @return {String}
+   */
+
+  get startOffset() {
+    return this.selection.startOffset
+  }
+
+  /**
+   * Get the current end offset.
+   *
+   * @return {String}
+   */
+
+  get endOffset() {
+    return this.selection.endOffset
+  }
+
+  /**
+   * Get the current anchor key.
+   *
+   * @return {String}
+   */
+
+  get anchorKey() {
+    return this.selection.anchorKey
+  }
+
+  /**
+   * Get the current focus key.
+   *
+   * @return {String}
+   */
+
+  get focusKey() {
+    return this.selection.focusKey
+  }
+
+  /**
+   * Get the current anchor offset.
+   *
+   * @return {String}
+   */
+
+  get anchorOffset() {
+    return this.selection.anchorOffset
+  }
+
+  /**
+   * Get the current focus offset.
+   *
+   * @return {String}
+   */
+
+  get focusOffset() {
+    return this.selection.focusOffset
+  }
+
+  /**
+   * Get the current start text node's closest block parent.
+   *
+   * @return {Block}
+   */
+
+  get startBlock() {
+    return this.document.getClosestBlock(this.selection.startKey)
+  }
+
+  /**
+   * Get the current end text node's closest block parent.
+   *
+   * @return {Block}
+   */
+
+  get endBlock() {
+    return this.document.getClosestBlock(this.selection.endKey)
+  }
+
+  /**
+   * Get the current anchor text node's closest block parent.
+   *
+   * @return {Block}
+   */
+
+  get anchorBlock() {
+    return this.document.getClosestBlock(this.selection.anchorKey)
+  }
+
+  /**
+   * Get the current focus text node's closest block parent.
+   *
+   * @return {Block}
+   */
+
+  get focusBlock() {
+    return this.document.getClosestBlock(this.selection.focusKey)
+  }
+
+  /**
+   * Get the current start text node's closest inline parent.
+   *
+   * @return {Inline}
+   */
+
+  get startInline() {
+    return this.document.getClosestInline(this.selection.startKey)
+  }
+
+  /**
+   * Get the current end text node's closest inline parent.
+   *
+   * @return {Inline}
+   */
+
+  get endInline() {
+    return this.document.getClosestInline(this.selection.endKey)
+  }
+
+  /**
+   * Get the current anchor text node's closest inline parent.
+   *
+   * @return {Inline}
+   */
+
+  get anchorInline() {
+    return this.document.getClosestInline(this.selection.anchorKey)
+  }
+
+  /**
+   * Get the current focus text node's closest inline parent.
+   *
+   * @return {Inline}
+   */
+
+  get focusInline() {
+    return this.document.getClosestInline(this.selection.focusKey)
+  }
+
+  /**
+   * Get the current start text node.
+   *
+   * @return {Text}
+   */
+
+  get startText() {
+    return this.document.getDescendant(this.selection.startKey)
+  }
+
+  /**
+   * Get the current end node.
+   *
+   * @return {Text}
+   */
+
+  get endText() {
+    return this.document.getDescendant(this.selection.endKey)
+  }
+
+  /**
+   * Get the current anchor node.
+   *
+   * @return {Text}
+   */
+
+  get anchorText() {
+    return this.document.getDescendant(this.selection.anchorKey)
+  }
+
+  /**
+   * Get the current focus node.
+   *
+   * @return {Text}
+   */
+
+  get focusText() {
+    return this.document.getDescendant(this.selection.focusKey)
+  }
+
+  /**
+   * Get the characters in the current selection.
+   *
+   * @return {List<Character>}
+   */
+
+  get characters() {
+    return this.document.getCharactersAtRange(this.selection)
+  }
+
+  /**
+   * Get the marks of the current selection.
+   *
+   * @return {Set<Mark>}
+   */
+
+  get marks() {
+    return this.selection.isUnset
+      ? new Set()
+      : this.selection.marks || this.document.getMarksAtRange(this.selection)
+  }
+
+  /**
+   * Get the block nodes in the current selection.
+   *
+   * @return {List<Block>}
+   */
+
+  get blocks() {
+    return this.selection.isUnset
+      ? new List()
+      : this.document.getBlocksAtRange(this.selection)
+  }
+
+  /**
+   * Get the fragment of the current selection.
+   *
+   * @return {Document}
+   */
+
+  get fragment() {
+    return this.selection.isUnset
+      ? Document.create()
+      : this.document.getFragmentAtRange(this.selection)
+  }
+
+  /**
+   * Get the inline nodes in the current selection.
+   *
+   * @return {List<Inline>}
+   */
+
+  get inlines() {
+    return this.selection.isUnset
+      ? new List()
+      : this.document.getInlinesAtRange(this.selection)
+  }
+
+  /**
+   * Get the text nodes in the current selection.
+   *
+   * @return {List<Text>}
+   */
+
+  get texts() {
+    return this.selection.isUnset
+      ? new List()
+      : this.document.getTextsAtRange(this.selection)
+  }
+
+  /**
+   * Return a new `Transform` with the current state as a starting point.
+   *
+   * @param {Object} properties
+   * @return {Transform}
+   */
+
+  transform(properties = {}) {
+    const state = this
+    return new Transform({
+      ...properties,
+      state
+    })
+  }
+
+}
+
+/**
+ * Export.
+ */
+
+export default State

--- a/src/lib/slate/models/text.js
+++ b/src/lib/slate/models/text.js
@@ -1,0 +1,432 @@
+
+import Character from './character'
+import Mark from './mark'
+import Range from './range'
+import memoize from '../utils/memoize'
+import generateKey from '../utils/generate-key'
+import { List, Record, OrderedSet, Set, is } from 'immutable'
+
+/**
+ * Default properties.
+ *
+ * @type {Object}
+ */
+
+const DEFAULTS = {
+  characters: new List(),
+  key: null
+}
+
+/**
+ * Text.
+ *
+ * @type {Text}
+ */
+
+class Text extends new Record(DEFAULTS) {
+
+  /**
+   * Create a new `Text` with `properties`.
+   *
+   * @param {Object|Text} properties
+   * @return {Text}
+   */
+
+  static create(properties = {}) {
+    if (properties instanceof Text) return properties
+    properties.key = properties.key || generateKey()
+    properties.characters = Character.createList(properties.characters)
+    return new Text(properties)
+  }
+
+  /**
+   * Create a new `Text` from a string
+   *
+   * @param {String} text
+   * @param {Set<Mark>} marks (optional)
+   * @return {Text}
+   */
+
+  static createFromString(text, marks = Set()) {
+    return Text.createFromRanges([
+      Range.create({ text, marks })
+    ])
+  }
+
+  /**
+   * Create a new `Text` from a list of ranges
+   *
+   * @param {List<Range>|Array<Range>} ranges
+   * @return {Text}
+   */
+
+  static createFromRanges(ranges) {
+    return Text.create({
+      characters: ranges.reduce((characters, range) => {
+        range = Range.create(range)
+        return characters.concat(range.getCharacters())
+      }, Character.createList())
+    })
+  }
+
+  /**
+   * Create a list of `Texts` from an array.
+   *
+   * @param {Array} elements
+   * @return {List<Text>}
+   */
+
+  static createList(elements = []) {
+    if (List.isList(elements)) return elements
+    return new List(elements.map(Text.create))
+  }
+
+  /**
+   * Get the node's kind.
+   *
+   * @return {String}
+   */
+
+  get kind() {
+    return 'text'
+  }
+
+  /**
+   * Is the node empty?
+   *
+   * @return {Boolean}
+   */
+
+  get isEmpty() {
+    return this.text == ''
+  }
+
+  /**
+   * Get the length of the concatenated text of the node.
+   *
+   * @return {Number}
+   */
+
+  get length() {
+    return this.text.length
+  }
+
+  /**
+   * Get the concatenated text of the node.
+   *
+   * @return {String}
+   */
+
+  get text() {
+    return this.characters.reduce((string, char) => string + char.text, '')
+  }
+
+  /**
+   * Add a `mark` at `index` and `length`.
+   *
+   * @param {Number} index
+   * @param {Number} length
+   * @param {Mark} mark
+   * @return {Text}
+   */
+
+  addMark(index, length, mark) {
+    const characters = this.characters.map((char, i) => {
+      if (i < index) return char
+      if (i >= index + length) return char
+      let { marks } = char
+      marks = marks.add(mark)
+      char = char.set('marks', marks)
+      return char
+    })
+
+    return this.set('characters', characters)
+  }
+
+  /**
+   * Derive a set of decorated characters with `decorators`.
+   *
+   * @param {Array} decorators
+   * @return {List<Character>}
+   */
+
+  getDecorations(decorators) {
+    const node = this
+    let { characters } = node
+    if (characters.size == 0) return characters
+
+    for (const decorator of decorators) {
+      const decorateds = decorator(node)
+      characters = characters.merge(decorateds)
+    }
+
+    return characters
+  }
+
+  /**
+   * Get the decorations for the node from a `schema`.
+   *
+   * @param {Schema} schema
+   * @return {Array}
+   */
+
+  getDecorators(schema) {
+    return schema.__getDecorators(this)
+  }
+
+  /**
+   * Get all of the marks on the text.
+   *
+   * @return {OrderedSet<Mark>}
+   */
+
+  getMarks() {
+    const array = this.getMarksAsArray()
+    return new OrderedSet(array)
+  }
+
+  /**
+   * Get all of the marks on the text as an array
+   *
+   * @return {Array}
+   */
+
+  getMarksAsArray() {
+    return this.characters.reduce((array, char) => {
+      return array.concat(char.marks.toArray())
+    }, [])
+  }
+
+  /**
+   * Get the marks on the text at `index`.
+   *
+   * @param {Number} index
+   * @return {Set<Mark>}
+   */
+
+  getMarksAtIndex(index) {
+    if (index == 0) return Mark.createSet()
+    const { characters } = this
+    const char = characters.get(index - 1)
+    if (!char) return Mark.createSet()
+    return char.marks
+  }
+
+  /**
+   * Get a node by `key`, to parallel other nodes.
+   *
+   * @param {String} key
+   * @return {Node|Null}
+   */
+
+  getNode(key) {
+    return this.key == key
+      ? this
+      : null
+  }
+
+  /**
+   * Derive the ranges for a list of `characters`.
+   *
+   * @param {Array|Void} decorators (optional)
+   * @return {List<Range>}
+   */
+
+  getRanges(decorators = []) {
+    const characters = this.getDecorations(decorators)
+    let ranges = []
+
+    // PERF: cache previous values for faster lookup.
+    let prevChar
+    let prevRange
+
+    // If there are no characters, return one empty range.
+    if (characters.size == 0) {
+      ranges.push({})
+    }
+
+    // Otherwise, loop the characters and build the ranges...
+    else {
+      characters.forEach((char, i) => {
+        const { marks, text } = char
+
+        // The first one can always just be created.
+        if (i == 0) {
+          prevChar = char
+          prevRange = { text, marks }
+          ranges.push(prevRange)
+          return
+        }
+
+        // Otherwise, compare the current and previous marks.
+        const prevMarks = prevChar.marks
+        const isSame = is(marks, prevMarks)
+
+        // If the marks are the same, add the text to the previous range.
+        if (isSame) {
+          prevChar = char
+          prevRange.text += text
+          return
+        }
+
+        // Otherwise, create a new range.
+        prevChar = char
+        prevRange = { text, marks }
+        ranges.push(prevRange)
+      }, [])
+    }
+
+    // PERF: convert the ranges to immutable objects after iterating.
+    ranges = new List(ranges.map(object => new Range(object)))
+
+    // Return the ranges.
+    return ranges
+  }
+
+  /**
+   * Check if the node has a node by `key`, to parallel other nodes.
+   *
+   * @param {String} key
+   * @return {Boolean}
+   */
+
+  hasNode(key) {
+    return !!this.getNode(key)
+  }
+
+  /**
+   * Insert `text` at `index`.
+   *
+   * @param {Numbder} index
+   * @param {String} text
+   * @param {String} marks (optional)
+   * @return {Text}
+   */
+
+  insertText(index, text, marks) {
+    marks = marks || this.getMarksAtIndex(index)
+    let { characters } = this
+    const chars = Character.createListFromText(text, marks)
+
+    characters = characters.slice(0, index)
+      .concat(chars)
+      .concat(characters.slice(index))
+
+    return this.set('characters', characters)
+  }
+
+  /**
+   * Regenerate the node's key.
+   *
+   * @return {Text}
+   */
+
+  regenerateKey() {
+    const key = generateKey()
+    return this.set('key', key)
+  }
+
+  /**
+   * Remove a `mark` at `index` and `length`.
+   *
+   * @param {Number} index
+   * @param {Number} length
+   * @param {Mark} mark
+   * @return {Text}
+   */
+
+  removeMark(index, length, mark) {
+    const characters = this.characters.map((char, i) => {
+      if (i < index) return char
+      if (i >= index + length) return char
+      let { marks } = char
+      marks = marks.remove(mark)
+      char = char.set('marks', marks)
+      return char
+    })
+
+    return this.set('characters', characters)
+  }
+
+  /**
+   * Remove text from the text node at `index` for `length`.
+   *
+   * @param {Number} index
+   * @param {Number} length
+   * @return {Text}
+   */
+
+  removeText(index, length) {
+    let { characters } = this
+    const start = index
+    const end = index + length
+    characters = characters.filterNot((char, i) => start <= i && i < end)
+    return this.set('characters', characters)
+  }
+
+  /**
+   * Update a `mark` at `index` and `length` with `properties`.
+   *
+   * @param {Number} index
+   * @param {Number} length
+   * @param {Mark} mark
+   * @param {Mark} newMark
+   * @return {Text}
+   */
+
+  updateMark(index, length, mark, newMark) {
+    const characters = this.characters.map((char, i) => {
+      if (i < index) return char
+      if (i >= index + length) return char
+      let { marks } = char
+      if (!marks.has(mark)) return char
+      marks = marks.remove(mark)
+      marks = marks.add(newMark)
+      char = char.set('marks', marks)
+      return char
+    })
+
+    return this.set('characters', characters)
+  }
+
+  /**
+   * Validate the text node against a `schema`.
+   *
+   * @param {Schema} schema
+   * @return {Object|Void}
+   */
+
+  validate(schema) {
+    return schema.__validate(this)
+  }
+
+}
+
+/**
+ * Memoize read methods.
+ */
+
+memoize(Text.prototype, [
+  'getMarks',
+  'getMarksAsArray',
+], {
+  takesArguments: false,
+})
+
+memoize(Text.prototype, [
+  'getDecorations',
+  'getDecorators',
+  'getMarksAtIndex',
+  'getRanges',
+  'validate'
+], {
+  takesArguments: true,
+})
+
+/**
+ * Export.
+ *
+ * @type {Text}
+ */
+
+export default Text

--- a/src/lib/slate/models/transform.js
+++ b/src/lib/slate/models/transform.js
@@ -1,0 +1,172 @@
+
+import Debug from 'debug'
+import Transforms from '../transforms'
+
+/**
+ * Debug.
+ *
+ * @type {Function}
+ */
+
+const debug = Debug('slate:transform')
+
+/**
+ * Transform.
+ *
+ * @type {Transform}
+ */
+
+class Transform {
+
+  /**
+   * Constructor.
+   *
+   * @param {Object} properties
+   *   @property {State} state
+   */
+
+  constructor(properties) {
+    const { state } = properties
+    this.state = state
+    this.operations = []
+  }
+
+  /**
+   * Get the kind.
+   *
+   * @return {String}
+   */
+
+  get kind() {
+    return 'transform'
+  }
+
+  /**
+   * Apply the transform and return the new state.
+   *
+   * @param {Object} options
+   *   @property {Boolean} isNative
+   *   @property {Boolean} merge
+   *   @property {Boolean} save
+   * @return {State}
+   */
+
+  apply(options = {}) {
+    const transform = this
+    let { merge, save, isNative = false } = options
+
+    // Ensure that the selection is normalized.
+    transform.normalizeSelection()
+
+    const { state, operations } = transform
+    const { history } = state
+    const { undos } = history
+    const previous = undos.peek()
+
+    // If there are no operations, abort early.
+    if (!operations.length) return state
+
+    // If there's a previous save point, determine if the new operations should
+    // be merged into the previous ones.
+    if (previous && merge == null) {
+      merge = (
+        isOnlySelections(operations) ||
+        isContiguousInserts(operations, previous) ||
+        isContiguousRemoves(operations, previous)
+      )
+    }
+
+    // If the save flag isn't set, determine whether we should save.
+    if (save == null) {
+      save = !isOnlySelections(operations)
+    }
+
+    // Save the new operations.
+    if (save) this.save({ merge })
+
+    // Return the new state with the `isNative` flag set.
+    return this.state.set('isNative', !!isNative)
+  }
+
+}
+
+/**
+ * Add a transform method for each of the transforms.
+ */
+
+Object.keys(Transforms).forEach((type) => {
+  Transform.prototype[type] = function (...args) {
+    debug(type, { args })
+    Transforms[type](this, ...args)
+    return this
+  }
+})
+
+/**
+ * Check whether a list of `operations` only contains selection operations.
+ *
+ * @param {Array} operations
+ * @return {Boolean}
+ */
+
+function isOnlySelections(operations) {
+  return operations.every(op => op.type == 'set_selection')
+}
+
+/**
+ * Check whether a list of `operations` and a list of `previous` operations are
+ * contiguous text insertions.
+ *
+ * @param {Array} operations
+ * @param {Array} previous
+ */
+
+function isContiguousInserts(operations, previous) {
+  const edits = operations.filter(op => op.type != 'set_selection')
+  const prevEdits = previous.filter(op => op.type != 'set_selection')
+  if (!edits.length || !prevEdits.length) return false
+
+  const onlyInserts = edits.every(op => op.type == 'insert_text')
+  const prevOnlyInserts = prevEdits.every(op => op.type == 'insert_text')
+  if (!onlyInserts || !prevOnlyInserts) return false
+
+  const first = edits[0]
+  const last = prevEdits[prevEdits.length - 1]
+  if (first.key != last.key) return false
+  if (first.offset != last.offset + last.text.length) return false
+
+  return true
+}
+
+/**
+ * Check whether a list of `operations` and a list of `previous` operations are
+ * contiguous text removals.
+ *
+ * @param {Array} operations
+ * @param {Array} previous
+ */
+
+function isContiguousRemoves(operations, previous) {
+  const edits = operations.filter(op => op.type != 'set_selection')
+  const prevEdits = previous.filter(op => op.type != 'set_selection')
+  if (!edits.length || !prevEdits.length) return false
+
+  const onlyRemoves = edits.every(op => op.type == 'remove_text')
+  const prevOnlyRemoves = prevEdits.every(op => op.type == 'remove_text')
+  if (!onlyRemoves || !prevOnlyRemoves) return false
+
+  const first = edits[0]
+  const last = prevEdits[prevEdits.length - 1]
+  if (first.key != last.key) return false
+  if (first.offset + first.length != last.offset) return false
+
+  return true
+}
+
+/**
+ * Export.
+ *
+ * @type {Transform}
+ */
+
+export default Transform

--- a/src/lib/slate/plugins/Readme.md
+++ b/src/lib/slate/plugins/Readme.md
@@ -1,0 +1,2 @@
+
+This directory contains the only plugin that ships with Slate by default, which controls all of the "core" logic. For example, it handles splitting apart paragraphs when `enter` is pressed, or inserting plain text content from the clipboard on paste.

--- a/src/lib/slate/plugins/core.js
+++ b/src/lib/slate/plugins/core.js
@@ -1,0 +1,999 @@
+
+import Base64 from '../serializers/base-64'
+import Content from '../components/content'
+import Character from '../models/character'
+import Debug from 'debug'
+import getPoint from '../utils/get-point'
+import Placeholder from '../components/placeholder'
+import React from 'react'
+import getWindow from 'get-window'
+import findDOMNode from '../utils/find-dom-node'
+import { IS_CHROME, IS_MAC, IS_SAFARI } from '../constants/environment'
+
+/**
+ * Debug.
+ *
+ * @type {Function}
+ */
+
+const debug = Debug('slate:core')
+
+/**
+ * The default plugin.
+ *
+ * @param {Object} options
+ *   @property {Element} placeholder
+ *   @property {String} placeholderClassName
+ *   @pr`o`perty {Object} placeholderStyle
+ * @return {Object}
+ */
+
+function Plugin(options = {}) {
+  const {
+    placeholder,
+    placeholderClassName,
+    placeholderStyle,
+  } = options
+
+  /**
+   * On before change, enforce the editor's schema.
+   *
+   * @param {State} state
+   * @param {Editor} schema
+   * @return {State}
+   */
+
+  function onBeforeChange(state, editor) {
+    // Don't normalize with plugins schema when typing text in native mode
+    if (state.isNative) return state
+
+    const schema = editor.getSchema()
+    const prevState = editor.getState()
+
+    // Since schema can only normalize the document, we avoid creating
+    // a transform and normalize the selection if the document is the same
+    if (prevState && state.document == prevState.document) return state
+
+    const newState = state.transform()
+      .normalize(schema)
+      .apply({ merge: true })
+
+    debug('onBeforeChange')
+    return newState
+  }
+
+  /**
+   * On before input, see if we can let the browser continue with it's native
+   * input behavior, to avoid a re-render for performance.
+   *
+   * @param {Event} e
+   * @param {Object} data
+   * @param {State} state
+   * @param {Editor} editor
+   * @return {State}
+   */
+
+  function onBeforeInput(e, data, state, editor) {
+    const { document, startKey, startBlock, startOffset, startInline, startText } = state
+    const pText = startBlock.getPreviousText(startKey)
+    const pInline = pText && startBlock.getClosestInline(pText.key)
+    const nText = startBlock.getNextText(startKey)
+    const nInline = nText && startBlock.getClosestInline(nText.key)
+
+    // Determine what the characters would be if natively inserted.
+    const schema = editor.getSchema()
+    const decorators = document.getDescendantDecorators(startKey, schema)
+    const initialChars = startText.getDecorations(decorators)
+    const prevChar = startOffset === 0 ? null : initialChars.get(startOffset - 1)
+    const nextChar = startOffset === initialChars.size ? null : initialChars.get(startOffset)
+    const char = Character.create({
+      text: e.data,
+      // When cursor is at start of a range of marks, without preceding text,
+      // the native behavior is to insert inside the range of marks.
+      marks: (
+        (prevChar && prevChar.marks) ||
+        (nextChar && nextChar.marks) ||
+        []
+      )
+    })
+
+    const chars = initialChars.insert(startOffset, char)
+
+    let transform = state.transform()
+
+    // COMPAT: In iOS, when choosing from the predictive text suggestions, the
+    // native selection will be changed to span the existing word, so that the word
+    // is replaced. But the `select` event for this change doesn't fire until after
+    // the `beforeInput` event, even though the native selection is updated. So we
+    // need to manually adjust the selection to be in sync. (03/18/2017)
+    const window = getWindow(e.target)
+    const native = window.getSelection()
+    const { anchorNode, anchorOffset, focusNode, focusOffset } = native
+    const anchorPoint = getPoint(anchorNode, anchorOffset, state, editor)
+    const focusPoint = getPoint(focusNode, focusOffset, state, editor)
+    if (anchorPoint && focusPoint) {
+      const { selection } = state
+      if (
+        selection.anchorKey !== anchorPoint.key ||
+        selection.anchorOffset !== anchorPoint.offset ||
+        selection.focusKey !== focusPoint.key ||
+        selection.focusOffset !== focusPoint.offset
+      ) {
+        transform = transform
+          .select({
+            anchorKey: anchorPoint.key,
+            anchorOffset: anchorPoint.offset,
+            focusKey: focusPoint.key,
+            focusOffset: focusPoint.offset
+          })
+      }
+    }
+
+    // Determine what the characters should be, if not natively inserted.
+    let next = transform
+      .insertText(e.data)
+      .apply()
+
+    const nextText = next.startText
+    const nextChars = nextText.getDecorations(decorators)
+
+    // We do not have to re-render if the current selection is collapsed, the
+    // current node is not empty, there are no marks on the cursor, the cursor
+    // is not at the edge of an inline node, the cursor isn't at the starting
+    // edge of a text node after an inline node, and the natively inserted
+    // characters would be the same as the non-native.
+    const isNative = (
+      // If the selection is expanded, we don't know what the edit will look
+      // like so we can't let it happen natively.
+      (state.isCollapsed) &&
+      // If the selection has marks, then we need to render it non-natively
+      // because we need to create the new marks as well.
+      (state.selection.marks == null) &&
+      // If the text node in question has no content, browsers might do weird
+      // things so we need to insert it normally instead.
+      (state.startText.text != '') &&
+      // COMPAT: Browsers do weird things when typing at the edges of inline
+      // nodes, so we can't let them render natively. (?)
+      (!startInline || !state.selection.isAtStartOf(startInline)) &&
+      (!startInline || !state.selection.isAtEndOf(startInline)) &&
+      // COMPAT: In Chrome & Safari, it isn't possible to have a selection at
+      // the starting edge of a text node after another inline node. It will
+      // have been automatically changed. So we can't render natively because
+      // the cursor isn't technique in the right spot. (2016/12/01)
+      (!(pInline && !pInline.isVoid && startOffset == 0)) &&
+      (!(nInline && !nInline.isVoid && startOffset == startText.length)) &&
+      // If the
+      (chars.equals(nextChars))
+    )
+
+    // Add the `isNative` flag directly, so we don't have to re-transform.
+    if (isNative) {
+      next = next.set('isNative', isNative)
+    }
+
+    // If not native, prevent default so that the DOM remains untouched.
+    if (!isNative) e.preventDefault()
+
+    debug('onBeforeInput', { data, isNative })
+    return next
+  }
+
+  /**
+   * On blur.
+   *
+   * @param {Event} e
+   * @param {Object} data
+   * @param {State} state
+   * @return {State}
+   */
+
+  function onBlur(e, data, state) {
+    debug('onBlur', { data })
+    return state
+      .transform()
+      .blur()
+      .apply()
+  }
+
+  /**
+   * On copy.
+   *
+   * @param {Event} e
+   * @param {Object} data
+   * @param {State} state
+   * @return {State}
+   */
+
+  function onCopy(e, data, state) {
+    debug('onCopy', data)
+    onCutOrCopy(e, data, state)
+  }
+
+  /**
+   * On cut.
+   *
+   * @param {Event} e
+   * @param {Object} data
+   * @param {State} state
+   * @param {Editor} editor
+   * @return {State}
+   */
+
+  function onCut(e, data, state, editor) {
+    debug('onCut', data)
+    onCutOrCopy(e, data, state)
+    const window = getWindow(e.target)
+
+    // Once the fake cut content has successfully been added to the clipboard,
+    // delete the content in the current selection.
+    window.requestAnimationFrame(() => {
+      const next = editor
+        .getState()
+        .transform()
+        .delete()
+        .apply()
+
+      editor.onChange(next)
+    })
+  }
+
+  /**
+   * On cut or copy, create a fake selection so that we can add a Base 64
+   * encoded copy of the fragment to the HTML, to decode on future pastes.
+   *
+   * @param {Event} e
+   * @param {Object} data
+   * @param {State} state
+   * @return {State}
+   */
+
+  function onCutOrCopy(e, data, state) {
+    const window = getWindow(e.target)
+    const native = window.getSelection()
+    const { endBlock, endInline } = state
+    const isVoidBlock = endBlock && endBlock.isVoid
+    const isVoidInline = endInline && endInline.isVoid
+    const isVoid = isVoidBlock || isVoidInline
+
+    // If the selection is collapsed, and it isn't inside a void node, abort.
+    if (native.isCollapsed && !isVoid) return
+
+    const { fragment } = data
+    const encoded = Base64.serializeNode(fragment)
+    const range = native.getRangeAt(0)
+    let contents = range.cloneContents()
+    let attach = contents.childNodes[0]
+
+    // If the end node is a void node, we need to move the end of the range from
+    // the void node's spacer span, to the end of the void node's content.
+    if (isVoid) {
+      const r = range.cloneRange()
+      const node = findDOMNode(isVoidBlock ? endBlock : endInline)
+      r.setEndAfter(node)
+      contents = r.cloneContents()
+      attach = contents.childNodes[contents.childNodes.length - 1].firstChild
+    }
+
+    // Remove any zero-width space spans from the cloned DOM so that they don't
+    // show up elsewhere when pasted.
+    const zws = [].slice.call(contents.querySelectorAll('[data-slate-zero-width]'))
+    zws.forEach(zw => zw.parentNode.removeChild(zw))
+
+    // COMPAT: In Chrome and Safari, if the last element in the selection to
+    // copy has `contenteditable="false"` the copy will fail, and nothing will
+    // be put in the clipboard. So we remove them all. (2017/05/04)
+    if (IS_CHROME || IS_SAFARI) {
+      const els = [].slice.call(contents.querySelectorAll('[contenteditable="false"]'))
+      els.forEach(el => el.removeAttribute('contenteditable'))
+    }
+
+    // Set a `data-slate-fragment` attribute on a non-empty node, so it shows up
+    // in the HTML, and can be used for intra-Slate pasting. If it's a text
+    // node, wrap it in a `<span>` so we have something to set an attribute on.
+    if (attach.nodeType == 3) {
+      const span = window.document.createElement('span')
+      span.appendChild(attach)
+      contents.appendChild(span)
+      attach = span
+    }
+
+    attach.setAttribute('data-slate-fragment', encoded)
+
+    // Add the phony content to the DOM, and select it, so it will be copied.
+    const body = window.document.querySelector('body')
+    const div = window.document.createElement('div')
+    div.setAttribute('contenteditable', true)
+    div.style.position = 'absolute'
+    div.style.left = '-9999px'
+    div.appendChild(contents)
+    body.appendChild(div)
+
+    // COMPAT: In Firefox, trying to use the terser `native.selectAllChildren`
+    // throws an error, so we use the older `range` equivalent. (2016/06/21)
+    const r = window.document.createRange()
+    r.selectNodeContents(div)
+    native.removeAllRanges()
+    native.addRange(r)
+
+    // Revert to the previous selection right after copying.
+    window.requestAnimationFrame(() => {
+      body.removeChild(div)
+      native.removeAllRanges()
+      native.addRange(range)
+    })
+  }
+
+  /**
+   * On drop.
+   *
+   * @param {Event} e
+   * @param {Object} data
+   * @param {State} state
+   * @return {State}
+   */
+
+  function onDrop(e, data, state) {
+    debug('onDrop', { data })
+
+    switch (data.type) {
+      case 'text':
+      case 'html':
+        return onDropText(e, data, state)
+      case 'fragment':
+        return onDropFragment(e, data, state)
+    }
+  }
+
+  /**
+   * On drop fragment.
+   *
+   * @param {Event} e
+   * @param {Object} data
+   * @param {State} state
+   * @return {State}
+   */
+
+  function onDropFragment(e, data, state) {
+    debug('onDropFragment', { data })
+
+    const { selection } = state
+    let { fragment, target, isInternal } = data
+
+    // If the drag is internal and the target is after the selection, it
+    // needs to account for the selection's content being deleted.
+    if (
+      isInternal &&
+      selection.endKey == target.endKey &&
+      selection.endOffset < target.endOffset
+    ) {
+      target = target.move(selection.startKey == selection.endKey
+        ? 0 - selection.endOffset - selection.startOffset
+        : 0 - selection.endOffset)
+    }
+
+    const transform = state.transform()
+
+    if (isInternal) transform.delete()
+
+    return transform
+      .select(target)
+      .insertFragment(fragment)
+      .apply()
+  }
+
+  /**
+   * On drop text, split the blocks at new lines.
+   *
+   * @param {Event} e
+   * @param {Object} data
+   * @param {State} state
+   * @return {State}
+   */
+
+  function onDropText(e, data, state) {
+    debug('onDropText', { data })
+
+    const { text, target } = data
+    const transform = state
+      .transform()
+      .select(target)
+
+    text
+      .split('\n')
+      .forEach((line, i) => {
+        if (i > 0) transform.splitBlock()
+        transform.insertText(line)
+      })
+
+    return transform.apply()
+  }
+
+  /**
+   * On key down.
+   *
+   * @param {Event} e
+   * @param {Object} data
+   * @param {State} state
+   * @return {State}
+   */
+
+  function onKeyDown(e, data, state) {
+    debug('onKeyDown', { data })
+
+    switch (data.key) {
+      case 'enter': return onKeyDownEnter(e, data, state)
+      case 'backspace': return onKeyDownBackspace(e, data, state)
+      case 'delete': return onKeyDownDelete(e, data, state)
+      case 'left': return onKeyDownLeft(e, data, state)
+      case 'right': return onKeyDownRight(e, data, state)
+      case 'up': return onKeyDownUp(e, data, state)
+      case 'down': return onKeyDownDown(e, data, state)
+      case 'd': return onKeyDownD(e, data, state)
+      case 'h': return onKeyDownH(e, data, state)
+      case 'k': return onKeyDownK(e, data, state)
+      case 'y': return onKeyDownY(e, data, state)
+      case 'z': return onKeyDownZ(e, data, state)
+    }
+  }
+
+  /**
+   * On `enter` key down, split the current block in half.
+   *
+   * @param {Event} e
+   * @param {Object} data
+   * @param {State} state
+   * @return {State}
+   */
+
+  function onKeyDownEnter(e, data, state) {
+    const { document, startKey } = state
+    const hasVoidParent = document.hasVoidParent(startKey)
+
+    // For void nodes, we don't want to split. Instead we just move to the start
+    // of the next text node if one exists.
+    if (hasVoidParent) {
+      const text = document.getNextText(startKey)
+      if (!text) return
+      return state
+        .transform()
+        .collapseToStartOf(text)
+        .apply()
+    }
+
+    return state
+      .transform()
+      .splitBlock()
+      .apply()
+  }
+
+  /**
+   * On `backspace` key down, delete backwards.
+   *
+   * @param {Event} e
+   * @param {Object} data
+   * @param {State} state
+   * @return {State}
+   */
+
+  function onKeyDownBackspace(e, data, state) {
+    let boundary = 'Char'
+    if (data.isWord) boundary = 'Word'
+    if (data.isLine) boundary = 'Line'
+
+    return state
+      .transform()
+      [`delete${boundary}Backward`]()
+      .apply()
+  }
+
+  /**
+   * On `delete` key down, delete forwards.
+   *
+   * @param {Event} e
+   * @param {Object} data
+   * @param {State} state
+   * @return {State}
+   */
+
+  function onKeyDownDelete(e, data, state) {
+    let boundary = 'Char'
+    if (data.isWord) boundary = 'Word'
+    if (data.isLine) boundary = 'Line'
+
+    return state
+      .transform()
+      [`delete${boundary}Forward`]()
+      .apply()
+  }
+
+  /**
+   * On `left` key down, move backward.
+   *
+   * COMPAT: This is required to make navigating with the left arrow work when
+   * a void node is selected.
+   *
+   * COMPAT: This is also required to solve for the case where an inline node is
+   * surrounded by empty text nodes with zero-width spaces in them. Without this
+   * the zero-width spaces will cause two arrow keys to jump to the next text.
+   *
+   * @param {Event} e
+   * @param {Object} data
+   * @param {State} state
+   * @return {State}
+   */
+
+  function onKeyDownLeft(e, data, state) {
+    if (data.isCtrl) return
+    if (data.isAlt) return
+    if (state.isExpanded) return
+
+    const { document, startKey, startText } = state
+    const hasVoidParent = document.hasVoidParent(startKey)
+
+    // If the current text node is empty, or we're inside a void parent, we're
+    // going to need to handle the selection behavior.
+    if (startText.text == '' || hasVoidParent) {
+      e.preventDefault()
+      const previous = document.getPreviousText(startKey)
+
+      // If there's no previous text node in the document, abort.
+      if (!previous) return
+
+      // If the previous text is in the current block, and inside a non-void
+      // inline node, move one character into the inline node.
+      const { startBlock } = state
+      const previousBlock = document.getClosestBlock(previous.key)
+      const previousInline = document.getClosestInline(previous.key)
+
+      if (previousBlock === startBlock && previousInline && !previousInline.isVoid) {
+        const extendOrMove = data.isShift ? 'extend' : 'move'
+        return state
+          .transform()
+          .collapseToEndOf(previous)
+          [extendOrMove](-1)
+          .apply()
+      }
+
+      // Otherwise, move to the end of the previous node.
+      return state
+        .transform()
+        .collapseToEndOf(previous)
+        .apply()
+    }
+  }
+
+  /**
+   * On `right` key down, move forward.
+   *
+   * COMPAT: This is required to make navigating with the right arrow work when
+   * a void node is selected.
+   *
+   * COMPAT: This is also required to solve for the case where an inline node is
+   * surrounded by empty text nodes with zero-width spaces in them. Without this
+   * the zero-width spaces will cause two arrow keys to jump to the next text.
+   *
+   * COMPAT: In Chrome & Safari, selections that are at the zero offset of
+   * an inline node will be automatically replaced to be at the last offset
+   * of a previous inline node, which screws us up, so we never want to set the
+   * selection to the very start of an inline node here. (2016/11/29)
+   *
+   * @param {Event} e
+   * @param {Object} data
+   * @param {State} state
+   * @return {State}
+   */
+
+  function onKeyDownRight(e, data, state) {
+    if (data.isCtrl) return
+    if (data.isAlt) return
+    if (state.isExpanded) return
+
+    const { document, startKey, startText } = state
+    const hasVoidParent = document.hasVoidParent(startKey)
+
+    // If the current text node is empty, or we're inside a void parent, we're
+    // going to need to handle the selection behavior.
+    if (startText.text == '' || hasVoidParent) {
+      e.preventDefault()
+      const next = document.getNextText(startKey)
+
+      // If there's no next text node in the document, abort.
+      if (!next) return state
+
+      // If the next text is inside a void node, move to the end of it.
+      const isInVoid = document.hasVoidParent(next.key)
+
+      if (isInVoid) {
+        return state
+          .transform()
+          .collapseToEndOf(next)
+          .apply()
+      }
+
+      // If the next text is in the current block, and inside an inline node,
+      // move one character into the inline node.
+      const { startBlock } = state
+      const nextBlock = document.getClosestBlock(next.key)
+      const nextInline = document.getClosestInline(next.key)
+
+      if (nextBlock == startBlock && nextInline) {
+        const extendOrMove = data.isShift ? 'extend' : 'move'
+        return state
+          .transform()
+          .collapseToStartOf(next)
+          [extendOrMove](1)
+          .apply()
+      }
+
+      // Otherwise, move to the start of the next text node.
+      return state
+        .transform()
+        .collapseToStartOf(next)
+        .apply()
+    }
+  }
+
+  /**
+   * On `up` key down, for Macs, move the selection to start of the block.
+   *
+   * COMPAT: Certain browsers don't handle the selection updates properly. In
+   * Chrome, option-shift-up doesn't properly extend the selection. And in
+   * Firefox, option-up doesn't properly move the selection.
+   *
+   * @param {Event} e
+   * @param {Object} data
+   * @param {State} state
+   * @return {State}
+   */
+
+  function onKeyDownUp(e, data, state) {
+    if (!IS_MAC || data.isCtrl || !data.isAlt) return
+
+    const transform = data.isShift ? 'extendToStartOf' : 'collapseToStartOf'
+    const { selection, document, focusKey, focusBlock } = state
+    const block = selection.hasFocusAtStartOf(focusBlock)
+      ? document.getPreviousBlock(focusKey)
+      : focusBlock
+
+    if (!block) return
+    const text = block.getFirstText()
+
+    e.preventDefault()
+    return state
+      .transform()
+      [transform](text)
+      .apply()
+  }
+
+  /**
+   * On `down` key down, for Macs, move the selection to end of the block.
+   *
+   * COMPAT: Certain browsers don't handle the selection updates properly. In
+   * Chrome, option-shift-down doesn't properly extend the selection. And in
+   * Firefox, option-down doesn't properly move the selection.
+   *
+   * @param {Event} e
+   * @param {Object} data
+   * @param {State} state
+   * @return {State}
+   */
+
+  function onKeyDownDown(e, data, state) {
+    if (!IS_MAC || data.isCtrl || !data.isAlt) return
+
+    const transform = data.isShift ? 'extendToEndOf' : 'collapseToEndOf'
+    const { selection, document, focusKey, focusBlock } = state
+    const block = selection.hasFocusAtEndOf(focusBlock)
+      ? document.getNextBlock(focusKey)
+      : focusBlock
+
+    if (!block) return
+    const text = block.getLastText()
+
+    e.preventDefault()
+    return state
+      .transform()
+      [transform](text)
+      .apply()
+  }
+
+  /**
+   * On `d` key down, for Macs, delete one character forward.
+   *
+   * @param {Event} e
+   * @param {Object} data
+   * @param {State} state
+   * @return {State}
+   */
+
+  function onKeyDownD(e, data, state) {
+    if (!IS_MAC || !data.isCtrl) return
+    e.preventDefault()
+    return state
+      .transform()
+      .deleteCharForward()
+      .apply()
+  }
+
+  /**
+   * On `h` key down, for Macs, delete until the end of the line.
+   *
+   * @param {Event} e
+   * @param {Object} data
+   * @param {State} state
+   * @return {State}
+   */
+
+  function onKeyDownH(e, data, state) {
+    if (!IS_MAC || !data.isCtrl) return
+    e.preventDefault()
+    return state
+      .transform()
+      .deleteCharBackward()
+      .apply()
+  }
+
+  /**
+   * On `k` key down, for Macs, delete until the end of the line.
+   *
+   * @param {Event} e
+   * @param {Object} data
+   * @param {State} state
+   * @return {State}
+   */
+
+  function onKeyDownK(e, data, state) {
+    if (!IS_MAC || !data.isCtrl) return
+    e.preventDefault()
+    return state
+      .transform()
+      .deleteLineForward()
+      .apply()
+  }
+
+  /**
+   * On `y` key down, redo.
+   *
+   * @param {Event} e
+   * @param {Object} data
+   * @param {State} state
+   * @return {State}
+   */
+
+  function onKeyDownY(e, data, state) {
+    if (!data.isMod) return
+
+    return state
+      .transform()
+      .redo()
+      .apply({ save: false })
+  }
+
+  /**
+   * On `z` key down, undo or redo.
+   *
+   * @param {Event} e
+   * @param {Object} data
+   * @param {State} state
+   * @return {State}
+   */
+
+  function onKeyDownZ(e, data, state) {
+    if (!data.isMod) return
+
+    return state
+      .transform()
+      [data.isShift ? 'redo' : 'undo']()
+      .apply({ save: false })
+  }
+
+  /**
+   * On paste.
+   *
+   * @param {Event} e
+   * @param {Object} data
+   * @param {State} state
+   * @return {State}
+   */
+
+  function onPaste(e, data, state) {
+    debug('onPaste', { data })
+
+    switch (data.type) {
+      case 'fragment':
+        return onPasteFragment(e, data, state)
+      case 'text':
+      case 'html':
+        return onPasteText(e, data, state)
+    }
+  }
+
+  /**
+   * On paste fragment.
+   *
+   * @param {Event} e
+   * @param {Object} data
+   * @param {State} state
+   * @return {State}
+   */
+
+  function onPasteFragment(e, data, state) {
+    debug('onPasteFragment', { data })
+
+    return state
+      .transform()
+      .insertFragment(data.fragment)
+      .apply()
+  }
+
+  /**
+   * On paste text, split blocks at new lines.
+   *
+   * @param {Event} e
+   * @param {Object} data
+   * @param {State} state
+   * @return {State}
+   */
+
+  function onPasteText(e, data, state) {
+    debug('onPasteText', { data })
+
+    const transform = state.transform()
+
+    data.text
+      .split('\n')
+      .forEach((line, i) => {
+        if (i > 0) transform.splitBlock()
+        transform.insertText(line)
+      })
+
+    return transform.apply()
+  }
+
+  /**
+   * On select.
+   *
+   * @param {Event} e
+   * @param {Object} data
+   * @param {State} state
+   * @return {State}
+   */
+
+  function onSelect(e, data, state) {
+    debug('onSelect', { data })
+
+    return state
+      .transform()
+      .select(data.selection)
+      .apply()
+  }
+
+  /**
+   * Render.
+   *
+   * @param {Object} props
+   * @param {State} state
+   * @param {Editor} editor
+   * @return {Object}
+   */
+
+  function render(props, state, editor) {
+    return (
+      <Content
+        autoCorrect={props.autoCorrect}
+        autoFocus={props.autoFocus}
+        className={props.className}
+        children={props.children}
+        editor={editor}
+        onBeforeInput={editor.onBeforeInput}
+        onBlur={editor.onBlur}
+        onFocus={editor.onFocus}
+        onChange={editor.onChange}
+        onCopy={editor.onCopy}
+        onCut={editor.onCut}
+        onDrop={editor.onDrop}
+        onInput={editor.onInput}
+        onKeyDown={editor.onKeyDown}
+        onPaste={editor.onPaste}
+        onSelect={editor.onSelect}
+        readOnly={props.readOnly}
+        role={props.role}
+        schema={editor.getSchema()}
+        spellCheck={props.spellCheck}
+        state={state}
+        style={props.style}
+        tabIndex={props.tabIndex}
+      />
+    )
+  }
+
+  /**
+   * A default schema rule to render block nodes.
+   *
+   * @type {Object}
+   */
+
+  const BLOCK_RENDER_RULE = {
+    match: (node) => {
+      return node.kind == 'block'
+    },
+    render: (props) => {
+      return (
+        <div {...props.attributes} style={{ position: 'relative' }}>
+          {props.children}
+          {placeholder
+            ? <Placeholder
+                className={placeholderClassName}
+                node={props.node}
+                parent={props.state.document}
+                state={props.state}
+                style={placeholderStyle}
+              >
+                {placeholder}
+              </Placeholder>
+            : null}
+        </div>
+      )
+    }
+  }
+
+  /**
+   * A default schema rule to render inline nodes.
+   *
+   * @type {Object}
+   */
+
+  const INLINE_RENDER_RULE = {
+    match: (node) => {
+      return node.kind == 'inline'
+    },
+    render: (props) => {
+      return (
+        <span {...props.attributes} style={{ position: 'relative' }}>
+          {props.children}
+        </span>
+      )
+    }
+  }
+
+  /**
+   * Add default rendering rules to the schema.
+   *
+   * @type {Object}
+   */
+
+  const schema = {
+    rules: [
+      BLOCK_RENDER_RULE,
+      INLINE_RENDER_RULE
+    ]
+  }
+
+  /**
+   * Return the core plugin.
+   *
+   * @type {Object}
+   */
+
+  return {
+    onBeforeChange,
+    onBeforeInput,
+    onBlur,
+    onCopy,
+    onCut,
+    onDrop,
+    onKeyDown,
+    onPaste,
+    onSelect,
+    render,
+    schema,
+  }
+}
+
+/**
+ * Export.
+ *
+ * @type {Object}
+ */
+
+export default Plugin

--- a/src/lib/slate/schemas/Readme.md
+++ b/src/lib/slate/schemas/Readme.md
@@ -1,0 +1,2 @@
+
+This directory contains the core schema that ships with Slate by default, which controls all of the "core" document and selection validation logic. For example, it ensures that two adjacent text nodes are always joined, or that the top-level document only ever contains block nodes. It is not exposed by default, since it is only needed internally.

--- a/src/lib/slate/schemas/core.js
+++ b/src/lib/slate/schemas/core.js
@@ -1,0 +1,307 @@
+
+import Schema from '../models/schema'
+import Text from '../models/text'
+import { List } from 'immutable'
+
+/**
+ * Options object with normalize set to `false`.
+ *
+ * @type {Object}
+ */
+
+const OPTS = { normalize: false }
+
+/**
+ * Define the core schema rules, order-sensitive.
+ *
+ * @type {Array}
+ */
+
+const rules = [
+
+  /**
+   * Only allow block nodes in documents.
+   *
+   * @type {Object}
+   */
+
+  {
+    match: (node) => {
+      return node.kind == 'document'
+    },
+    validate: (document) => {
+      const invalids = document.nodes.filter(n => n.kind != 'block')
+      return invalids.size ? invalids : null
+    },
+    normalize: (transform, document, invalids) => {
+      invalids.forEach((node) => {
+        transform.removeNodeByKey(node.key, OPTS)
+      })
+    }
+  },
+
+  /**
+   * Only allow block, inline and text nodes in blocks.
+   *
+   * @type {Object}
+   */
+
+  {
+    match: (node) => {
+      return node.kind == 'block'
+    },
+    validate: (block) => {
+      const invalids = block.nodes.filter((n) => {
+        return n.kind != 'block' && n.kind != 'inline' && n.kind != 'text'
+      })
+
+      return invalids.size ? invalids : null
+    },
+    normalize: (transform, block, invalids) => {
+      invalids.forEach((node) => {
+        transform.removeNodeByKey(node.key, OPTS)
+      })
+    }
+  },
+
+  /**
+   * Only allow inline and text nodes in inlines.
+   *
+   * @type {Object}
+   */
+
+  {
+    match: (object) => {
+      return object.kind == 'inline'
+    },
+    validate: (inline) => {
+      const invalids = inline.nodes.filter(n => n.kind != 'inline' && n.kind != 'text')
+      return invalids.size ? invalids : null
+    },
+    normalize: (transform, inline, invalids) => {
+      invalids.forEach((node) => {
+        transform.removeNodeByKey(node.key, OPTS)
+      })
+    }
+  },
+
+  /**
+   * Ensure that block and inline nodes have at least one text child.
+   *
+   * @type {Object}
+   */
+
+  {
+    match: (object) => {
+      return object.kind == 'block' || object.kind == 'inline'
+    },
+    validate: (node) => {
+      return node.nodes.size == 0
+    },
+    normalize: (transform, node) => {
+      const text = Text.create()
+      transform.insertNodeByKey(node.key, 0, text, OPTS)
+    }
+  },
+
+  /**
+   * Ensure that void nodes contain a text node with a single space of text.
+   *
+   * @type {Object}
+   */
+
+  {
+    match: (object) => {
+      return (
+        (object.kind == 'inline' || object.kind == 'block') &&
+        (object.isVoid)
+      )
+    },
+    validate: (node) => {
+      return node.text !== ' ' || node.nodes.size !== 1
+    },
+    normalize: (transform, node, result) => {
+      const text = Text.createFromString(' ')
+      const index = node.nodes.size
+
+      transform.insertNodeByKey(node.key, index, text, OPTS)
+
+      node.nodes.forEach((child) => {
+        transform.removeNodeByKey(child.key, OPTS)
+      })
+    }
+  },
+
+  /**
+   * Ensure that inline nodes are never empty.
+   *
+   * This rule is applied to all blocks, because when they contain an empty
+   * inline, we need to remove the inline from that parent block. If `validate`
+   * was to be memoized, it should be against the parent node, not the inline
+   * themselves.
+   *
+   * @type {Object}
+   */
+
+  {
+    match: (object) => {
+      return object.kind == 'block'
+    },
+    validate: (block) => {
+      const invalids = block.nodes.filter(n => n.kind == 'inline' && n.text == '')
+      return invalids.size ? invalids : null
+    },
+    normalize: (transform, block, invalids) => {
+      // If all of the block's nodes are invalid, insert an empty text node so
+      // that the selection will be preserved when they are all removed.
+      if (block.nodes.size == invalids.size) {
+        const text = Text.create()
+        transform.insertNodeByKey(block.key, 1, text, OPTS)
+      }
+
+      invalids.forEach((node) => {
+        transform.removeNodeByKey(node.key, OPTS)
+      })
+    }
+  },
+
+  /**
+   * Ensure that inline void nodes are surrounded by text nodes, by adding extra
+   * blank text nodes if necessary.
+   *
+   * @type {Object}
+   */
+
+  {
+    match: (object) => {
+      return object.kind == 'block' || object.kind == 'inline'
+    },
+    validate: (node) => {
+      const invalids = node.nodes.reduce((list, child, index) => {
+        if (child.kind !== 'inline') return list
+
+        const prev = index > 0 ? node.nodes.get(index - 1) : null
+        const next = node.nodes.get(index + 1)
+        // We don't test if "prev" is inline, since it has already been processed in the loop
+        const insertBefore = !prev
+        const insertAfter = !next || (next.kind == 'inline')
+
+        if (insertAfter || insertBefore) {
+          list = list.push({ insertAfter, insertBefore, index })
+        }
+
+        return list
+      }, new List())
+
+      return invalids.size ? invalids : null
+    },
+    normalize: (transform, block, invalids) => {
+      // Shift for every text node inserted previously.
+      let shift = 0
+
+      invalids.forEach(({ index, insertAfter, insertBefore }) => {
+        if (insertBefore) {
+          transform.insertNodeByKey(block.key, shift + index, Text.create(), OPTS)
+          shift++
+        }
+
+        if (insertAfter) {
+          transform.insertNodeByKey(block.key, shift + index + 1, Text.create(), OPTS)
+          shift++
+        }
+      })
+    }
+  },
+
+  /**
+   * Join adjacent text nodes.
+   *
+   * @type {Object}
+   */
+
+  {
+    match: (object) => {
+      return object.kind == 'block' || object.kind == 'inline'
+    },
+    validate: (node) => {
+      const invalids = node.nodes
+        .map((child, i) => {
+          const next = node.nodes.get(i + 1)
+          if (child.kind != 'text') return
+          if (!next || next.kind != 'text') return
+          return [child, next]
+        })
+        .filter(Boolean)
+
+      return invalids.size ? invalids : null
+    },
+    normalize: (transform, node, pairs) => {
+      // We reverse the list to handle consecutive joins, since the earlier nodes
+      // will always exist after each join.
+      pairs.reverse().forEach((pair) => {
+        const [ first, second ] = pair
+        return transform.joinNodeByKey(second.key, first.key, OPTS)
+      })
+    }
+  },
+
+  /**
+   * Prevent extra empty text nodes, except when adjacent to inline void nodes.
+   *
+   * @type {Object}
+   */
+
+  {
+    match: (object) => {
+      return object.kind == 'block' || object.kind == 'inline'
+    },
+    validate: (node) => {
+      const { nodes } = node
+      if (nodes.size <= 1) return
+
+      const invalids = nodes.filter((desc, i) => {
+        if (desc.kind != 'text') return
+        if (desc.length > 0) return
+
+        const prev = i > 0 ? nodes.get(i - 1) : null
+        const next = nodes.get(i + 1)
+
+        // If it's the first node, and the next is a void, preserve it.
+        if (!prev && next.kind == 'inline') return
+
+        // It it's the last node, and the previous is an inline, preserve it.
+        if (!next && prev.kind == 'inline') return
+
+        // If it's surrounded by inlines, preserve it.
+        if (next && prev && next.kind == 'inline' && prev.kind == 'inline') return
+
+        // Otherwise, remove it.
+        return true
+      })
+
+      return invalids.size ? invalids : null
+    },
+    normalize: (transform, node, invalids) => {
+      invalids.forEach((text) => {
+        transform.removeNodeByKey(text.key, OPTS)
+      })
+    }
+  }
+
+]
+
+/**
+ * Create the core schema.
+ *
+ * @type {Schema}
+ */
+
+const SCHEMA = Schema.create({ rules })
+
+/**
+ * Export.
+ *
+ * @type {Schema}
+ */
+
+export default SCHEMA

--- a/src/lib/slate/serializers/Readme.md
+++ b/src/lib/slate/serializers/Readme.md
@@ -1,0 +1,24 @@
+
+This directory contains the serializers that ship by default with Slate. They are not the only serializers, it's fairly easy to implement your own if you have more complex use cases. Here's what the core serializers do:
+
+- [Html](#html)
+- [Raw](#raw)
+
+#### Html
+
+The `Html` serializer offers a simple way to serialize and deserialize an HTML schema of your choosing.
+
+It doesn't hardcode any information about the schema itself (like which tag means "bold"), but allows you to build up a simple HTML serializer for your own use case.
+
+It handles all of the heavy lifting of actually parsing the HTML, and iterating over the elements, and all you have to supply it is a `serialize()` and `deserialize()` function for each type of [`Node`](../models#node) or [`Mark`](../models/#mark) you want it to handle.
+
+If called with `{render: false}` as the optional second argument, the serializer will return an iterable list of the top-level React elements generated, instead of automatically rendering these to a markup string.
+
+
+#### Raw
+
+The `Raw` serializer is the simplest serializer, which translates a [`State`](../models#state) into JSON.
+
+It doesn't just use Immutable.js's [`.toJSON()`](https://facebook.github.io/immutable-js/docs/#/List/toJS) method. Instead, it performs a little bit of "minifying" logic to reduce unnecessary information from being in the raw output.
+
+It also transforms [`Text`](../models#text) nodes's content from being organized by [`Characters`](../models#character) into the concept of "ranges", which have a unique set of [`Marks`](../models#mark).

--- a/src/lib/slate/serializers/base-64.js
+++ b/src/lib/slate/serializers/base-64.js
@@ -1,0 +1,93 @@
+
+import Raw from './raw'
+
+/**
+ * Encode a JSON `object` as base-64 `string`.
+ *
+ * @param {Object} object
+ * @return {String}
+ */
+
+function encode(object) {
+  const string = JSON.stringify(object)
+  const encoded = window.btoa(window.encodeURIComponent(string))
+  return encoded
+}
+
+/**
+ * Decode a base-64 `string` to a JSON `object`.
+ *
+ * @param {String} string
+ * @return {Object}
+ */
+
+function decode(string) {
+  const decoded = window.decodeURIComponent(window.atob(string))
+  const object = JSON.parse(decoded)
+  return object
+}
+
+/**
+ * Deserialize a State `string`.
+ *
+ * @param {String} string
+ * @return {State}
+ */
+
+function deserialize(string, options) {
+  const raw = decode(string)
+  const state = Raw.deserialize(raw, options)
+  return state
+}
+
+/**
+ * Deserialize a Node `string`.
+ *
+ * @param {String} string
+ * @return {Node}
+ */
+
+function deserializeNode(string, options) {
+  const raw = decode(string)
+  const node = Raw.deserializeNode(raw, options)
+  return node
+}
+
+/**
+ * Serialize a `state`.
+ *
+ * @param {State} state
+ * @return {String}
+ */
+
+function serialize(state, options) {
+  const raw = Raw.serialize(state, options)
+  const encoded = encode(raw)
+  return encoded
+}
+
+/**
+ * Serialize a `node`.
+ *
+ * @param {Node} node
+ * @return {String}
+ */
+
+function serializeNode(node, options) {
+  const raw = Raw.serializeNode(node, options)
+  const encoded = encode(raw)
+  return encoded
+}
+
+/**
+ * Export.
+ *
+ * @type {Object}
+ */
+
+export default {
+  deserialize,
+  deserializeNode,
+  serialize,
+  serializeNode
+}

--- a/src/lib/slate/serializers/html.js
+++ b/src/lib/slate/serializers/html.js
@@ -1,0 +1,353 @@
+
+import Raw from './raw'
+import React from 'react'
+import ReactDOMServer from 'react-dom/server'
+import cheerio from 'cheerio'
+import typeOf from 'type-of'
+import { Record } from 'immutable'
+
+/**
+ * String.
+ *
+ * @type {String}
+ */
+
+const String = new Record({
+  kind: 'string',
+  text: ''
+})
+
+/**
+ * A rule to (de)serialize text nodes. This is automatically added to the HTML
+ * serializer so that users don't have to worry about text-level serialization.
+ *
+ * @type {Object}
+ */
+
+const TEXT_RULE = {
+
+  deserialize(el) {
+    if (el.tagName == 'br') {
+      return {
+        kind: 'text',
+        text: '\n'
+      }
+    }
+
+    if (el.type == 'text') {
+      if (el.data && el.data.match(/<!--.*?-->/)) return
+
+      return {
+        kind: 'text',
+        text: el.data
+      }
+    }
+  },
+
+  serialize(obj, children) {
+    if (obj.kind == 'string') {
+      return children
+        .split('\n')
+        .reduce((array, text, i) => {
+          if (i != 0) array.push(<br />)
+          array.push(text)
+          return array
+        }, [])
+    }
+  }
+
+}
+
+/**
+ * HTML serializer.
+ *
+ * @type {Html}
+ */
+
+class Html {
+
+  /**
+   * Create a new serializer with `rules`.
+   *
+   * @param {Object} options
+   *   @property {Array} rules
+   *   @property {String} defaultBlockType
+   *   @property {String|Object} defaultBlockType
+   */
+
+  constructor(options = {}) {
+    this.rules = [
+      ...(options.rules || []),
+      TEXT_RULE
+    ]
+
+    this.defaultBlockType = options.defaultBlockType || 'paragraph'
+  }
+
+  /**
+   * Deserialize pasted HTML.
+   *
+   * @param {String} html
+   * @param {Object} options
+   *   @property {Boolean} toRaw
+   * @return {State}
+   */
+
+  deserialize = (html, options = {}) => {
+    const $ = cheerio.load(html).root()
+    const children = $.children().toArray()
+    let nodes = this.deserializeElements(children)
+
+    // HACK: ensure for now that all top-level inline are wrapped into a block.
+    nodes = nodes.reduce((memo, node, i, original) => {
+      if (node.kind == 'block') {
+        memo.push(node)
+        return memo
+      }
+
+      if (i > 0 && original[i - 1].kind != 'block') {
+        const block = memo[memo.length - 1]
+        block.nodes.push(node)
+        return memo
+      }
+
+      const { defaultBlockType } = this
+      const defaults = typeof defaultBlockType == 'string'
+        ? { type: defaultBlockType }
+        : defaultBlockType
+
+      const block = {
+        kind: 'block',
+        nodes: [node],
+        ...defaults
+      }
+
+      memo.push(block)
+      return memo
+    }, [])
+
+    const raw = {
+      kind: 'state',
+      document: {
+        kind: 'document',
+        nodes,
+      }
+    }
+
+    if (options.toRaw) {
+      return raw
+    }
+
+    const state = Raw.deserialize(raw, { terse: true })
+    return state
+  }
+
+  /**
+   * Deserialize an array of Cheerio `elements`.
+   *
+   * @param {Array} elements
+   * @return {Array}
+   */
+
+  deserializeElements = (elements = []) => {
+    let nodes = []
+
+    elements.forEach((element) => {
+      const node = this.deserializeElement(element)
+      switch (typeOf(node)) {
+        case 'array':
+          nodes = nodes.concat(node)
+          break
+        case 'object':
+          nodes.push(node)
+          break
+      }
+    })
+
+    return nodes
+  }
+
+  /**
+   * Deserialize a Cheerio `element`.
+   *
+   * @param {Object} element
+   * @return {Any}
+   */
+
+  deserializeElement = (element) => {
+    let node
+
+    const next = (elements) => {
+      switch (typeOf(elements)) {
+        case 'array':
+          return this.deserializeElements(elements)
+        case 'object':
+          return this.deserializeElement(elements)
+        case 'null':
+        case 'undefined':
+          return
+        default:
+          throw new Error(`The \`next\` argument was called with invalid children: "${elements}".`)
+      }
+    }
+
+    for (const rule of this.rules) {
+      if (!rule.deserialize) continue
+      const ret = rule.deserialize(element, next)
+      const type = typeOf(ret)
+
+      if (type != 'array' && type != 'object' && type != 'null' && type != 'undefined') {
+        throw new Error(`A rule returned an invalid deserialized representation: "${node}".`)
+      }
+
+      if (ret === undefined) continue
+      if (ret === null) return null
+
+      node = ret.kind == 'mark' ? this.deserializeMark(ret) : ret
+      break
+    }
+
+    return node || next(element.children)
+  }
+
+  /**
+   * Deserialize a `mark` object.
+   *
+   * @param {Object} mark
+   * @return {Array}
+   */
+
+  deserializeMark = (mark) => {
+    const { type, data } = mark
+
+    const applyMark = (node) => {
+      if (node.kind == 'mark') {
+        return this.deserializeMark(node)
+      }
+
+      else if (node.kind == 'text') {
+        if (!node.ranges) node.ranges = [{ text: node.text }]
+        node.ranges = node.ranges.map((range) => {
+          range.marks = range.marks || []
+          range.marks.push({ type, data })
+          return range
+        })
+      }
+
+      else {
+        node.nodes = node.nodes.map(applyMark)
+      }
+
+      return node
+    }
+
+    return mark.nodes.reduce((nodes, node) => {
+      const ret = applyMark(node)
+      if (Array.isArray(ret)) return nodes.concat(ret)
+      nodes.push(ret)
+      return nodes
+    }, [])
+  }
+
+  /**
+   * Serialize a `state` object into an HTML string.
+   *
+   * @param {State} state
+   * @param {Object} options
+   *   @property {Boolean} render
+   * @return {String|Array}
+   */
+
+  serialize = (state, options = {}) => {
+    const { document } = state
+    const elements = document.nodes.map(this.serializeNode)
+    if (options.render === false) return elements
+
+    const html = ReactDOMServer.renderToStaticMarkup(<body>{elements}</body>)
+    const inner = html.slice(6, -7)
+    return inner
+  }
+
+  /**
+   * Serialize a `node`.
+   *
+   * @param {Node} node
+   * @return {String}
+   */
+
+  serializeNode = (node) => {
+    if (node.kind == 'text') {
+      const ranges = node.getRanges()
+      return ranges.map(this.serializeRange)
+    }
+
+    const children = node.nodes.map(this.serializeNode)
+
+    for (const rule of this.rules) {
+      if (!rule.serialize) continue
+      const ret = rule.serialize(node, children)
+      if (ret) return addKey(ret)
+    }
+
+    throw new Error(`No serializer defined for node of type "${node.type}".`)
+  }
+
+  /**
+   * Serialize a `range`.
+   *
+   * @param {Range} range
+   * @return {String}
+   */
+
+  serializeRange = (range) => {
+    const string = new String({ text: range.text })
+    const text = this.serializeString(string)
+
+    return range.marks.reduce((children, mark) => {
+      for (const rule of this.rules) {
+        if (!rule.serialize) continue
+        const ret = rule.serialize(mark, children)
+        if (ret) return addKey(ret)
+      }
+
+      throw new Error(`No serializer defined for mark of type "${mark.type}".`)
+    }, text)
+  }
+
+  /**
+   * Serialize a `string`.
+   *
+   * @param {String} string
+   * @return {String}
+   */
+
+  serializeString = (string) => {
+    for (const rule of this.rules) {
+      if (!rule.serialize) continue
+      const ret = rule.serialize(string, string.text)
+      if (ret) return ret
+    }
+  }
+
+}
+
+/**
+ * Add a unique key to a React `element`.
+ *
+ * @param {Element} element
+ * @return {Element}
+ */
+
+let key = 0
+
+function addKey(element) {
+  return React.cloneElement(element, { key: key++ })
+}
+
+/**
+ * Export.
+ *
+ * @type {Html}
+ */
+
+export default Html

--- a/src/lib/slate/serializers/plain.js
+++ b/src/lib/slate/serializers/plain.js
@@ -1,0 +1,63 @@
+
+import Raw from '../serializers/raw'
+
+/**
+ * Deserialize a plain text `string` to a state.
+ *
+ * @param {String} string
+ * @param {Object} options
+ *   @property {Boolean} toRaw
+ * @return {State}
+ */
+
+function deserialize(string, options = {}) {
+  const raw = {
+    kind: 'state',
+    document: {
+      kind: 'document',
+      nodes: string.split('\n').map((line) => {
+        return {
+          kind: 'block',
+          type: 'line',
+          nodes: [
+            {
+              kind: 'text',
+              ranges: [
+                {
+                  text: line,
+                  marks: [],
+                }
+              ]
+            }
+          ]
+        }
+      }),
+    }
+  }
+
+  return options.toRaw ? raw : Raw.deserialize(raw)
+}
+
+/**
+ * Serialize a `state` to plain text.
+ *
+ * @param {State} state
+ * @return {String}
+ */
+
+function serialize(state) {
+  return state.document.nodes
+    .map(block => block.text)
+    .join('\n')
+}
+
+/**
+ * Export.
+ *
+ * @type {Object}
+ */
+
+export default {
+  deserialize,
+  serialize
+}

--- a/src/lib/slate/serializers/raw.js
+++ b/src/lib/slate/serializers/raw.js
@@ -1,0 +1,722 @@
+
+import Block from '../models/block'
+import Character from '../models/character'
+import Document from '../models/document'
+import Inline from '../models/inline'
+import Mark from '../models/mark'
+import Selection from '../models/selection'
+import State from '../models/state'
+import Text from '../models/text'
+import isEmpty from 'is-empty'
+
+/**
+ * Raw.
+ *
+ * @type {Object}
+ */
+
+const Raw = {
+
+  /**
+   * Deserialize a JSON `object`.
+   *
+   * @param {Object} object
+   * @param {Object} options (optional)
+   * @return {Block}
+   */
+
+  deserialize(object, options) {
+    return Raw.deserializeState(object, options)
+  },
+
+  /**
+   * Deserialize a JSON `object` representing a `Block`.
+   *
+   * @param {Object} object
+   * @param {Object} options (optional)
+   * @return {Block}
+   */
+
+  deserializeBlock(object, options = {}) {
+    if (options.terse) object = Raw.untersifyBlock(object)
+
+    return Block.create({
+      key: object.key,
+      type: object.type,
+      data: object.data,
+      isVoid: object.isVoid,
+      nodes: Block.createList(object.nodes.map((node) => {
+        return Raw.deserializeNode(node, options)
+      }))
+    })
+  },
+
+  /**
+   * Deserialize a JSON `object` representing a `Document`.
+   *
+   * @param {Object} object
+   * @param {Object} options (optional)
+   * @return {Document}
+   */
+
+  deserializeDocument(object, options) {
+    return Document.create({
+      key: object.key,
+      data: object.data,
+      nodes: Block.createList(object.nodes.map((node) => {
+        return Raw.deserializeNode(node, options)
+      }))
+    })
+  },
+
+  /**
+   * Deserialize a JSON `object` representing an `Inline`.
+   *
+   * @param {Object} object
+   * @param {Object} options (optional)
+   * @return {Inline}
+   */
+
+  deserializeInline(object, options = {}) {
+    if (options.terse) object = Raw.untersifyInline(object)
+
+    return Inline.create({
+      key: object.key,
+      type: object.type,
+      data: object.data,
+      isVoid: object.isVoid,
+      nodes: Inline.createList(object.nodes.map((node) => {
+        return Raw.deserializeNode(node, options)
+      }))
+    })
+  },
+
+  /**
+   * Deserialize a JSON `object` representing a `Mark`.
+   *
+   * @param {Object} object
+   * @param {Object} options (optional)
+   * @return {Mark}
+   */
+
+  deserializeMark(object, options) {
+    return Mark.create(object)
+  },
+
+  /**
+   * Deserialize a JSON object representing a `Node`.
+   *
+   * @param {Object} object
+   * @param {Object} options (optional)
+   * @return {Node}
+   */
+
+  deserializeNode(object, options) {
+    switch (object.kind) {
+      case 'block': return Raw.deserializeBlock(object, options)
+      case 'document': return Raw.deserializeDocument(object, options)
+      case 'inline': return Raw.deserializeInline(object, options)
+      case 'text': return Raw.deserializeText(object, options)
+      default: {
+        throw new Error(`Unrecognized node kind "${object.kind}".`)
+      }
+    }
+  },
+
+  /**
+   * Deserialize a JSON `object` representing a `Range`.
+   *
+   * @param {Object} object
+   * @param {Object} options (optional)
+   * @return {List<Character>}
+   */
+
+  deserializeRange(object, options = {}) {
+    if (options.terse) object = Raw.untersifyRange(object)
+
+    const marks = Mark.createSet(object.marks.map((mark) => {
+      return Raw.deserializeMark(mark, options)
+    }))
+
+    return Character.createList(object.text
+      .split('')
+      .map((char) => {
+        return Character.create({
+          text: char,
+          marks,
+        })
+      }))
+  },
+
+  /**
+   * Deserialize a JSON `object` representing a `Selection`.
+   *
+   * @param {Object} object
+   * @param {Object} options (optional)
+   * @return {State}
+   */
+
+  deserializeSelection(object, options = {}) {
+    return Selection.create({
+      anchorKey: object.anchorKey,
+      anchorOffset: object.anchorOffset,
+      focusKey: object.focusKey,
+      focusOffset: object.focusOffset,
+      isFocused: object.isFocused,
+    })
+  },
+
+  /**
+   * Deserialize a JSON `object` representing a `State`.
+   *
+   * @param {Object} object
+   * @param {Object} options (optional)
+   * @return {State}
+   */
+
+  deserializeState(object, options = {}) {
+    if (options.terse) object = Raw.untersifyState(object)
+
+    const document = Raw.deserializeDocument(object.document, options)
+    let selection
+
+    if (object.selection != null) {
+      selection = Raw.deserializeSelection(object.selection, options)
+    }
+
+    return State.create({ document, selection }, options)
+  },
+
+  /**
+   * Deserialize a JSON `object` representing a `Text`.
+   *
+   * @param {Object} object
+   * @param {Object} options (optional)
+   * @return {Text}
+   */
+
+  deserializeText(object, options = {}) {
+    if (options.terse) object = Raw.untersifyText(object)
+
+    return Text.create({
+      key: object.key,
+      characters: object.ranges.reduce((characters, range) => {
+        return characters.concat(Raw.deserializeRange(range, options))
+      }, Character.createList())
+    })
+  },
+
+  /**
+   * Serialize a `model`.
+   *
+   * @param {Mixed} model
+   * @param {Object} options (optional)
+   * @return {Object}
+   */
+
+  serialize(model, options) {
+    return Raw.serializeState(model, options)
+  },
+
+  /**
+   * Serialize a `block` node.
+   *
+   * @param {Block} block
+   * @param {Object} options (optional)
+   * @return {Object}
+   */
+
+  serializeBlock(block, options = {}) {
+    const object = {
+      data: block.data.toJSON(),
+      key: block.key,
+      kind: block.kind,
+      isVoid: block.isVoid,
+      type: block.type,
+      nodes: block.nodes
+        .toArray()
+        .map(node => Raw.serializeNode(node, options))
+    }
+
+    if (!options.preserveKeys) {
+      delete object.key
+    }
+
+    return options.terse
+      ? Raw.tersifyBlock(object)
+      : object
+  },
+
+  /**
+   * Serialize a `document`.
+   *
+   * @param {Document} document
+   * @param {Object} options (optional)
+   * @return {Object}
+   */
+
+  serializeDocument(document, options = {}) {
+    const object = {
+      data: document.data.toJSON(),
+      key: document.key,
+      kind: document.kind,
+      nodes: document.nodes
+        .toArray()
+        .map(node => Raw.serializeNode(node, options))
+    }
+
+    if (!options.preserveKeys) {
+      delete object.key
+    }
+
+    return options.terse
+      ? Raw.tersifyDocument(object)
+      : object
+  },
+
+  /**
+   * Serialize an `inline` node.
+   *
+   * @param {Inline} inline
+   * @param {Object} options (optional)
+   * @return {Object}
+   */
+
+  serializeInline(inline, options = {}) {
+    const object = {
+      data: inline.data.toJSON(),
+      key: inline.key,
+      kind: inline.kind,
+      isVoid: inline.isVoid,
+      type: inline.type,
+      nodes: inline.nodes
+        .toArray()
+        .map(node => Raw.serializeNode(node, options))
+    }
+
+    if (!options.preserveKeys) {
+      delete object.key
+    }
+
+    return options.terse
+      ? Raw.tersifyInline(object)
+      : object
+  },
+
+  /**
+   * Serialize a `mark`.
+   *
+   * @param {Mark} mark
+   * @param {Object} options (optional)
+   * @return {Object}
+   */
+
+  serializeMark(mark, options = {}) {
+    const object = {
+      data: mark.data.toJSON(),
+      kind: mark.kind,
+      type: mark.type
+    }
+
+    return options.terse
+      ? Raw.tersifyMark(object)
+      : object
+  },
+
+  /**
+   * Serialize a `node`.
+   *
+   * @param {Node} node
+   * @param {Object} options (optional)
+   * @return {Object}
+   */
+
+  serializeNode(node, options) {
+    switch (node.kind) {
+      case 'block': return Raw.serializeBlock(node, options)
+      case 'document': return Raw.serializeDocument(node, options)
+      case 'inline': return Raw.serializeInline(node, options)
+      case 'text': return Raw.serializeText(node, options)
+      default: {
+        throw new Error(`Unrecognized node kind "${node.kind}".`)
+      }
+    }
+  },
+
+  /**
+   * Serialize a `range`.
+   *
+   * @param {Range} range
+   * @param {Object} options (optional)
+   * @return {Object}
+   */
+
+  serializeRange(range, options = {}) {
+    const object = {
+      kind: range.kind,
+      text: range.text,
+      marks: range.marks
+        .toArray()
+        .map(mark => Raw.serializeMark(mark, options))
+    }
+
+    return options.terse
+      ? Raw.tersifyRange(object)
+      : object
+  },
+
+  /**
+   * Serialize a `selection`.
+   *
+   * @param {Selection} selection
+   * @param {Object} options (optional)
+   * @return {Object}
+   */
+
+  serializeSelection(selection, options = {}) {
+    const object = {
+      kind: selection.kind,
+      anchorKey: selection.anchorKey,
+      anchorOffset: selection.anchorOffset,
+      focusKey: selection.focusKey,
+      focusOffset: selection.focusOffset,
+      isBackward: selection.isBackward,
+      isFocused: selection.isFocused,
+    }
+
+    return options.terse
+      ? Raw.tersifySelection(object)
+      : object
+  },
+
+  /**
+   * Serialize a `state`.
+   *
+   * @param {State} state
+   * @param {Object} options (optional)
+   * @return {Object}
+   */
+
+  serializeState(state, options = {}) {
+    const object = {
+      document: Raw.serializeDocument(state.document, options),
+      selection: Raw.serializeSelection(state.selection, options),
+      kind: state.kind
+    }
+
+    if (!options.preserveSelection) {
+      delete object.selection
+    }
+
+    const ret = options.terse
+      ? Raw.tersifyState(object)
+      : object
+
+    return ret
+  },
+
+  /**
+   * Serialize a `text` node.
+   *
+   * @param {Text} text
+   * @param {Object} options (optional)
+   * @return {Object}
+   */
+
+  serializeText(text, options = {}) {
+    const object = {
+      key: text.key,
+      kind: text.kind,
+      ranges: text
+        .getRanges()
+        .toArray()
+        .map(range => Raw.serializeRange(range, options))
+    }
+
+    if (!options.preserveKeys) {
+      delete object.key
+    }
+
+    return options.terse
+      ? Raw.tersifyText(object)
+      : object
+  },
+
+  /**
+   * Create a terse representation of a block `object`.
+   *
+   * @param {Object} object
+   * @return {Object}
+   */
+
+  tersifyBlock(object) {
+    const ret = {}
+    ret.kind = object.kind
+    ret.type = object.type
+    if (object.key) ret.key = object.key
+    if (!object.isVoid) ret.nodes = object.nodes
+    if (object.isVoid) ret.isVoid = object.isVoid
+    if (!isEmpty(object.data)) ret.data = object.data
+    return ret
+  },
+
+  /**
+   * Create a terse representation of a document `object.
+   *
+   * @param {Object} object
+   * @return {Object}
+   */
+
+  tersifyDocument(object) {
+    const ret = {}
+    ret.nodes = object.nodes
+    if (object.key) ret.key = object.key
+    if (!isEmpty(object.data)) ret.data = object.data
+    return ret
+  },
+
+  /**
+   * Create a terse representation of a inline `object`.
+   *
+   * @param {Object} object
+   * @return {Object}
+   */
+
+  tersifyInline(object) {
+    const ret = {}
+    ret.kind = object.kind
+    ret.type = object.type
+    if (object.key) ret.key = object.key
+    if (!object.isVoid) ret.nodes = object.nodes
+    if (object.isVoid) ret.isVoid = object.isVoid
+    if (!isEmpty(object.data)) ret.data = object.data
+    return ret
+  },
+
+  /**
+   * Create a terse representation of a mark `object`.
+   *
+   * @param {Object} object
+   * @return {Object}
+   */
+
+  tersifyMark(object) {
+    const ret = {}
+    ret.type = object.type
+    if (!isEmpty(object.data)) ret.data = object.data
+    return ret
+  },
+
+  /**
+   * Create a terse representation of a range `object`.
+   *
+   * @param {Object} object
+   * @return {Object}
+   */
+
+  tersifyRange(object) {
+    const ret = {}
+    ret.text = object.text
+    if (!isEmpty(object.marks)) ret.marks = object.marks
+    return ret
+  },
+
+  /**
+   * Create a terse representation of a selection `object.`
+   *
+   * @param {Object} object
+   * @return {Object}
+   */
+
+  tersifySelection(object) {
+    return {
+      anchorKey: object.anchorKey,
+      anchorOffset: object.anchorOffset,
+      focusKey: object.focusKey,
+      focusOffset: object.focusOffset,
+      isFocused: object.isFocused,
+    }
+  },
+
+  /**
+   * Create a terse representation of a state `object`.
+   *
+   * @param {Object} object
+   * @return {Object}
+   */
+
+  tersifyState(object) {
+    if (object.selection == null) {
+      return object.document
+    }
+
+    return {
+      document: object.document,
+      selection: object.selection
+    }
+  },
+
+  /**
+   * Create a terse representation of a text `object`.
+   *
+   * @param {Object} object
+   * @return {Object}
+   */
+
+  tersifyText(object) {
+    const ret = {}
+    ret.kind = object.kind
+    if (object.key) ret.key = object.key
+
+    if (object.ranges.length == 1 && object.ranges[0].marks == null) {
+      ret.text = object.ranges[0].text
+    } else {
+      ret.ranges = object.ranges
+    }
+
+    return ret
+  },
+
+  /**
+   * Convert a terse representation of a block `object` into a non-terse one.
+   *
+   * @param {Object} object
+   * @return {Object}
+   */
+
+  untersifyBlock(object) {
+    if (object.isVoid || !object.nodes || !object.nodes.length) {
+      return {
+        key: object.key,
+        data: object.data,
+        kind: object.kind,
+        type: object.type,
+        isVoid: object.isVoid,
+        nodes: [
+          {
+            kind: 'text',
+            text: ''
+          }
+        ]
+      }
+    }
+
+    return object
+  },
+
+  /**
+   * Convert a terse representation of a inline `object` into a non-terse one.
+   *
+   * @param {Object} object
+   * @return {Object}
+   */
+
+  untersifyInline(object) {
+    if (object.isVoid || !object.nodes || !object.nodes.length) {
+      return {
+        key: object.key,
+        data: object.data,
+        kind: object.kind,
+        type: object.type,
+        isVoid: object.isVoid,
+        nodes: [
+          {
+            kind: 'text',
+            text: ''
+          }
+        ]
+      }
+    }
+
+    return object
+  },
+
+  /**
+   * Convert a terse representation of a range `object` into a non-terse one.
+   *
+   * @param {Object} object
+   * @return {Object}
+   */
+
+  untersifyRange(object) {
+    return {
+      kind: 'range',
+      text: object.text,
+      marks: object.marks || []
+    }
+  },
+
+  /**
+   * Convert a terse representation of a selection `object` into a non-terse one.
+   *
+   * @param {Object} object
+   * @return {Object}
+   */
+
+  untersifySelection(object) {
+    return {
+      kind: 'selection',
+      anchorKey: object.anchorKey,
+      anchorOffset: object.anchorOffset,
+      focusKey: object.focusKey,
+      focusOffset: object.focusOffset,
+      isBackward: null,
+      isFocused: false
+    }
+  },
+
+  /**
+   * Convert a terse representation of a state `object` into a non-terse one.
+   *
+   * @param {Object} object
+   * @return {Object}
+   */
+
+  untersifyState(object) {
+    if (object.selection || object.document) {
+      return {
+        kind: 'state',
+        document: object.document,
+        selection: object.selection,
+      }
+    }
+
+    return {
+      kind: 'state',
+      document: {
+        data: object.data,
+        key: object.key,
+        kind: 'document',
+        nodes: object.nodes
+      }
+    }
+  },
+
+  /**
+   * Convert a terse representation of a text `object` into a non-terse one.
+   *
+   * @param {Object} object
+   * @return {Object}
+   */
+
+  untersifyText(object) {
+    if (object.ranges) return object
+
+    return {
+      key: object.key,
+      kind: object.kind,
+      ranges: [{
+        text: object.text,
+        marks: object.marks || []
+      }]
+    }
+  }
+}
+
+/**
+ * Export.
+ *
+ * @type {Object}
+ */
+
+export default Raw

--- a/src/lib/slate/transforms/Readme.md
+++ b/src/lib/slate/transforms/Readme.md
@@ -1,0 +1,2 @@
+
+This directory contains all of the transforms that ship with Slate by default. For example, transforms like `insertText` or `addMarkAtRange`.

--- a/src/lib/slate/transforms/apply-operation.js
+++ b/src/lib/slate/transforms/apply-operation.js
@@ -1,0 +1,482 @@
+
+import Debug from 'debug'
+import warn from '../utils/warn'
+
+/**
+ * Debug.
+ *
+ * @type {Function}
+ */
+
+const debug = Debug('slate:operation')
+
+/**
+ * Transforms.
+ *
+ * @type {Object}
+ */
+
+const Transforms = {}
+
+/**
+ * Operations.
+ *
+ * @type {Object}
+ */
+
+const OPERATIONS = {
+  // Text operations.
+  insert_text: insertText,
+  remove_text: removeText,
+  // Mark operations.
+  add_mark: addMark,
+  remove_mark: removeMark,
+  set_mark: setMark,
+  // Node operations.
+  insert_node: insertNode,
+  join_node: joinNode,
+  move_node: moveNode,
+  remove_node: removeNode,
+  set_node: setNode,
+  split_node: splitNode,
+  // Selection operations.
+  set_selection: setSelection
+}
+
+/**
+ * Apply an `operation` to the current state.
+ *
+ * @param {Transform} transform
+ * @param {Object} operation
+ */
+
+Transforms.applyOperation = (transform, operation) => {
+  const { state, operations } = transform
+  const { type } = operation
+  const fn = OPERATIONS[type]
+
+  if (!fn) {
+    throw new Error(`Unknown operation type: "${type}".`)
+  }
+
+  debug(type, operation)
+  transform.state = fn(state, operation)
+  transform.operations = operations.concat([operation])
+}
+
+/**
+ * Add mark to text at `offset` and `length` in node by `path`.
+ *
+ * @param {State} state
+ * @param {Object} operation
+ * @return {State}
+ */
+
+function addMark(state, operation) {
+  const { path, offset, length, mark } = operation
+  let { document } = state
+  let node = document.assertPath(path)
+  node = node.addMark(offset, length, mark)
+  document = document.updateDescendant(node)
+  state = state.set('document', document)
+  return state
+}
+
+/**
+ * Insert a `node` at `index` in a node by `path`.
+ *
+ * @param {State} state
+ * @param {Object} operation
+ * @return {State}
+ */
+
+function insertNode(state, operation) {
+  const { path, index, node } = operation
+  let { document } = state
+  let parent = document.assertPath(path)
+  const isParent = document == parent
+  parent = parent.insertNode(index, node)
+  document = isParent ? parent : document.updateDescendant(parent)
+  state = state.set('document', document)
+  return state
+}
+
+/**
+ * Insert `text` at `offset` in node by `path`.
+ *
+ * @param {State} state
+ * @param {Object} operation
+ * @return {State}
+ */
+
+function insertText(state, operation) {
+  const { path, offset, text, marks } = operation
+  let { document, selection } = state
+  const { anchorKey, focusKey, anchorOffset, focusOffset } = selection
+  let node = document.assertPath(path)
+
+  // Update the document
+  node = node.insertText(offset, text, marks)
+  document = document.updateDescendant(node)
+
+  // Update the selection
+  if (anchorKey == node.key && anchorOffset >= offset) {
+    selection = selection.moveAnchor(text.length)
+  }
+  if (focusKey == node.key && focusOffset >= offset) {
+    selection = selection.moveFocus(text.length)
+  }
+
+  state = state.set('document', document).set('selection', selection)
+  return state
+}
+
+/**
+ * Join a node by `path` with a node `withPath`.
+ *
+ * @param {State} state
+ * @param {Object} operation
+ *   @param {Boolean} operation.deep (optional) Join recursively the
+ *   respective last node and first node of the nodes' children. Like a zipper :)
+ * @return {State}
+ */
+
+function joinNode(state, operation) {
+  const { path, withPath, deep = false } = operation
+  let { document, selection } = state
+  const first = document.assertPath(withPath)
+  const second = document.assertPath(path)
+
+  document = document.joinNode(first, second, { deep })
+
+  // If the operation is deep, or the nodes are text nodes, it means we will be
+  // merging two text nodes together, so we need to update the selection.
+  if (deep || second.kind == 'text') {
+    const { anchorKey, anchorOffset, focusKey, focusOffset } = selection
+    const firstText = first.kind == 'text' ? first : first.getLastText()
+    const secondText = second.kind == 'text' ? second : second.getFirstText()
+
+    if (anchorKey == secondText.key) {
+      selection = selection.merge({
+        anchorKey: firstText.key,
+        anchorOffset: anchorOffset + firstText.characters.size
+      })
+    }
+
+    if (focusKey == secondText.key) {
+      selection = selection.merge({
+        focusKey: firstText.key,
+        focusOffset: focusOffset + firstText.characters.size
+      })
+    }
+  }
+
+  state = state.set('document', document).set('selection', selection)
+  return state
+}
+
+/**
+ * Move a node by `path` to a new parent by `path` and `index`.
+ *
+ * @param {State} state
+ * @param {Object} operation
+ * @return {State}
+ */
+
+function moveNode(state, operation) {
+  const { path, newPath, newIndex } = operation
+  let { document } = state
+  const node = document.assertPath(path)
+  const index = path.pop()
+  const parentDepth = path.length
+
+  // Remove the node from its current parent
+  let parent = document.getParent(node.key)
+  parent = parent.removeNode(index)
+  document = parent.kind === 'document' ? parent : document.updateDescendant(parent)
+
+  // Check if `parent` is an anchestor of `target`
+  const isAncestor = path.every((x, i) => x === newPath[i])
+
+  let target
+
+  // If `parent` ia an ancestor of `target` and they have the same depth,
+  // then `parent` and `target` are the same node.
+  if (isAncestor && parentDepth === newPath.length) {
+    target = parent
+  }
+
+  // Else if `parent` is an ancestor of `target` and `node` index is less than
+  // the index of the `target` ancestor with the same depth of `node`,
+  // then removing `node` changes the path to `target`.
+  // So we have to adjust `newPath` before picking `target`.
+  else if (isAncestor && index < newPath[parentDepth]) {
+    newPath[parentDepth]--
+    target = document.assertPath(newPath)
+  }
+
+  // Else pick `target`
+  else {
+    target = document.assertPath(newPath)
+  }
+
+  // Insert the new node to its new parent
+  target = target.insertNode(newIndex, node)
+  document = target.kind === 'document' ? target : document.updateDescendant(target)
+
+  state = state.set('document', document)
+  return state
+}
+
+/**
+ * Remove mark from text at `offset` and `length` in node by `path`.
+ *
+ * @param {State} state
+ * @param {Object} operation
+ * @return {State}
+ */
+
+function removeMark(state, operation) {
+  const { path, offset, length, mark } = operation
+  let { document } = state
+  let node = document.assertPath(path)
+  node = node.removeMark(offset, length, mark)
+  document = document.updateDescendant(node)
+  state = state.set('document', document)
+  return state
+}
+
+/**
+ * Remove a node by `path`.
+ *
+ * @param {State} state
+ * @param {Object} operation
+ * @return {State}
+ */
+
+function removeNode(state, operation) {
+  const { path } = operation
+  let { document, selection } = state
+  const { startKey, endKey } = selection
+  const node = document.assertPath(path)
+
+  // If the selection is set, check to see if it needs to be updated.
+  if (selection.isSet) {
+    const hasStartNode = node.hasNode(startKey)
+    const hasEndNode = node.hasNode(endKey)
+
+    // If one of the selection's nodes is being removed, we need to update it.
+    if (hasStartNode) {
+      const prev = document.getPreviousText(startKey)
+      const next = document.getNextText(startKey)
+
+      if (prev) {
+        selection = selection.moveStartTo(prev.key, prev.length)
+      } else if (next) {
+        selection = selection.moveStartTo(next.key, 0)
+      } else {
+        selection = selection.deselect()
+      }
+    }
+
+    if (hasEndNode) {
+      const prev = document.getPreviousText(endKey)
+      const next = document.getNextText(endKey)
+
+      if (prev) {
+        selection = selection.moveEndTo(prev.key, prev.length)
+      } else if (next) {
+        selection = selection.moveEndTo(next.key, 0)
+      } else {
+        selection = selection.deselect()
+      }
+    }
+  }
+
+  // Remove the node from the document.
+  let parent = document.getParent(node.key)
+  const index = parent.nodes.indexOf(node)
+  const isParent = document == parent
+  parent = parent.removeNode(index)
+  document = isParent ? parent : document.updateDescendant(parent)
+
+  // Update the document and selection.
+  state = state.set('document', document).set('selection', selection)
+  return state
+}
+
+/**
+ * Remove text at `offset` and `length` in node by `path`.
+ *
+ * @param {State} state
+ * @param {Object} operation
+ * @return {State}
+ */
+
+function removeText(state, operation) {
+  const { path, offset, length } = operation
+  const rangeOffset = offset + length
+  let { document, selection } = state
+  const { anchorKey, focusKey, anchorOffset, focusOffset } = selection
+  let node = document.assertPath(path)
+
+  // Update the selection
+  if (anchorKey == node.key && anchorOffset >= rangeOffset) {
+    selection = selection.moveAnchor(-length)
+  }
+  if (focusKey == node.key && focusOffset >= rangeOffset) {
+    selection = selection.moveFocus(-length)
+  }
+
+  node = node.removeText(offset, length)
+  document = document.updateDescendant(node)
+  state = state.set('document', document).set('selection', selection)
+  return state
+}
+
+/**
+ * Set `properties` on mark on text at `offset` and `length` in node by `path`.
+ *
+ * @param {State} state
+ * @param {Object} operation
+ * @return {State}
+ */
+
+function setMark(state, operation) {
+  const { path, offset, length, mark, newMark } = operation
+  let { document } = state
+  let node = document.assertPath(path)
+  node = node.updateMark(offset, length, mark, newMark)
+  document = document.updateDescendant(node)
+  state = state.set('document', document)
+  return state
+}
+
+/**
+ * Set `properties` on a node by `path`.
+ *
+ * @param {State} state
+ * @param {Object} operation
+ * @return {State}
+ */
+
+function setNode(state, operation) {
+  const { path, properties } = operation
+  let { document } = state
+  let node = document.assertPath(path)
+
+  // Deprecate the ability to overwite a node's children.
+  if (properties.nodes && properties.nodes != node.nodes) {
+    warn('Updating a Node\'s `nodes` property via `setNode()` is not allowed. Use the appropriate insertion and removal operations instead. The opeartion in question was:', operation)
+    delete properties.nodes
+  }
+
+  // Deprecate the ability to change a node's key.
+  if (properties.key && properties.key != node.key) {
+    warn('Updating a Node\'s `key` property via `setNode()` is not allowed. There should be no reason to do this. The opeartion in question was:', operation)
+    delete properties.key
+  }
+
+  node = node.merge(properties)
+  document = node.kind === 'document' ? node : document.updateDescendant(node)
+  state = state.set('document', document)
+  return state
+}
+
+/**
+ * Set `properties` on the selection.
+ *
+ * @param {State} state
+ * @param {Object} operation
+ * @return {State}
+ */
+
+function setSelection(state, operation) {
+  const properties = { ...operation.properties }
+  let { document, selection } = state
+
+  if (properties.anchorPath !== undefined) {
+    properties.anchorKey = properties.anchorPath === null
+      ? null
+      : document.assertPath(properties.anchorPath).key
+    delete properties.anchorPath
+  }
+
+  if (properties.focusPath !== undefined) {
+    properties.focusKey = properties.focusPath === null
+      ? null
+      : document.assertPath(properties.focusPath).key
+    delete properties.focusPath
+  }
+
+  selection = selection.merge(properties)
+  selection = selection.normalize(document)
+  state = state.set('selection', selection)
+  return state
+}
+
+/**
+ * Split a node by `path` at `offset`.
+ *
+ * @param {State} state
+ * @param {Object} operation
+ *   @param {Array} operation.path The path of the node to split
+ *   @param {Number} operation.offset (optional) Split using a relative offset
+ *   @param {Number} operation.count (optional) Split after `count`
+ *   children. Cannot be used in combination with offset.
+ * @return {State}
+ */
+
+function splitNode(state, operation) {
+  const { path, offset, count } = operation
+  let { document, selection } = state
+
+  // If there's no offset, it's using the `count` instead.
+  if (offset == null) {
+    document = document.splitNodeAfter(path, count)
+    state = state.set('document', document)
+    return state
+  }
+
+  // Otherwise, split using the `offset`, but calculate a few things first.
+  const node = document.assertPath(path)
+  const text = node.kind == 'text' ? node : node.getTextAtOffset(offset)
+  const textOffset = node.kind == 'text' ? offset : offset - node.getOffset(text.key)
+  const { anchorKey, anchorOffset, focusKey, focusOffset } = selection
+
+  document = document.splitNode(path, offset)
+
+  // Determine whether we need to update the selection.
+  const splitAnchor = text.key == anchorKey && textOffset <= anchorOffset
+  const splitFocus = text.key == focusKey && textOffset <= focusOffset
+
+  // If either the anchor of focus was after the split, we need to update them.
+  if (splitFocus || splitAnchor) {
+    const nextText = document.getNextText(text.key)
+
+    if (splitAnchor) {
+      selection = selection.merge({
+        anchorKey: nextText.key,
+        anchorOffset: anchorOffset - textOffset
+      })
+    }
+
+    if (splitFocus) {
+      selection = selection.merge({
+        focusKey: nextText.key,
+        focusOffset: focusOffset - textOffset
+      })
+    }
+  }
+
+  state = state.set('document', document).set('selection', selection)
+  return state
+}
+
+/**
+ * Export.
+ *
+ * @type {Object}
+ */
+
+export default Transforms

--- a/src/lib/slate/transforms/at-current-range.js
+++ b/src/lib/slate/transforms/at-current-range.js
@@ -1,0 +1,499 @@
+
+import Normalize from '../utils/normalize'
+
+/**
+ * Transforms.
+ *
+ * @type {Object}
+ */
+
+const Transforms = {}
+
+/**
+ * Add a `mark` to the characters in the current selection.
+ *
+ * @param {Transform} transform
+ * @param {Mark} mark
+ */
+
+Transforms.addMark = (transform, mark) => {
+  mark = Normalize.mark(mark)
+  const { state } = transform
+  const { document, selection } = state
+
+  if (selection.isExpanded) {
+    transform.addMarkAtRange(selection, mark)
+    return
+  }
+
+  if (selection.marks) {
+    const marks = selection.marks.add(mark)
+    const sel = selection.set('marks', marks)
+    transform.select(sel)
+    return
+  }
+
+  const marks = document.getMarksAtRange(selection).add(mark)
+  const sel = selection.set('marks', marks)
+  transform.select(sel)
+}
+
+/**
+ * Delete at the current selection.
+ *
+ * @param {Transform} transform
+ */
+
+Transforms.delete = (transform) => {
+  const { state } = transform
+  const { selection } = state
+  if (selection.isCollapsed) return
+
+  transform
+    .snapshotSelection()
+    .deleteAtRange(selection)
+    // Ensure that the selection is collapsed to the start, because in certain
+    // cases when deleting across inline nodes this isn't guaranteed.
+    .collapseToStart()
+    .snapshotSelection()
+}
+
+/**
+ * Delete backward `n` characters at the current selection.
+ *
+ * @param {Transform} transform
+ * @param {Number} n (optional)
+ */
+
+Transforms.deleteBackward = (transform, n = 1) => {
+  const { state } = transform
+  const { selection } = state
+  transform.deleteBackwardAtRange(selection, n)
+}
+
+/**
+ * Delete backward until the character boundary at the current selection.
+ *
+ * @param {Transform} transform
+ */
+
+Transforms.deleteCharBackward = (transform) => {
+  const { state } = transform
+  const { selection } = state
+  transform.deleteCharBackwardAtRange(selection)
+}
+
+/**
+ * Delete backward until the line boundary at the current selection.
+ *
+ * @param {Transform} transform
+ */
+
+Transforms.deleteLineBackward = (transform) => {
+  const { state } = transform
+  const { selection } = state
+  transform.deleteLineBackwardAtRange(selection)
+}
+
+/**
+ * Delete backward until the word boundary at the current selection.
+ *
+ * @param {Transform} transform
+ */
+
+Transforms.deleteWordBackward = (transform) => {
+  const { state } = transform
+  const { selection } = state
+  transform.deleteWordBackwardAtRange(selection)
+}
+
+/**
+ * Delete forward `n` characters at the current selection.
+ *
+ * @param {Transform} transform
+ * @param {Number} n (optional)
+ */
+
+Transforms.deleteForward = (transform, n = 1) => {
+  const { state } = transform
+  const { selection } = state
+  transform.deleteForwardAtRange(selection, n)
+}
+
+/**
+ * Delete forward until the character boundary at the current selection.
+ *
+ * @param {Transform} transform
+ */
+
+Transforms.deleteCharForward = (transform) => {
+  const { state } = transform
+  const { selection } = state
+  transform.deleteCharForwardAtRange(selection)
+}
+
+/**
+ * Delete forward until the line boundary at the current selection.
+ *
+ * @param {Transform} transform
+ */
+
+Transforms.deleteLineForward = (transform) => {
+  const { state } = transform
+  const { selection } = state
+  transform.deleteLineForwardAtRange(selection)
+}
+
+/**
+ * Delete forward until the word boundary at the current selection.
+ *
+ * @param {Transform} transform
+ */
+
+Transforms.deleteWordForward = (transform) => {
+  const { state } = transform
+  const { selection } = state
+  transform.deleteWordForwardAtRange(selection)
+}
+
+/**
+ * Insert a `block` at the current selection.
+ *
+ * @param {Transform} transform
+ * @param {String|Object|Block} block
+ */
+
+Transforms.insertBlock = (transform, block) => {
+  block = Normalize.block(block)
+  const { state } = transform
+  const { selection } = state
+  transform.insertBlockAtRange(selection, block)
+
+  // If the node was successfully inserted, update the selection.
+  const node = transform.state.document.getNode(block.key)
+  if (node) transform.collapseToEndOf(node)
+}
+
+/**
+ * Insert a `fragment` at the current selection.
+ *
+ * @param {Transform} transform
+ * @param {Document} fragment
+ */
+
+Transforms.insertFragment = (transform, fragment) => {
+  let { state } = transform
+  let { document, selection } = state
+
+  if (!fragment.nodes.size) return
+
+  const { startText, endText } = state
+  const lastText = fragment.getLastText()
+  const lastInline = fragment.getClosestInline(lastText.key)
+  const keys = document.getTexts().map(text => text.key)
+  const isAppending = (
+    selection.hasEdgeAtEndOf(endText) ||
+    selection.hasEdgeAtStartOf(startText)
+  )
+
+  transform.deselect()
+  transform.insertFragmentAtRange(selection, fragment)
+  state = transform.state
+  document = state.document
+
+  const newTexts = document.getTexts().filter(n => !keys.includes(n.key))
+  const newText = isAppending ? newTexts.last() : newTexts.takeLast(2).first()
+  let after
+
+  if (newText && lastInline) {
+    after = selection.collapseToEndOf(newText)
+  }
+
+  else if (newText) {
+    after = selection
+      .collapseToStartOf(newText)
+      .move(lastText.length)
+  }
+
+  else {
+    after = selection
+      .collapseToStart()
+      .move(lastText.length)
+  }
+
+  transform.select(after)
+}
+
+/**
+ * Insert a `inline` at the current selection.
+ *
+ * @param {Transform} transform
+ * @param {String|Object|Block} inline
+ */
+
+Transforms.insertInline = (transform, inline) => {
+  inline = Normalize.inline(inline)
+  const { state } = transform
+  const { selection } = state
+  transform.insertInlineAtRange(selection, inline)
+
+  // If the node was successfully inserted, update the selection.
+  const node = transform.state.document.getNode(inline.key)
+  if (node) transform.collapseToEndOf(node)
+}
+
+/**
+ * Insert a `text` string at the current selection.
+ *
+ * @param {Transform} transform
+ * @param {String} text
+ * @param {Set<Mark>} marks (optional)
+ */
+
+Transforms.insertText = (transform, text, marks) => {
+  const { state } = transform
+  const { document, selection } = state
+  marks = marks || selection.marks
+  transform.insertTextAtRange(selection, text, marks)
+
+  // If the text was successfully inserted, and the selection had marks on it,
+  // unset the selection's marks.
+  if (selection.marks && document != transform.state.document) {
+    transform.select({ marks: null })
+  }
+}
+
+/**
+ * Set `properties` of the block nodes in the current selection.
+ *
+ * @param {Transform} transform
+ * @param {Object} properties
+ */
+
+Transforms.setBlock = (transform, properties) => {
+  const { state } = transform
+  const { selection } = state
+  transform.setBlockAtRange(selection, properties)
+}
+
+/**
+ * Set `properties` of the inline nodes in the current selection.
+ *
+ * @param {Transform} transform
+ * @param {Object} properties
+ */
+
+Transforms.setInline = (transform, properties) => {
+  const { state } = transform
+  const { selection } = state
+  transform.setInlineAtRange(selection, properties)
+}
+
+/**
+ * Split the block node at the current selection, to optional `depth`.
+ *
+ * @param {Transform} transform
+ * @param {Number} depth (optional)
+ */
+
+Transforms.splitBlock = (transform, depth = 1) => {
+  const { state } = transform
+  const { selection } = state
+  transform
+    .snapshotSelection()
+    .splitBlockAtRange(selection, depth)
+    .collapseToEnd()
+    .snapshotSelection()
+}
+
+/**
+ * Split the inline nodes at the current selection, to optional `depth`.
+ *
+ * @param {Transform} transform
+ * @param {Number} depth (optional)
+ */
+
+Transforms.splitInline = (transform, depth = Infinity) => {
+  const { state } = transform
+  const { selection } = state
+  transform
+    .snapshotSelection()
+    .splitInlineAtRange(selection, depth)
+    .snapshotSelection()
+}
+
+/**
+ * Remove a `mark` from the characters in the current selection.
+ *
+ * @param {Transform} transform
+ * @param {Mark} mark
+ */
+
+Transforms.removeMark = (transform, mark) => {
+  mark = Normalize.mark(mark)
+  const { state } = transform
+  const { document, selection } = state
+
+  if (selection.isExpanded) {
+    transform.removeMarkAtRange(selection, mark)
+    return
+  }
+
+  if (selection.marks) {
+    const marks = selection.marks.remove(mark)
+    const sel = selection.set('marks', marks)
+    transform.select(sel)
+    return
+  }
+
+  const marks = document.getMarksAtRange(selection).remove(mark)
+  const sel = selection.set('marks', marks)
+  transform.select(sel)
+}
+
+/**
+ * Add or remove a `mark` from the characters in the current selection,
+ * depending on whether it's already there.
+ *
+ * @param {Transform} transform
+ * @param {Mark} mark
+ */
+
+Transforms.toggleMark = (transform, mark) => {
+  mark = Normalize.mark(mark)
+  const { state } = transform
+  const exists = state.marks.some(m => m.equals(mark))
+
+  if (exists) {
+    transform.removeMark(mark)
+  } else {
+    transform.addMark(mark)
+  }
+}
+
+/**
+ * Unwrap the current selection from a block parent with `properties`.
+ *
+ * @param {Transform} transform
+ * @param {Object|String} properties
+ */
+
+Transforms.unwrapBlock = (transform, properties) => {
+  const { state } = transform
+  const { selection } = state
+  transform.unwrapBlockAtRange(selection, properties)
+}
+
+/**
+ * Unwrap the current selection from an inline parent with `properties`.
+ *
+ * @param {Transform} transform
+ * @param {Object|String} properties
+ */
+
+Transforms.unwrapInline = (transform, properties) => {
+  const { state } = transform
+  const { selection } = state
+  transform.unwrapInlineAtRange(selection, properties)
+}
+
+/**
+ * Wrap the block nodes in the current selection with a new block node with
+ * `properties`.
+ *
+ * @param {Transform} transform
+ * @param {Object|String} properties
+ */
+
+Transforms.wrapBlock = (transform, properties) => {
+  const { state } = transform
+  const { selection } = state
+  transform.wrapBlockAtRange(selection, properties)
+}
+
+/**
+ * Wrap the current selection in new inline nodes with `properties`.
+ *
+ * @param {Transform} transform
+ * @param {Object|String} properties
+ */
+
+Transforms.wrapInline = (transform, properties) => {
+  let { state } = transform
+  let { document, selection } = state
+  let after
+
+  const { startKey } = selection
+  const previous = document.getPreviousText(startKey)
+
+  transform.deselect()
+  transform.wrapInlineAtRange(selection, properties)
+  state = transform.state
+  document = state.document
+
+  // Determine what the selection should be after wrapping.
+  if (selection.isCollapsed) {
+    after = selection
+  }
+
+  else if (selection.startOffset == 0) {
+    const text = previous ? document.getNextText(previous.key) : document.getFirstText()
+    after = selection.moveToRangeOf(text)
+  }
+
+  else if (selection.startKey == selection.endKey) {
+    const text = document.getNextText(selection.startKey)
+    after = selection.moveToRangeOf(text)
+  }
+
+  else {
+    const anchor = document.getNextText(selection.anchorKey)
+    const focus = document.getDescendant(selection.focusKey)
+    after = selection.merge({
+      anchorKey: anchor.key,
+      anchorOffset: 0,
+      focusKey: focus.key,
+      focusOffset: selection.focusOffset
+    })
+  }
+
+  after = after.normalize(document)
+  transform.select(after)
+}
+
+/**
+ * Wrap the current selection with prefix/suffix.
+ *
+ * @param {Transform} transform
+ * @param {String} prefix
+ * @param {String} suffix
+ */
+
+Transforms.wrapText = (transform, prefix, suffix = prefix) => {
+  const { state } = transform
+  const { selection } = state
+  transform.wrapTextAtRange(selection, prefix, suffix)
+
+  // If the selection was collapsed, it will have moved the start offset too.
+  if (selection.isCollapsed) {
+    transform.moveStart(0 - prefix.length)
+  }
+
+  // Adding the suffix will have pushed the end of the selection further on, so
+  // we need to move it back to account for this.
+  transform.moveEnd(0 - suffix.length)
+
+  // There's a chance that the selection points moved "through" each other,
+  // resulting in a now-incorrect selection direction.
+  if (selection.isForward != transform.state.selection.isForward) {
+    transform.flip()
+  }
+}
+
+/**
+ * Export.
+ *
+ * @type {Object}
+ */
+
+export default Transforms

--- a/src/lib/slate/transforms/at-range.js
+++ b/src/lib/slate/transforms/at-range.js
@@ -1,0 +1,1287 @@
+/* eslint no-console: 0 */
+
+import Normalize from '../utils/normalize'
+import String from '../utils/string'
+import SCHEMA from '../schemas/core'
+import { List } from 'immutable'
+
+/**
+ * Transforms.
+ *
+ * @type {Object}
+ */
+
+const Transforms = {}
+
+/**
+ * An options object with normalize set to `false`.
+ *
+ * @type {Object}
+ */
+
+const OPTS = {
+  normalize: false
+}
+
+/**
+ * Add a new `mark` to the characters at `range`.
+ *
+ * @param {Transform} transform
+ * @param {Selection} range
+ * @param {Mixed} mark
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+Transforms.addMarkAtRange = (transform, range, mark, options = {}) => {
+  if (range.isCollapsed) return
+
+  const { normalize = true } = options
+  const { state } = transform
+  const { document } = state
+  const { startKey, startOffset, endKey, endOffset } = range
+  const texts = document.getTextsAtRange(range)
+
+  texts.forEach((text) => {
+    const { key } = text
+    let index = 0
+    let length = text.length
+
+    if (key == startKey) index = startOffset
+    if (key == endKey) length = endOffset
+    if (key == startKey && key == endKey) length = endOffset - startOffset
+
+    transform.addMarkByKey(key, index, length, mark, { normalize })
+  })
+}
+
+/**
+ * Delete everything in a `range`.
+ *
+ * @param {Transform} transform
+ * @param {Selection} range
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+Transforms.deleteAtRange = (transform, range, options = {}) => {
+  if (range.isCollapsed) return
+
+  const { normalize = true } = options
+  const { startKey, startOffset, endKey, endOffset } = range
+
+  // If the start and end key are the same, we can just remove text.
+  if (startKey == endKey) {
+    const index = startOffset
+    const length = endOffset - startOffset
+    transform.removeTextByKey(startKey, index, length, { normalize })
+    return
+  }
+
+  // Split at the range edges within a common ancestor, without normalizing.
+  let { state } = transform
+  let { document } = state
+  let ancestor = document.getCommonAncestor(startKey, endKey)
+  let startChild = ancestor.getFurthestAncestor(startKey)
+  let endChild = ancestor.getFurthestAncestor(endKey)
+  const startOff = (startChild.kind == 'text' ? 0 : startChild.getOffset(startKey)) + startOffset
+  const endOff = (endChild.kind == 'text' ? 0 : endChild.getOffset(endKey)) + endOffset
+
+  transform.splitNodeByKey(startChild.key, startOff, OPTS)
+  transform.splitNodeByKey(endChild.key, endOff, OPTS)
+
+  // Refresh variables.
+  state = transform.state
+  document = state.document
+  ancestor = document.getCommonAncestor(startKey, endKey)
+  startChild = ancestor.getFurthestAncestor(startKey)
+  endChild = ancestor.getFurthestAncestor(endKey)
+  const startIndex = ancestor.nodes.indexOf(startChild)
+  const endIndex = ancestor.nodes.indexOf(endChild)
+  const middles = ancestor.nodes.slice(startIndex + 1, endIndex + 1)
+
+  // Remove all of the middle nodes, between the splits.
+  if (middles.size) {
+    middles.forEach((child) => {
+      transform.removeNodeByKey(child.key, OPTS)
+    })
+  }
+
+  // If the start and end block are different, move all of the nodes from the
+  // end block into the start block.
+  const startBlock = document.getClosestBlock(startKey)
+  const endBlock = document.getClosestBlock(document.getNextText(endKey).key)
+
+  if (startBlock.key !== endBlock.key) {
+    endBlock.nodes.forEach((child, i) => {
+      const newKey = startBlock.key
+      const newIndex = startBlock.nodes.size + i
+      transform.moveNodeByKey(child.key, newKey, newIndex, OPTS)
+    })
+
+    // Remove parents of endBlock as long as they have a single child
+    const lonely = document.getFurthestOnlyChildAncestor(endBlock.key) || endBlock
+    transform.removeNodeByKey(lonely.key, OPTS)
+  }
+
+  if (normalize) {
+    transform.normalizeNodeByKey(ancestor.key, SCHEMA)
+  }
+}
+
+/**
+ * Delete backward until the character boundary at a `range`.
+ *
+ * @param {Transform} transform
+ * @param {Selection} range
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+Transforms.deleteCharBackwardAtRange = (transform, range, options) => {
+  const { state } = transform
+  const { document } = state
+  const { startKey, startOffset } = range
+  const startBlock = document.getClosestBlock(startKey)
+  const offset = startBlock.getOffset(startKey)
+  const o = offset + startOffset
+  const { text } = startBlock
+  const n = String.getCharOffsetBackward(text, o)
+  transform.deleteBackwardAtRange(range, n, options)
+}
+
+/**
+ * Delete backward until the line boundary at a `range`.
+ *
+ * @param {Transform} transform
+ * @param {Selection} range
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+Transforms.deleteLineBackwardAtRange = (transform, range, options) => {
+  const { state } = transform
+  const { document } = state
+  const { startKey, startOffset } = range
+  const startBlock = document.getClosestBlock(startKey)
+  const offset = startBlock.getOffset(startKey)
+  const o = offset + startOffset
+  transform.deleteBackwardAtRange(range, o, options)
+}
+
+/**
+ * Delete backward until the word boundary at a `range`.
+ *
+ * @param {Transform} transform
+ * @param {Selection} range
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+Transforms.deleteWordBackwardAtRange = (transform, range, options) => {
+  const { state } = transform
+  const { document } = state
+  const { startKey, startOffset } = range
+  const startBlock = document.getClosestBlock(startKey)
+  const offset = startBlock.getOffset(startKey)
+  const o = offset + startOffset
+  const { text } = startBlock
+  const n = String.getWordOffsetBackward(text, o)
+  transform.deleteBackwardAtRange(range, n, options)
+}
+
+/**
+ * Delete backward `n` characters at a `range`.
+ *
+ * @param {Transform} transform
+ * @param {Selection} range
+ * @param {Number} n (optional)
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+Transforms.deleteBackwardAtRange = (transform, range, n = 1, options = {}) => {
+  const { normalize = true } = options
+  const { state } = transform
+  const { document } = state
+  const { startKey, focusOffset } = range
+
+  // If the range is expanded, perform a regular delete instead.
+  if (range.isExpanded) {
+    transform.deleteAtRange(range, { normalize })
+    return
+  }
+
+  const block = document.getClosestBlock(startKey)
+  // If the closest block is void, delete it.
+  if (block && block.isVoid) {
+    transform.removeNodeByKey(block.key, { normalize })
+    return
+  }
+  // If the closest is not void, but empty, remove it
+  if (block && !block.isVoid && block.isEmpty && document.nodes.size !== 1) {
+    transform.removeNodeByKey(block.key, { normalize })
+    return
+  }
+
+  // If the closest inline is void, delete it.
+  const inline = document.getClosestInline(startKey)
+  if (inline && inline.isVoid) {
+    transform.removeNodeByKey(inline.key, { normalize })
+    return
+  }
+
+  // If the range is at the start of the document, abort.
+  if (range.isAtStartOf(document)) {
+    return
+  }
+
+  // If the range is at the start of the text node, we need to figure out what
+  // is behind it to know how to delete...
+  const text = document.getDescendant(startKey)
+  if (range.isAtStartOf(text)) {
+    const prev = document.getPreviousText(text.key)
+    const prevBlock = document.getClosestBlock(prev.key)
+    const prevInline = document.getClosestInline(prev.key)
+
+    // If the previous block is void, remove it.
+    if (prevBlock && prevBlock.isVoid) {
+      transform.removeNodeByKey(prevBlock.key, { normalize })
+      return
+    }
+
+    // If the previous inline is void, remove it.
+    if (prevInline && prevInline.isVoid) {
+      transform.removeNodeByKey(prevInline.key, { normalize })
+      return
+    }
+
+    // If we're deleting by one character and the previous text node is not
+    // inside the current block, we need to join the two blocks together.
+    if (n == 1 && prevBlock != block) {
+      range = range.merge({
+        anchorKey: prev.key,
+        anchorOffset: prev.length,
+      })
+
+      transform.deleteAtRange(range, { normalize })
+      return
+    }
+  }
+
+  // If the focus offset is farther than the number of characters to delete,
+  // just remove the characters backwards inside the current node.
+  if (n < focusOffset) {
+    range = range.merge({
+      focusOffset: focusOffset - n,
+      isBackward: true,
+    })
+
+    transform.deleteAtRange(range, { normalize })
+    return
+  }
+
+  // Otherwise, we need to see how many nodes backwards to go.
+  let node = text
+  let offset = 0
+  let traversed = focusOffset
+
+  while (n > traversed) {
+    node = document.getPreviousText(node.key)
+    const next = traversed + node.length
+    if (n <= next) {
+      offset = next - n
+      break
+    } else {
+      traversed = next
+    }
+  }
+
+  // If the focus node is inside a void, go up until right after it.
+  if (document.hasVoidParent(node.key)) {
+    const parent = document.getClosestVoid(node.key)
+    node = document.getNextText(parent.key)
+    offset = 0
+  }
+
+  range = range.merge({
+    focusKey: node.key,
+    focusOffset: offset,
+    isBackward: true
+  })
+
+  transform.deleteAtRange(range, { normalize })
+}
+
+/**
+ * Delete forward until the character boundary at a `range`.
+ *
+ * @param {Transform} transform
+ * @param {Selection} range
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+Transforms.deleteCharForwardAtRange = (transform, range, options) => {
+  const { state } = transform
+  const { document } = state
+  const { startKey, startOffset } = range
+  const startBlock = document.getClosestBlock(startKey)
+  const offset = startBlock.getOffset(startKey)
+  const o = offset + startOffset
+  const { text } = startBlock
+  const n = String.getCharOffsetForward(text, o)
+  transform.deleteForwardAtRange(range, n, options)
+}
+
+/**
+ * Delete forward until the line boundary at a `range`.
+ *
+ * @param {Transform} transform
+ * @param {Selection} range
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+Transforms.deleteLineForwardAtRange = (transform, range, options) => {
+  const { state } = transform
+  const { document } = state
+  const { startKey, startOffset } = range
+  const startBlock = document.getClosestBlock(startKey)
+  const offset = startBlock.getOffset(startKey)
+  const o = offset + startOffset
+  transform.deleteForwardAtRange(range, o, options)
+}
+
+/**
+ * Delete forward until the word boundary at a `range`.
+ *
+ * @param {Transform} transform
+ * @param {Selection} range
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+Transforms.deleteWordForwardAtRange = (transform, range, options) => {
+  const { state } = transform
+  const { document } = state
+  const { startKey, startOffset } = range
+  const startBlock = document.getClosestBlock(startKey)
+  const offset = startBlock.getOffset(startKey)
+  const o = offset + startOffset
+  const { text } = startBlock
+  const n = String.getWordOffsetForward(text, o)
+  transform.deleteForwardAtRange(range, n, options)
+}
+
+/**
+ * Delete forward `n` characters at a `range`.
+ *
+ * @param {Transform} transform
+ * @param {Selection} range
+ * @param {Number} n (optional)
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+Transforms.deleteForwardAtRange = (transform, range, n = 1, options = {}) => {
+  const { normalize = true } = options
+  const { state } = transform
+  const { document } = state
+  const { startKey, focusOffset } = range
+
+  // If the range is expanded, perform a regular delete instead.
+  if (range.isExpanded) {
+    transform.deleteAtRange(range, { normalize })
+    return
+  }
+
+  const block = document.getClosestBlock(startKey)
+  // If the closest block is void, delete it.
+  if (block && block.isVoid) {
+    transform.removeNodeByKey(block.key, { normalize })
+    return
+  }
+  // If the closest is not void, but empty, remove it
+  if (block && !block.isVoid && block.isEmpty && document.nodes.size !== 1) {
+    transform.removeNodeByKey(block.key, { normalize })
+    return
+  }
+
+  // If the closest inline is void, delete it.
+  const inline = document.getClosestInline(startKey)
+  if (inline && inline.isVoid) {
+    transform.removeNodeByKey(inline.key, { normalize })
+    return
+  }
+
+  // If the range is at the start of the document, abort.
+  if (range.isAtEndOf(document)) {
+    return
+  }
+
+  // If the range is at the start of the text node, we need to figure out what
+  // is behind it to know how to delete...
+  const text = document.getDescendant(startKey)
+  if (range.isAtEndOf(text)) {
+    const next = document.getNextText(text.key)
+    const nextBlock = document.getClosestBlock(next.key)
+    const nextInline = document.getClosestInline(next.key)
+
+    // If the previous block is void, remove it.
+    if (nextBlock && nextBlock.isVoid) {
+      transform.removeNodeByKey(nextBlock.key, { normalize })
+      return
+    }
+
+    // If the previous inline is void, remove it.
+    if (nextInline && nextInline.isVoid) {
+      transform.removeNodeByKey(nextInline.key, { normalize })
+      return
+    }
+
+    // If we're deleting by one character and the previous text node is not
+    // inside the current block, we need to join the two blocks together.
+    if (n == 1 && nextBlock != block) {
+      range = range.merge({
+        focusKey: next.key,
+        focusOffset: 0
+      })
+
+      transform.deleteAtRange(range, { normalize })
+      return
+    }
+  }
+
+  // If the remaining characters to the end of the node is greater than or equal
+  // to the number of characters to delete, just remove the characters forwards
+  // inside the current node.
+  if (n <= (text.length - focusOffset)) {
+    range = range.merge({
+      focusOffset: focusOffset + n
+    })
+
+    transform.deleteAtRange(range, { normalize })
+    return
+  }
+
+  // Otherwise, we need to see how many nodes forwards to go.
+  let node = text
+  let offset = focusOffset
+  let traversed = text.length - focusOffset
+
+  while (n > traversed) {
+    node = document.getNextText(node.key)
+    const next = traversed + node.length
+    if (n <= next) {
+      offset = n - traversed
+      break
+    } else {
+      traversed = next
+    }
+  }
+
+  // If the focus node is inside a void, go up until right before it.
+  if (document.hasVoidParent(node.key)) {
+    const parent = document.getClosestVoid(node.key)
+    node = document.getPreviousText(parent.key)
+    offset = node.length
+  }
+
+  range = range.merge({
+    focusKey: node.key,
+    focusOffset: offset,
+  })
+
+  transform.deleteAtRange(range, { normalize })
+}
+
+/**
+ * Insert a `block` node at `range`.
+ *
+ * @param {Transform} transform
+ * @param {Selection} range
+ * @param {Block|String|Object} block
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+Transforms.insertBlockAtRange = (transform, range, block, options = {}) => {
+  block = Normalize.block(block)
+  const { normalize = true } = options
+
+  if (range.isExpanded) {
+    transform.deleteAtRange(range)
+    range = range.collapseToStart()
+  }
+
+  const { state } = transform
+  const { document } = state
+  const { startKey, startOffset } = range
+  const startText = document.assertDescendant(startKey)
+  const startBlock = document.getClosestBlock(startKey)
+  const parent = document.getParent(startBlock.key)
+  const index = parent.nodes.indexOf(startBlock)
+
+  if (startBlock.isVoid) {
+    transform.insertNodeByKey(parent.key, index + 1, block, { normalize })
+  }
+
+  else if (startBlock.isEmpty) {
+    transform.removeNodeByKey(startBlock.key)
+    transform.insertNodeByKey(parent.key, index, block, { normalize })
+  }
+
+  else if (range.isAtStartOf(startBlock)) {
+    transform.insertNodeByKey(parent.key, index, block, { normalize })
+  }
+
+  else if (range.isAtEndOf(startBlock)) {
+    transform.insertNodeByKey(parent.key, index + 1, block, { normalize })
+  }
+
+  else {
+    const offset = startBlock.getOffset(startText.key) + startOffset
+    transform.splitNodeByKey(startBlock.key, offset, { normalize })
+    transform.insertNodeByKey(parent.key, index + 1, block, { normalize })
+  }
+
+  if (normalize) {
+    transform.normalizeNodeByKey(parent.key, SCHEMA)
+  }
+}
+
+/**
+ * Insert a `fragment` at a `range`.
+ *
+ * @param {Transform} transform
+ * @param {Selection} range
+ * @param {Document} fragment
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+Transforms.insertFragmentAtRange = (transform, range, fragment, options = {}) => {
+  const { normalize = true } = options
+
+  // If the range is expanded, delete it first.
+  if (range.isExpanded) {
+    transform.deleteAtRange(range, OPTS)
+    range = range.collapseToStart()
+  }
+
+  // If the fragment is empty, there's nothing to do after deleting.
+  if (!fragment.nodes.size) return
+
+  // Regenerate the keys for all of the fragments nodes, so that they're
+  // guaranteed not to collide with the existing keys in the document. Otherwise
+  // they will be rengerated automatically and we won't have an easy way to
+  // reference them.
+  fragment = fragment.mapDescendants(child => child.regenerateKey())
+
+  // Calculate a few things...
+  const { startKey, startOffset } = range
+  let { state } = transform
+  let { document } = state
+  let startText = document.getDescendant(startKey)
+  let startBlock = document.getClosestBlock(startText.key)
+  let startChild = startBlock.getFurthestAncestor(startText.key)
+  const isAtStart = range.isAtStartOf(startBlock)
+  const parent = document.getParent(startBlock.key)
+  const index = parent.nodes.indexOf(startBlock)
+  const offset = startChild == startText
+    ? startOffset
+    : startChild.getOffset(startText.key) + startOffset
+
+  const blocks = fragment.getBlocks()
+  const firstBlock = blocks.first()
+  const lastBlock = blocks.last()
+
+  // If the fragment only contains a void block, use `insertBlock` instead.
+  if (firstBlock == lastBlock && firstBlock.isVoid) {
+    transform.insertBlockAtRange(range, firstBlock, options)
+    return
+  }
+
+  // If the first and last block aren't the same, we need to insert all of the
+  // nodes after the fragment's first block at the index.
+  if (firstBlock != lastBlock) {
+    const lonelyParent = fragment.getFurthest(firstBlock.key, p => p.nodes.size == 1)
+    const lonelyChild = lonelyParent || firstBlock
+    const startIndex = parent.nodes.indexOf(startBlock)
+    fragment = fragment.removeDescendant(lonelyChild.key)
+
+    fragment.nodes.forEach((node, i) => {
+      const newIndex = startIndex + i + 1
+      transform.insertNodeByKey(parent.key, newIndex, node, OPTS)
+    })
+  }
+
+  // Check if we need to split the node.
+  if (startOffset != 0) {
+    transform.splitNodeByKey(startChild.key, offset, OPTS)
+  }
+
+  // Update our variables with the new state.
+  state = transform.state
+  document = state.document
+  startText = document.getDescendant(startKey)
+  startBlock = document.getClosestBlock(startKey)
+  startChild = startBlock.getFurthestAncestor(startText.key)
+
+  // If the first and last block aren't the same, we need to move any of the
+  // starting block's children after the split into the last block of the
+  // fragment, which has already been inserted.
+  if (firstBlock != lastBlock) {
+    const nextChild = isAtStart ? startChild : startBlock.getNextSibling(startChild.key)
+    const nextNodes = nextChild ? startBlock.nodes.skipUntil(n => n.key == nextChild.key) : List()
+    const lastIndex = lastBlock.nodes.size
+
+    nextNodes.forEach((node, i) => {
+      const newIndex = lastIndex + i
+      transform.moveNodeByKey(node.key, lastBlock.key, newIndex, OPTS)
+    })
+  }
+
+  // If the starting block is empty, we replace it entirely with the first block
+  // of the fragment, since this leads to a more expected behavior for the user.
+  if (startBlock.isEmpty) {
+    transform.removeNodeByKey(startBlock.key, OPTS)
+    transform.insertNodeByKey(parent.key, index, firstBlock, OPTS)
+  }
+
+  // Otherwise, we maintain the starting block, and insert all of the first
+  // block's inline nodes into it at the split point.
+  else {
+    const inlineChild = startBlock.getFurthestAncestor(startText.key)
+    const inlineIndex = startBlock.nodes.indexOf(inlineChild)
+
+    firstBlock.nodes.forEach((inline, i) => {
+      const o = startOffset == 0 ? 0 : 1
+      const newIndex = inlineIndex + i + o
+      transform.insertNodeByKey(startBlock.key, newIndex, inline, OPTS)
+    })
+  }
+
+  // Normalize if requested.
+  if (normalize) {
+    transform.normalizeNodeByKey(parent.key, SCHEMA)
+  }
+}
+
+/**
+ * Insert an `inline` node at `range`.
+ *
+ * @param {Transform} transform
+ * @param {Selection} range
+ * @param {Inline|String|Object} inline
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+Transforms.insertInlineAtRange = (transform, range, inline, options = {}) => {
+  const { normalize = true } = options
+  inline = Normalize.inline(inline)
+
+  if (range.isExpanded) {
+    transform.deleteAtRange(range, OPTS)
+    range = range.collapseToStart()
+  }
+
+  const { state } = transform
+  const { document } = state
+  const { startKey, startOffset } = range
+  const parent = document.getParent(startKey)
+  const startText = document.assertDescendant(startKey)
+  const index = parent.nodes.indexOf(startText)
+
+  if (parent.isVoid) return
+
+  transform.splitNodeByKey(startKey, startOffset, OPTS)
+  transform.insertNodeByKey(parent.key, index + 1, inline, OPTS)
+
+  if (normalize) {
+    transform.normalizeNodeByKey(parent.key, SCHEMA)
+  }
+}
+
+/**
+ * Insert `text` at a `range`, with optional `marks`.
+ *
+ * @param {Transform} transform
+ * @param {Selection} range
+ * @param {String} text
+ * @param {Set<Mark>} marks (optional)
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+Transforms.insertTextAtRange = (transform, range, text, marks, options = {}) => {
+  let { normalize } = options
+  const { state } = transform
+  const { document } = state
+  const { startKey, startOffset } = range
+  const parent = document.getParent(startKey)
+
+  if (parent.isVoid) return
+
+  if (range.isExpanded) {
+    transform.deleteAtRange(range, OPTS)
+  }
+
+  // PERF: Unless specified, don't normalize if only inserting text.
+  if (normalize !== undefined) {
+    normalize = range.isExpanded
+  }
+
+  transform.insertTextByKey(startKey, startOffset, text, marks, { normalize })
+}
+
+/**
+ * Remove an existing `mark` to the characters at `range`.
+ *
+ * @param {Transform} transform
+ * @param {Selection} range
+ * @param {Mark|String} mark (optional)
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+Transforms.removeMarkAtRange = (transform, range, mark, options = {}) => {
+  if (range.isCollapsed) return
+
+  const { normalize = true } = options
+  const { state } = transform
+  const { document } = state
+  const texts = document.getTextsAtRange(range)
+  const { startKey, startOffset, endKey, endOffset } = range
+
+  texts.forEach((text) => {
+    const { key } = text
+    let index = 0
+    let length = text.length
+
+    if (key == startKey) index = startOffset
+    if (key == endKey) length = endOffset
+    if (key == startKey && key == endKey) length = endOffset - startOffset
+
+    transform.removeMarkByKey(key, index, length, mark, { normalize })
+  })
+}
+
+/**
+ * Set the `properties` of block nodes in a `range`.
+ *
+ * @param {Transform} transform
+ * @param {Selection} range
+ * @param {Object|String} properties
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+Transforms.setBlockAtRange = (transform, range, properties, options = {}) => {
+  const { normalize = true } = options
+  const { state } = transform
+  const { document } = state
+  const blocks = document.getBlocksAtRange(range)
+
+  blocks.forEach((block) => {
+    transform.setNodeByKey(block.key, properties, { normalize })
+  })
+}
+
+/**
+ * Set the `properties` of inline nodes in a `range`.
+ *
+ * @param {Transform} transform
+ * @param {Selection} range
+ * @param {Object|String} properties
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+Transforms.setInlineAtRange = (transform, range, properties, options = {}) => {
+  const { normalize = true } = options
+  const { state } = transform
+  const { document } = state
+  const inlines = document.getInlinesAtRange(range)
+
+  inlines.forEach((inline) => {
+    transform.setNodeByKey(inline.key, properties, { normalize })
+  })
+}
+
+/**
+ * Split the block nodes at a `range`, to optional `height`.
+ *
+ * @param {Transform} transform
+ * @param {Selection} range
+ * @param {Number} height (optional)
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+Transforms.splitBlockAtRange = (transform, range, height = 1, options = {}) => {
+  const { normalize = true } = options
+
+  if (range.isExpanded) {
+    transform.deleteAtRange(range, { normalize })
+    range = range.collapseToStart()
+  }
+
+  const { startKey, startOffset } = range
+  const { state } = transform
+  const { document } = state
+  let node = document.assertDescendant(startKey)
+  let parent = document.getClosestBlock(node.key)
+  let offset = startOffset
+  let h = 0
+
+  while (parent && parent.kind == 'block' && h < height) {
+    offset += parent.getOffset(node.key)
+    node = parent
+    parent = document.getClosestBlock(parent.key)
+    h++
+  }
+
+  transform.splitNodeByKey(node.key, offset, { normalize })
+}
+
+/**
+ * Split the inline nodes at a `range`, to optional `height`.
+ *
+ * @param {Transform} transform
+ * @param {Selection} range
+ * @param {Number} height (optional)
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+Transforms.splitInlineAtRange = (transform, range, height = Infinity, options = {}) => {
+  const { normalize = true } = options
+
+  if (range.isExpanded) {
+    transform.deleteAtRange(range, { normalize })
+    range = range.collapseToStart()
+  }
+
+  const { startKey, startOffset } = range
+  const { state } = transform
+  const { document } = state
+  let node = document.assertDescendant(startKey)
+  let parent = document.getClosestInline(node.key)
+  let offset = startOffset
+  let h = 0
+
+  while (parent && parent.kind == 'inline' && h < height) {
+    offset += parent.getOffset(node.key)
+    node = parent
+    parent = document.getClosestInline(parent.key)
+    h++
+  }
+
+  transform.splitNodeByKey(node.key, offset, { normalize })
+}
+
+/**
+ * Add or remove a `mark` from the characters at `range`, depending on whether
+ * it's already there.
+ *
+ * @param {Transform} transform
+ * @param {Selection} range
+ * @param {Mixed} mark
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+Transforms.toggleMarkAtRange = (transform, range, mark, options = {}) => {
+  if (range.isCollapsed) return
+
+  mark = Normalize.mark(mark)
+
+  const { normalize = true } = options
+  const { state } = transform
+  const { document } = state
+  const marks = document.getMarksAtRange(range)
+  const exists = marks.some(m => m.equals(mark))
+
+  if (exists) {
+    transform.removeMarkAtRange(range, mark, { normalize })
+  } else {
+    transform.addMarkAtRange(range, mark, { normalize })
+  }
+}
+
+/**
+ * Unwrap all of the block nodes in a `range` from a block with `properties`.
+ *
+ * @param {Transform} transform
+ * @param {Selection} range
+ * @param {String|Object} properties
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+Transforms.unwrapBlockAtRange = (transform, range, properties, options = {}) => {
+  properties = Normalize.nodeProperties(properties)
+
+  const { normalize = true } = options
+  let { state } = transform
+  let { document } = state
+  const blocks = document.getBlocksAtRange(range)
+  const wrappers = blocks
+    .map((block) => {
+      return document.getClosest(block.key, (parent) => {
+        if (parent.kind != 'block') return false
+        if (properties.type != null && parent.type != properties.type) return false
+        if (properties.isVoid != null && parent.isVoid != properties.isVoid) return false
+        if (properties.data != null && !parent.data.isSuperset(properties.data)) return false
+        return true
+      })
+    })
+    .filter(exists => exists)
+    .toOrderedSet()
+    .toList()
+
+  wrappers.forEach((block) => {
+    const first = block.nodes.first()
+    const last = block.nodes.last()
+    const parent = document.getParent(block.key)
+    const index = parent.nodes.indexOf(block)
+
+    const children = block.nodes.filter((child) => {
+      return blocks.some(b => child == b || child.hasDescendant(b.key))
+    })
+
+    const firstMatch = children.first()
+    const lastMatch = children.last()
+
+    if (first == firstMatch && last == lastMatch) {
+      block.nodes.forEach((child, i) => {
+        transform.moveNodeByKey(child.key, parent.key, index + i, OPTS)
+      })
+
+      transform.removeNodeByKey(block.key, OPTS)
+    }
+
+    else if (last == lastMatch) {
+      block.nodes
+        .skipUntil(n => n == firstMatch)
+        .forEach((child, i) => {
+          transform.moveNodeByKey(child.key, parent.key, index + 1 + i, OPTS)
+        })
+    }
+
+    else if (first == firstMatch) {
+      block.nodes
+        .takeUntil(n => n == lastMatch)
+        .push(lastMatch)
+        .forEach((child, i) => {
+          transform.moveNodeByKey(child.key, parent.key, index + i, OPTS)
+        })
+    }
+
+    else {
+      const offset = block.getOffset(firstMatch.key)
+
+      transform.splitNodeByKey(block.key, offset, OPTS)
+      state = transform.state
+      document = state.document
+
+      children.forEach((child, i) => {
+        if (i == 0) {
+          const extra = child
+          child = document.getNextBlock(child.key)
+          transform.removeNodeByKey(extra.key, OPTS)
+        }
+
+        transform.moveNodeByKey(child.key, parent.key, index + 1 + i, OPTS)
+      })
+    }
+  })
+
+  // TODO: optmize to only normalize the right block
+  if (normalize) {
+    transform.normalizeDocument(SCHEMA)
+  }
+}
+
+/**
+ * Unwrap the inline nodes in a `range` from an inline with `properties`.
+ *
+ * @param {Transform} transform
+ * @param {Selection} range
+ * @param {String|Object} properties
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+Transforms.unwrapInlineAtRange = (transform, range, properties, options = {}) => {
+  properties = Normalize.nodeProperties(properties)
+
+  const { normalize = true } = options
+  const { state } = transform
+  const { document } = state
+  const texts = document.getTextsAtRange(range)
+  const inlines = texts
+    .map((text) => {
+      return document.getClosest(text.key, (parent) => {
+        if (parent.kind != 'inline') return false
+        if (properties.type != null && parent.type != properties.type) return false
+        if (properties.isVoid != null && parent.isVoid != properties.isVoid) return false
+        if (properties.data != null && !parent.data.isSuperset(properties.data)) return false
+        return true
+      })
+    })
+    .filter(exists => exists)
+    .toOrderedSet()
+    .toList()
+
+  inlines.forEach((inline) => {
+    const parent = transform.state.document.getParent(inline.key)
+    const index = parent.nodes.indexOf(inline)
+
+    inline.nodes.forEach((child, i) => {
+      transform.moveNodeByKey(child.key, parent.key, index + i, OPTS)
+    })
+  })
+
+  // TODO: optmize to only normalize the right block
+  if (normalize) {
+    transform.normalizeDocument(SCHEMA)
+  }
+}
+
+/**
+ * Wrap all of the blocks in a `range` in a new `block`.
+ *
+ * @param {Transform} transform
+ * @param {Selection} range
+ * @param {Block|Object|String} block
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+Transforms.wrapBlockAtRange = (transform, range, block, options = {}) => {
+  block = Normalize.block(block)
+  block = block.set('nodes', block.nodes.clear())
+
+  const { normalize = true } = options
+  const { state } = transform
+  const { document } = state
+
+  const blocks = document.getBlocksAtRange(range)
+  const firstblock = blocks.first()
+  const lastblock = blocks.last()
+  let parent, siblings, index
+
+  // If there is only one block in the selection then we know the parent and
+  // siblings.
+  if (blocks.length === 1) {
+    parent = document.getParent(firstblock.key)
+    siblings = blocks
+  }
+
+  // Determine closest shared parent to all blocks in selection.
+  else {
+    parent = document.getClosest(firstblock.key, (p1) => {
+      return !!document.getClosest(lastblock.key, p2 => p1 == p2)
+    })
+  }
+
+  // If no shared parent could be found then the parent is the document.
+  if (parent == null) parent = document
+
+  // Create a list of direct children siblings of parent that fall in the
+  // selection.
+  if (siblings == null) {
+    const indexes = parent.nodes.reduce((ind, node, i) => {
+      if (node == firstblock || node.hasDescendant(firstblock.key)) ind[0] = i
+      if (node == lastblock || node.hasDescendant(lastblock.key)) ind[1] = i
+      return ind
+    }, [])
+
+    index = indexes[0]
+    siblings = parent.nodes.slice(indexes[0], indexes[1] + 1)
+  }
+
+  // Get the index to place the new wrapped node at.
+  if (index == null) {
+    index = parent.nodes.indexOf(siblings.first())
+  }
+
+  // Inject the new block node into the parent.
+  transform.insertNodeByKey(parent.key, index, block, OPTS)
+
+  // Move the sibling nodes into the new block node.
+  siblings.forEach((node, i) => {
+    transform.moveNodeByKey(node.key, block.key, i, OPTS)
+  })
+
+  if (normalize) {
+    transform.normalizeNodeByKey(parent.key, SCHEMA)
+  }
+}
+
+/**
+ * Wrap the text and inlines in a `range` in a new `inline`.
+ *
+ * @param {Transform} transform
+ * @param {Selection} range
+ * @param {Inline|Object|String} inline
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+Transforms.wrapInlineAtRange = (transform, range, inline, options = {}) => {
+  let { state } = transform
+  let { document } = state
+  const { normalize = true } = options
+  const { startKey, startOffset, endKey, endOffset } = range
+
+  if (range.isCollapsed) {
+    // Wrapping an inline void
+    const inlineParent = document.getClosestInline(startKey)
+    if (!inlineParent.isVoid) {
+      return
+    }
+
+    return transform.wrapInlineByKey(inlineParent.key, inline, options)
+  }
+
+  inline = Normalize.inline(inline)
+  inline = inline.set('nodes', inline.nodes.clear())
+
+  const blocks = document.getBlocksAtRange(range)
+  let startBlock = document.getClosestBlock(startKey)
+  let endBlock = document.getClosestBlock(endKey)
+  let startChild = startBlock.getFurthestAncestor(startKey)
+  const endChild = endBlock.getFurthestAncestor(endKey)
+  const startIndex = startBlock.nodes.indexOf(startChild)
+  const endIndex = endBlock.nodes.indexOf(endChild)
+
+  const startOff = startChild.key == startKey
+    ? startOffset
+    : startChild.getOffset(startKey) + startOffset
+
+  const endOff = endChild.key == endKey
+    ? endOffset
+    : endChild.getOffset(endKey) + endOffset
+
+  if (startBlock == endBlock) {
+    if (endOff != endChild.length) {
+      transform.splitNodeByKey(endChild.key, endOff, OPTS)
+    }
+
+    if (startOff != 0) {
+      transform.splitNodeByKey(startChild.key, startOff, OPTS)
+    }
+
+    state = transform.state
+    document = state.document
+    startBlock = document.getClosestBlock(startKey)
+    startChild = startBlock.getFurthestAncestor(startKey)
+
+    const startInner = startOff == 0
+      ? startChild
+      : document.getNextSibling(startChild.key)
+
+    const startInnerIndex = startBlock.nodes.indexOf(startInner)
+
+    const endInner = startKey == endKey ? startInner : startBlock.getFurthestAncestor(endKey)
+    const inlines = startBlock.nodes
+      .skipUntil(n => n == startInner)
+      .takeUntil(n => n == endInner)
+      .push(endInner)
+
+    const node = inline.regenerateKey()
+
+    transform.insertNodeByKey(startBlock.key, startInnerIndex, node, OPTS)
+
+    inlines.forEach((child, i) => {
+      transform.moveNodeByKey(child.key, node.key, i, OPTS)
+    })
+
+    if (normalize) {
+      transform.normalizeNodeByKey(startBlock.key, SCHEMA)
+    }
+  }
+
+  else {
+    transform.splitNodeByKey(startChild.key, startOff, OPTS)
+    transform.splitNodeByKey(endChild.key, endOff, OPTS)
+
+    state = transform.state
+    document = state.document
+    startBlock = document.getDescendant(startBlock.key)
+    endBlock = document.getDescendant(endBlock.key)
+
+    const startInlines = startBlock.nodes.slice(startIndex + 1)
+    const endInlines = endBlock.nodes.slice(0, endIndex + 1)
+    const startNode = inline.regenerateKey()
+    const endNode = inline.regenerateKey()
+
+    transform.insertNodeByKey(startBlock.key, startIndex - 1, startNode, OPTS)
+    transform.insertNodeByKey(endBlock.key, endIndex, endNode, OPTS)
+
+    startInlines.forEach((child, i) => {
+      transform.moveNodeByKey(child.key, startNode.key, i, OPTS)
+    })
+
+    endInlines.forEach((child, i) => {
+      transform.moveNodeByKey(child.key, endNode.key, i, OPTS)
+    })
+
+    if (normalize) {
+      transform
+        .normalizeNodeByKey(startBlock.key, SCHEMA)
+        .normalizeNodeByKey(endBlock.key, SCHEMA)
+    }
+
+    blocks.slice(1, -1).forEach((block) => {
+      const node = inline.regenerateKey()
+      transform.insertNodeByKey(block.key, 0, node, OPTS)
+
+      block.nodes.forEach((child, i) => {
+        transform.moveNodeByKey(child.key, node.key, i, OPTS)
+      })
+
+      if (normalize) {
+        transform.normalizeNodeByKey(block.key, SCHEMA)
+      }
+    })
+  }
+}
+
+/**
+ * Wrap the text in a `range` in a prefix/suffix.
+ *
+ * @param {Transform} transform
+ * @param {Selection} range
+ * @param {String} prefix
+ * @param {String} suffix (optional)
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+Transforms.wrapTextAtRange = (transform, range, prefix, suffix = prefix, options = {}) => {
+  const { normalize = true } = options
+  const { startKey, endKey } = range
+  const start = range.collapseToStart()
+  let end = range.collapseToEnd()
+
+  if (startKey == endKey) {
+    end = end.move(prefix.length)
+  }
+
+  transform.insertTextAtRange(start, prefix, [], { normalize })
+  transform.insertTextAtRange(end, suffix, [], { normalize })
+}
+
+/**
+ * Export.
+ *
+ * @type {Object}
+ */
+
+export default Transforms

--- a/src/lib/slate/transforms/by-key.js
+++ b/src/lib/slate/transforms/by-key.js
@@ -1,0 +1,443 @@
+
+import Normalize from '../utils/normalize'
+import SCHEMA from '../schemas/core'
+
+/**
+ * Transforms.
+ *
+ * @type {Object}
+ */
+
+const Transforms = {}
+
+/**
+ * Add mark to text at `offset` and `length` in node by `key`.
+ *
+ * @param {Transform} transform
+ * @param {String} key
+ * @param {Number} offset
+ * @param {Number} length
+ * @param {Mixed} mark
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+Transforms.addMarkByKey = (transform, key, offset, length, mark, options = {}) => {
+  mark = Normalize.mark(mark)
+  const { normalize = true } = options
+  const { state } = transform
+  const { document } = state
+  const path = document.getPath(key)
+
+  transform.addMarkOperation(path, offset, length, mark)
+
+  if (normalize) {
+    const parent = document.getParent(key)
+    transform.normalizeNodeByKey(parent.key, SCHEMA)
+  }
+}
+
+/**
+ * Insert a `node` at `index` in a node by `key`.
+ *
+ * @param {Transform} transform
+ * @param {String} key
+ * @param {Number} index
+ * @param {Node} node
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+Transforms.insertNodeByKey = (transform, key, index, node, options = {}) => {
+  const { normalize = true } = options
+  const { state } = transform
+  const { document } = state
+  const path = document.getPath(key)
+
+  transform.insertNodeOperation(path, index, node)
+
+  if (normalize) {
+    transform.normalizeNodeByKey(key, SCHEMA)
+  }
+}
+
+/**
+ * Insert `text` at `offset` in node by `key`.
+ *
+ * @param {Transform} transform
+ * @param {String} key
+ * @param {Number} offset
+ * @param {String} text
+ * @param {Set<Mark>} marks (optional)
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+Transforms.insertTextByKey = (transform, key, offset, text, marks, options = {}) => {
+  const { normalize = true } = options
+  const { state } = transform
+  const { document } = state
+  const path = document.getPath(key)
+
+  transform.insertTextOperation(path, offset, text, marks)
+
+  if (normalize) {
+    const parent = document.getParent(key)
+    transform.normalizeNodeByKey(parent.key, SCHEMA)
+  }
+}
+
+/**
+ * Join a node by `key` with a node `withKey`.
+ *
+ * @param {Transform} transform
+ * @param {String} key
+ * @param {String} withKey
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+Transforms.joinNodeByKey = (transform, key, withKey, options = {}) => {
+  const { normalize = true } = options
+  const { state } = transform
+  const { document } = state
+  const path = document.getPath(key)
+  const withPath = document.getPath(withKey)
+
+  transform.joinNodeOperation(path, withPath)
+
+  if (normalize) {
+    const parent = document.getCommonAncestor(key, withKey)
+    transform.normalizeNodeByKey(parent.key, SCHEMA)
+  }
+}
+
+/**
+ * Move a node by `key` to a new parent by `newKey` and `index`.
+ * `newKey` is the key of the container (it can be the document itself)
+ *
+ * @param {Transform} transform
+ * @param {String} key
+ * @param {String} newKey
+ * @param {Number} index
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+Transforms.moveNodeByKey = (transform, key, newKey, newIndex, options = {}) => {
+  const { normalize = true } = options
+  const { state } = transform
+  const { document } = state
+  const path = document.getPath(key)
+  const newPath = document.getPath(newKey)
+
+  transform.moveNodeOperation(path, newPath, newIndex)
+
+  if (normalize) {
+    const parent = document.getCommonAncestor(key, newKey)
+    transform.normalizeNodeByKey(parent.key, SCHEMA)
+  }
+}
+
+/**
+ * Remove mark from text at `offset` and `length` in node by `key`.
+ *
+ * @param {Transform} transform
+ * @param {String} key
+ * @param {Number} offset
+ * @param {Number} length
+ * @param {Mark} mark
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+Transforms.removeMarkByKey = (transform, key, offset, length, mark, options = {}) => {
+  mark = Normalize.mark(mark)
+  const { normalize = true } = options
+  const { state } = transform
+  const { document } = state
+  const path = document.getPath(key)
+
+  transform.removeMarkOperation(path, offset, length, mark)
+
+  if (normalize) {
+    const parent = document.getParent(key)
+    transform.normalizeNodeByKey(parent.key, SCHEMA)
+  }
+}
+
+/**
+ * Remove a node by `key`.
+ *
+ * @param {Transform} transform
+ * @param {String} key
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+Transforms.removeNodeByKey = (transform, key, options = {}) => {
+  const { normalize = true } = options
+  const { state } = transform
+  const { document } = state
+  const path = document.getPath(key)
+
+  transform.removeNodeOperation(path)
+
+  if (normalize) {
+    const parent = document.getParent(key)
+    transform.normalizeNodeByKey(parent.key, SCHEMA)
+  }
+}
+
+/**
+ * Remove text at `offset` and `length` in node by `key`.
+ *
+ * @param {Transform} transform
+ * @param {String} key
+ * @param {Number} offset
+ * @param {Number} length
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+Transforms.removeTextByKey = (transform, key, offset, length, options = {}) => {
+  const { normalize = true } = options
+  const { state } = transform
+  const { document } = state
+  const path = document.getPath(key)
+
+  transform.removeTextOperation(path, offset, length)
+
+  if (normalize) {
+    const block = document.getClosestBlock(key)
+    transform.normalizeNodeByKey(block.key, SCHEMA)
+  }
+}
+
+/**
+ * Set `properties` on mark on text at `offset` and `length` in node by `key`.
+ *
+ * @param {Transform} transform
+ * @param {String} key
+ * @param {Number} offset
+ * @param {Number} length
+ * @param {Mark} mark
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+Transforms.setMarkByKey = (transform, key, offset, length, mark, properties, options = {}) => {
+  mark = Normalize.mark(mark)
+  properties = Normalize.markProperties(properties)
+  const { normalize = true } = options
+  const newMark = mark.merge(properties)
+  const { state } = transform
+  const { document } = state
+  const path = document.getPath(key)
+
+  transform.setMarkOperation(path, offset, length, mark, newMark)
+
+  if (normalize) {
+    const parent = document.getParent(key)
+    transform.normalizeNodeByKey(parent.key, SCHEMA)
+  }
+}
+
+/**
+ * Set `properties` on a node by `key`.
+ *
+ * @param {Transform} transform
+ * @param {String} key
+ * @param {Object|String} properties
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+Transforms.setNodeByKey = (transform, key, properties, options = {}) => {
+  properties = Normalize.nodeProperties(properties)
+  const { normalize = true } = options
+  const { state } = transform
+  const { document } = state
+  const path = document.getPath(key)
+
+  transform.setNodeOperation(path, properties)
+
+  if (normalize) {
+    const node = key === document.key ? document : document.getParent(key)
+    transform.normalizeNodeByKey(node.key, SCHEMA)
+  }
+}
+
+/**
+ * Split a node by `key` at `offset`.
+ *
+ * @param {Transform} transform
+ * @param {String} key
+ * @param {Number} offset
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+Transforms.splitNodeByKey = (transform, key, offset, options = {}) => {
+  const { normalize = true } = options
+  const { state } = transform
+  const { document } = state
+  const path = document.getPath(key)
+
+  transform.splitNodeAtOffsetOperation(path, offset)
+
+  if (normalize) {
+    const parent = document.getParent(key)
+    transform.normalizeNodeByKey(parent.key, SCHEMA)
+  }
+}
+
+/**
+ * Unwrap content from an inline parent with `properties`.
+ *
+ * @param {Transform} transform
+ * @param {String} key
+ * @param {Object|String} properties
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+Transforms.unwrapInlineByKey = (transform, key, properties, options) => {
+  const { state } = transform
+  const { document, selection } = state
+  const node = document.assertDescendant(key)
+  const first = node.getFirstText()
+  const last = node.getLastText()
+  const range = selection.moveToRangeOf(first, last)
+  transform.unwrapInlineAtRange(range, properties, options)
+}
+
+/**
+ * Unwrap content from a block parent with `properties`.
+ *
+ * @param {Transform} transform
+ * @param {String} key
+ * @param {Object|String} properties
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+Transforms.unwrapBlockByKey = (transform, key, properties, options) => {
+  const { state } = transform
+  const { document, selection } = state
+  const node = document.assertDescendant(key)
+  const first = node.getFirstText()
+  const last = node.getLastText()
+  const range = selection.moveToRangeOf(first, last)
+  transform.unwrapBlockAtRange(range, properties, options)
+}
+
+/**
+ * Unwrap a single node from its parent.
+ *
+ * If the node is surrounded with siblings, its parent will be
+ * split. If the node is the only child, the parent is removed, and
+ * simply replaced by the node itself.  Cannot unwrap a root node.
+ *
+ * @param {Transform} transform
+ * @param {String} key
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+Transforms.unwrapNodeByKey = (transform, key, options = {}) => {
+  const { normalize = true } = options
+  const { state } = transform
+  const { document } = state
+  const parent = document.getParent(key)
+  const node = parent.getChild(key)
+
+  const index = parent.nodes.indexOf(node)
+  const isFirst = index === 0
+  const isLast = index === parent.nodes.size - 1
+
+  const parentParent = document.getParent(parent.key)
+  const parentIndex = parentParent.nodes.indexOf(parent)
+
+
+  if (parent.nodes.size === 1) {
+    transform.moveNodeByKey(key, parentParent.key, parentIndex, { normalize: false })
+    transform.removeNodeByKey(parent.key, options)
+  }
+
+  else if (isFirst) {
+    // Just move the node before its parent.
+    transform.moveNodeByKey(key, parentParent.key, parentIndex, options)
+  }
+
+  else if (isLast) {
+    // Just move the node after its parent.
+    transform.moveNodeByKey(key, parentParent.key, parentIndex + 1, options)
+  }
+
+  else {
+    const parentPath = document.getPath(parent.key)
+    // Split the parent.
+    transform.splitNodeOperation(parentPath, index)
+    // Extract the node in between the splitted parent.
+    transform.moveNodeByKey(key, parentParent.key, parentIndex + 1, { normalize: false })
+
+    if (normalize) {
+      transform.normalizeNodeByKey(parentParent.key, SCHEMA)
+    }
+  }
+}
+
+/**
+ * Wrap a node in an inline with `properties`.
+ *
+ * @param {Transform} transform
+ * @param {String} key The node to wrap
+ * @param {Block|Object|String} inline The wrapping inline (its children are discarded)
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+Transforms.wrapInlineByKey = (transform, key, inline, options) => {
+  inline = Normalize.inline(inline)
+  inline = inline.set('nodes', inline.nodes.clear())
+
+  const { document } = transform.state
+  const node = document.assertDescendant(key)
+  const parent = document.getParent(node.key)
+  const index = parent.nodes.indexOf(node)
+
+  transform.insertNodeByKey(parent.key, index, inline, { normalize: false })
+  transform.moveNodeByKey(node.key, inline.key, 0, options)
+}
+
+/**
+ * Wrap a node in a block with `properties`.
+ *
+ * @param {Transform} transform
+ * @param {String} key The node to wrap
+ * @param {Block|Object|String} block The wrapping block (its children are discarded)
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+Transforms.wrapBlockByKey = (transform, key, block, options) => {
+  block = Normalize.block(block)
+  block = block.set('nodes', block.nodes.clear())
+
+  const { document } = transform.state
+  const node = document.assertDescendant(key)
+  const parent = document.getParent(node.key)
+  const index = parent.nodes.indexOf(node)
+
+  transform.insertNodeByKey(parent.key, index, block, { normalize: false })
+  transform.moveNodeByKey(node.key, block.key, 0, options)
+}
+
+/**
+ * Export.
+ *
+ * @type {Object}
+ */
+
+export default Transforms

--- a/src/lib/slate/transforms/call.js
+++ b/src/lib/slate/transforms/call.js
@@ -1,0 +1,30 @@
+
+/**
+ * Transforms.
+ *
+ * @type {Object}
+ */
+
+const Transforms = {}
+
+/**
+ * Call a `fn` as if it was a core transform. This is a convenience method to
+ * make using non-core transforms easier to read and chain.
+ *
+ * @param {Transform} transform
+ * @param {Function} fn
+ * @param {Mixed} ...args
+ */
+
+Transforms.call = (transform, fn, ...args) => {
+  fn(transform, ...args)
+  return
+}
+
+/**
+ * Export.
+ *
+ * @type {Object}
+ */
+
+export default Transforms

--- a/src/lib/slate/transforms/index.js
+++ b/src/lib/slate/transforms/index.js
@@ -1,0 +1,28 @@
+
+import ApplyOperation from './apply-operation'
+import AtCurrentRange from './at-current-range'
+import AtRange from './at-range'
+import ByKey from './by-key'
+import Call from './call'
+import Normalize from './normalize'
+import OnHistory from './on-history'
+import OnSelection from './on-selection'
+import Operations from './operations'
+
+/**
+ * Export.
+ *
+ * @type {Object}
+ */
+
+export default {
+  ...ApplyOperation,
+  ...AtCurrentRange,
+  ...AtRange,
+  ...ByKey,
+  ...Call,
+  ...Normalize,
+  ...OnHistory,
+  ...OnSelection,
+  ...Operations,
+}

--- a/src/lib/slate/transforms/normalize.js
+++ b/src/lib/slate/transforms/normalize.js
@@ -1,0 +1,243 @@
+
+import Normalize from '../utils/normalize'
+import Schema from '../models/schema'
+import warn from '../utils/warn'
+import { Set } from 'immutable'
+
+/**
+ * Transforms.
+ *
+ * @type {Object}
+ */
+
+const Transforms = {}
+
+/**
+ * Normalize the document and selection with a `schema`.
+ *
+ * @param {Transform} transform
+ * @param {Schema} schema
+ */
+
+Transforms.normalize = (transform, schema) => {
+  transform.normalizeDocument(schema)
+  transform.normalizeSelection(schema)
+}
+
+/**
+ * Normalize the document with a `schema`.
+ *
+ * @param {Transform} transform
+ * @param {Schema} schema
+ */
+
+Transforms.normalizeDocument = (transform, schema) => {
+  const { state } = transform
+  const { document } = state
+  transform.normalizeNodeByKey(document.key, schema)
+}
+
+/**
+ * Normalize a `node` and its children with a `schema`.
+ *
+ * @param {Transform} transform
+ * @param {Node|String} key
+ * @param {Schema} schema
+ */
+
+Transforms.normalizeNodeByKey = (transform, key, schema) => {
+  assertSchema(schema)
+
+  // If the schema has no validation rules, there's nothing to normalize.
+  if (!schema.hasValidators) return
+
+  key = Normalize.key(key)
+  const { state } = transform
+  const { document } = state
+  const node = document.assertNode(key)
+
+  normalizeNodeAndChildren(transform, node, schema)
+}
+
+/**
+ * Normalize the selection.
+ *
+ * @param {Transform} transform
+ */
+
+Transforms.normalizeSelection = (transform) => {
+  let { state } = transform
+  let { document, selection } = state
+
+  // If document is empty, return
+  if (document.nodes.size === 0) {
+    return
+  }
+
+  selection = selection.normalize(document)
+
+  // If the selection is unset, or the anchor or focus key in the selection are
+  // pointing to nodes that no longer exist, warn (if not unset) and reset the selection.
+  if (
+    selection.isUnset ||
+    !document.hasDescendant(selection.anchorKey) ||
+    !document.hasDescendant(selection.focusKey)
+  ) {
+    if (!selection.isUnset) {
+      warn('The selection was invalid and was reset to start of the document. The selection in question was:', selection)
+    }
+
+    const firstText = document.getFirstText()
+    selection = selection.merge({
+      anchorKey: firstText.key,
+      anchorOffset: 0,
+      focusKey: firstText.key,
+      focusOffset: 0,
+      isBackward: false
+    })
+  }
+
+  state = state.set('selection', selection)
+  transform.state = state
+}
+
+/**
+ * Normalize a `node` and its children with a `schema`.
+ *
+ * @param {Transform} transform
+ * @param {Node} node
+ * @param {Schema} schema
+ */
+
+function normalizeNodeAndChildren(transform, node, schema) {
+  if (node.kind == 'text') {
+    normalizeNode(transform, node, schema)
+    return
+  }
+
+  // We can't just loop the children and normalize them, because in the process
+  // of normalizing one child, we might end up creating another. Instead, we
+  // have to normalize one at a time, and check for new children along the way.
+  // PERF: use a mutable array here instead of an immutable stack.
+  const keys = node.nodes.toArray().map(n => n.key)
+
+  // While there is still a child key that hasn't been normalized yet...
+  while (keys.length) {
+    const ops = transform.operations.length
+    let key
+
+    // PERF: use a mutable set here since we'll be add to it a lot.
+    let set = new Set().asMutable()
+
+    // Unwind the stack, normalizing every child and adding it to the set.
+    while (key = keys[0]) {
+      const child = node.getChild(key)
+      normalizeNodeAndChildren(transform, child, schema)
+      set.add(key)
+      keys.shift()
+    }
+
+    // Turn the set immutable to be able to compare against it.
+    set = set.asImmutable()
+
+    // PERF: Only re-find the node and re-normalize any new children if
+    // operations occured that might have changed it.
+    if (transform.operations.length != ops) {
+      node = refindNode(transform, node)
+
+      // Add any new children back onto the stack.
+      node.nodes.forEach((n) => {
+        if (set.has(n.key)) return
+        keys.unshift(n.key)
+      })
+    }
+  }
+
+  // Normalize the node itself if it still exists.
+  if (node) {
+    normalizeNode(transform, node, schema)
+  }
+}
+
+/**
+ * Re-find a reference to a node that may have been modified or removed
+ * entirely by a transform.
+ *
+ * @param {Transform} transform
+ * @param {Node} node
+ * @return {Node}
+ */
+
+function refindNode(transform, node) {
+  const { state } = transform
+  const { document } = state
+  return node.kind == 'document'
+    ? document
+    : document.getDescendant(node.key)
+}
+
+/**
+ * Normalize a `node` with a `schema`, but not its children.
+ *
+ * @param {Transform} transform
+ * @param {Node} node
+ * @param {Schema} schema
+ */
+
+function normalizeNode(transform, node, schema) {
+  const max = schema.rules.length
+  let iterations = 0
+
+  function iterate(t, n) {
+    const failure = n.validate(schema)
+    if (!failure) return
+
+    // Run the `normalize` function for the rule with the invalid value.
+    const { value, rule } = failure
+    rule.normalize(t, n, value)
+
+    // Re-find the node reference, in case it was updated. If the node no longer
+    // exists, we're done for this branch.
+    n = refindNode(t, n)
+    if (!n) return
+
+    // Increment the iterations counter, and check to make sure that we haven't
+    // exceeded the max. Without this check, it's easy for the `validate` or
+    // `normalize` function of a schema rule to be written incorrectly and for
+    // an infinite invalid loop to occur.
+    iterations++
+
+    if (iterations > max) {
+      throw new Error('A schema rule could not be validated after sufficient iterations. This is usually due to a `rule.validate` or `rule.normalize` function of a schema being incorrectly written, causing an infinite loop.')
+    }
+
+    // Otherwise, iterate again.
+    iterate(t, n)
+  }
+
+  iterate(transform, node)
+}
+
+/**
+ * Assert that a `schema` exists.
+ *
+ * @param {Schema} schema
+ */
+
+function assertSchema(schema) {
+  if (schema instanceof Schema) {
+    return
+  } else if (schema == null) {
+    throw new Error('You must pass a `schema` object.')
+  } else {
+    throw new Error(`You passed an invalid \`schema\` object: ${schema}.`)
+  }
+}
+
+/**
+ * Export.
+ *
+ * @type {Object}
+ */
+
+export default Transforms

--- a/src/lib/slate/transforms/on-history.js
+++ b/src/lib/slate/transforms/on-history.js
@@ -1,0 +1,122 @@
+
+/**
+ * Transforms.
+ *
+ * @type {Object}
+ */
+
+const Transforms = {}
+
+/**
+ * Redo to the next state in the history.
+ *
+ * @param {Transform} transform
+ */
+
+Transforms.redo = (transform) => {
+  let { state } = transform
+  let { history } = state
+  let { undos, redos } = history
+
+  // If there's no next snapshot, abort.
+  const next = redos.peek()
+  if (!next) return
+
+  // Shift the next state into the undo stack.
+  redos = redos.pop()
+  undos = undos.push(next)
+
+  // Replay the next operations.
+  next.forEach((op) => {
+    transform.applyOperation(op)
+  })
+
+  // Update the history.
+  state = transform.state
+  history = history.set('undos', undos).set('redos', redos)
+  state = state.set('history', history)
+
+  // Update the transform.
+  transform.state = state
+}
+
+/**
+ * Save the operations into the history.
+ *
+ * @param {Transform} transform
+ * @param {Object} options
+ */
+
+Transforms.save = (transform, options = {}) => {
+  const { merge = false } = options
+  let { state, operations } = transform
+  let { history } = state
+  let { undos, redos } = history
+  let previous = undos.peek()
+
+  // If there are no operations, abort.
+  if (!operations.length) return
+
+  // Create a new save point or merge the operations into the previous one.
+  if (merge && previous) {
+    undos = undos.pop()
+    previous = previous.concat(operations)
+    undos = undos.push(previous)
+  } else {
+    undos = undos.push(operations)
+  }
+
+  // Clear the redo stack and constrain the undos stack.
+  if (undos.size > 100) undos = undos.take(100)
+  redos = redos.clear()
+
+  // Update the state.
+  history = history.set('undos', undos).set('redos', redos)
+  state = state.set('history', history)
+
+  // Update the transform.
+  transform.state = state
+}
+
+/**
+ * Undo the previous operations in the history.
+ *
+ * @param {Transform} transform
+ */
+
+Transforms.undo = (transform) => {
+  let { state } = transform
+  let { history } = state
+  let { undos, redos } = history
+
+  // If there's no previous snapshot, abort.
+  const previous = undos.peek()
+  if (!previous) return
+
+  // Shift the previous operations into the redo stack.
+  undos = undos.pop()
+  redos = redos.push(previous)
+
+  // Replay the inverse of the previous operations.
+  previous.slice().reverse().forEach((op) => {
+    op.inverse.forEach((inv) => {
+      transform.applyOperation(inv)
+    })
+  })
+
+  // Update the history.
+  state = transform.state
+  history = history.set('undos', undos).set('redos', redos)
+  state = state.set('history', history)
+
+  // Update the transform.
+  transform.state = state
+}
+
+/**
+ * Export.
+ *
+ * @type {Object}
+ */
+
+export default Transforms

--- a/src/lib/slate/transforms/on-selection.js
+++ b/src/lib/slate/transforms/on-selection.js
@@ -1,0 +1,233 @@
+
+import warn from '../utils/warn'
+
+/**
+ * Transforms.
+ *
+ * @type {Object}
+ */
+
+const Transforms = {}
+
+/**
+ * Set `properties` on the selection.
+ *
+ * @param {Transform} transform
+ * @param {Object} properties
+ */
+
+Transforms.select = (transform, properties) => {
+  transform.setSelectionOperation(properties)
+}
+
+/**
+ * Selects the whole selection.
+ *
+ * @param {Transform} transform
+ * @param {Object} properties
+ */
+
+Transforms.selectAll = (transform) => {
+  const { state } = transform
+  const { document, selection } = state
+  const next = selection.moveToRangeOf(document)
+  transform.setSelectionOperation(next)
+}
+
+/**
+ * Snapshot the current selection.
+ *
+ * @param {Transform} transform
+ */
+
+Transforms.snapshotSelection = (transform) => {
+  const { state } = transform
+  const { selection } = state
+  transform.setSelectionOperation(selection, { snapshot: true })
+}
+
+/**
+ * Set `properties` on the selection.
+ *
+ * @param {Mixed} ...args
+ * @param {Transform} transform
+ */
+
+Transforms.moveTo = (transform, properties) => {
+  warn('The `moveTo()` transform is deprecated, please use `select()` instead.')
+  transform.select(properties)
+}
+
+/**
+ * Unset the selection's marks.
+ *
+ * @param {Transform} transform
+ */
+
+Transforms.unsetMarks = (transform) => {
+  warn('The `unsetMarks()` transform is deprecated.')
+  transform.setSelectionOperation({ marks: null })
+}
+
+/**
+ * Unset the selection, removing an association to a node.
+ *
+ * @param {Transform} transform
+ */
+
+Transforms.unsetSelection = (transform) => {
+  warn('The `unsetSelection()` transform is deprecated, please use `deselect()` instead.')
+  transform.setSelectionOperation({
+    anchorKey: null,
+    anchorOffset: 0,
+    focusKey: null,
+    focusOffset: 0,
+    isFocused: false,
+    isBackward: false
+  })
+}
+
+/**
+ * Mix in selection transforms that are just a proxy for the selection method.
+ */
+
+const PROXY_TRANSFORMS = [
+  'blur',
+  'collapseTo',
+  'collapseToAnchor',
+  'collapseToEnd',
+  'collapseToEndOf',
+  'collapseToFocus',
+  'collapseToStart',
+  'collapseToStartOf',
+  'extend',
+  'extendTo',
+  'extendToEndOf',
+  'extendToStartOf',
+  'flip',
+  'focus',
+  'move',
+  'moveAnchor',
+  'moveAnchorOffsetTo',
+  'moveAnchorTo',
+  'moveAnchorToEndOf',
+  'moveAnchorToStartOf',
+  'moveEnd',
+  'moveEndOffsetTo',
+  'moveEndTo',
+  'moveFocus',
+  'moveFocusOffsetTo',
+  'moveFocusTo',
+  'moveFocusToEndOf',
+  'moveFocusToStartOf',
+  'moveOffsetsTo',
+  'moveStart',
+  'moveStartOffsetTo',
+  'moveStartTo',
+  // 'moveTo', Commented out for now, since it conflicts with a deprecated one.
+  'moveToEnd',
+  'moveToEndOf',
+  'moveToRangeOf',
+  'moveToStart',
+  'moveToStartOf',
+  'deselect',
+]
+
+PROXY_TRANSFORMS.forEach((method) => {
+  Transforms[method] = (transform, ...args) => {
+    const normalize = method != 'deselect'
+    const { state } = transform
+    const { document, selection } = state
+    let next = selection[method](...args)
+    if (normalize) next = next.normalize(document)
+    transform.setSelectionOperation(next)
+  }
+})
+
+/**
+ * Mix in node-related transforms.
+ */
+
+const PREFIXES = [
+  'moveTo',
+  'collapseTo',
+  'extendTo',
+]
+
+const DIRECTIONS = [
+  'Next',
+  'Previous',
+]
+
+const KINDS = [
+  'Block',
+  'Inline',
+  'Text',
+]
+
+PREFIXES.forEach((prefix) => {
+  const edges = [
+    'Start',
+    'End',
+  ]
+
+  if (prefix == 'moveTo') {
+    edges.push('Range')
+  }
+
+  edges.forEach((edge) => {
+    DIRECTIONS.forEach((direction) => {
+      KINDS.forEach((kind) => {
+        const get = `get${direction}${kind}`
+        const getAtRange = `get${kind}sAtRange`
+        const index = direction == 'Next' ? 'last' : 'first'
+        const method = `${prefix}${edge}Of`
+        const name = `${method}${direction}${kind}`
+
+        Transforms[name] = (transform) => {
+          const { state } = transform
+          const { document, selection } = state
+          const nodes = document[getAtRange](selection)
+          const node = nodes[index]()
+          const target = document[get](node.key)
+          if (!target) return
+          const next = selection[method](target)
+          transform.setSelectionOperation(next)
+        }
+      })
+    })
+  })
+})
+
+/**
+ * Mix in deprecated transforms with a warning.
+ */
+
+const DEPRECATED_TRANSFORMS = [
+  ['extendBackward', 'extend', 'The `extendBackward(n)` transform is deprecated, please use `extend(n)` instead with a negative offset.'],
+  ['extendForward', 'extend', 'The `extendForward(n)` transform is deprecated, please use `extend(n)` instead.'],
+  ['moveBackward', 'move', 'The `moveBackward(n)` transform is deprecated, please use `move(n)` instead with a negative offset.'],
+  ['moveForward', 'move', 'The `moveForward(n)` transform is deprecated, please use `move(n)` instead.'],
+  ['moveStartOffset', 'moveStart', 'The `moveStartOffset(n)` transform is deprecated, please use `moveStart(n)` instead.'],
+  ['moveEndOffset', 'moveEnd', 'The `moveEndOffset(n)` transform is deprecated, please use `moveEnd()` instead.'],
+  ['moveToOffsets', 'moveOffsetsTo', 'The `moveToOffsets()` transform is deprecated, please use `moveOffsetsTo()` instead.'],
+  ['flipSelection', 'flip', 'The `flipSelection()` transform is deprecated, please use `flip()` instead.'],
+]
+
+DEPRECATED_TRANSFORMS.forEach(([ old, current, warning ]) => {
+  Transforms[old] = (transform, ...args) => {
+    warn(warning)
+    const { state } = transform
+    const { document, selection } = state
+    const sel = selection[current](...args).normalize(document)
+    transform.setSelectionOperation(sel)
+  }
+})
+
+/**
+ * Export.
+ *
+ * @type {Object}
+ */
+
+export default Transforms

--- a/src/lib/slate/transforms/operations.js
+++ b/src/lib/slate/transforms/operations.js
@@ -1,0 +1,502 @@
+
+import Normalize from '../utils/normalize'
+
+/**
+ * Transforms.
+ *
+ * @type {Object}
+ */
+
+const Transforms = {}
+
+/**
+ * Add mark to text at `offset` and `length` in node by `path`.
+ *
+ * @param {Transform} transform
+ * @param {Array} path
+ * @param {Number} offset
+ * @param {Number} length
+ * @param {Mixed} mark
+ */
+
+Transforms.addMarkOperation = (transform, path, offset, length, mark) => {
+  const inverse = [{
+    type: 'remove_mark',
+    path,
+    offset,
+    length,
+    mark,
+  }]
+
+  const operation = {
+    type: 'add_mark',
+    path,
+    offset,
+    length,
+    mark,
+    inverse,
+  }
+
+  transform.applyOperation(operation)
+}
+
+/**
+ * Insert a `node` at `index` in a node by `path`.
+ *
+ * @param {Transform} transform
+ * @param {Array} path
+ * @param {Number} index
+ * @param {Node} node
+ */
+
+Transforms.insertNodeOperation = (transform, path, index, node) => {
+  const inversePath = path.slice().concat([index])
+  const inverse = [{
+    type: 'remove_node',
+    path: inversePath,
+  }]
+
+  const operation = {
+    type: 'insert_node',
+    path,
+    index,
+    node,
+    inverse,
+  }
+
+  transform.applyOperation(operation)
+}
+
+/**
+ * Insert `text` at `offset` in node by `path`.
+ *
+ * @param {Transform} transform
+ * @param {Array} path
+ * @param {Number} offset
+ * @param {String} text
+ * @param {Set<Mark>} marks (optional)
+ */
+
+Transforms.insertTextOperation = (transform, path, offset, text, marks) => {
+  const inverseLength = text.length
+  const inverse = [{
+    type: 'remove_text',
+    path,
+    offset,
+    length: inverseLength,
+  }]
+
+  const operation = {
+    type: 'insert_text',
+    path,
+    offset,
+    text,
+    marks,
+    inverse,
+  }
+
+  transform.applyOperation(operation)
+}
+
+/**
+ * Join a node by `path` with a node `withPath`.
+ *
+ * @param {Transform} transform
+ * @param {Array} path
+ * @param {Array} withPath
+ */
+
+Transforms.joinNodeOperation = (transform, path, withPath) => {
+  const { state } = transform
+  const { document } = state
+  const node = document.assertPath(withPath)
+
+  let inverse
+  if (node.kind === 'text') {
+    const offset = node.length
+
+    inverse = [{
+      type: 'split_node',
+      path: withPath,
+      offset,
+    }]
+  } else {
+    // The number of children after which we split
+    const count = node.nodes.count()
+
+    inverse = [{
+      type: 'split_node',
+      path: withPath,
+      count,
+    }]
+  }
+
+  const operation = {
+    type: 'join_node',
+    path,
+    withPath,
+    inverse,
+  }
+
+  transform.applyOperation(operation)
+}
+
+/**
+ * Move a node by `path` to a `newPath` and `newIndex`.
+ *
+ * @param {Transform} transform
+ * @param {Array} path
+ * @param {Array} newPath
+ * @param {Number} newIndex
+ */
+
+Transforms.moveNodeOperation = (transform, path, newPath, newIndex) => {
+  const parentPath = path.slice(0, -1)
+  const parentIndex = path[path.length - 1]
+  const inversePath = newPath.slice().concat([newIndex])
+
+  const inverse = [{
+    type: 'move_node',
+    path: inversePath,
+    newPath: parentPath,
+    newIndex: parentIndex,
+  }]
+
+  const operation = {
+    type: 'move_node',
+    path,
+    newPath,
+    newIndex,
+    inverse,
+  }
+
+  transform.applyOperation(operation)
+}
+
+/**
+ * Remove mark from text at `offset` and `length` in node by `path`.
+ *
+ * @param {Transform} transform
+ * @param {Array} path
+ * @param {Number} offset
+ * @param {Number} length
+ * @param {Mark} mark
+ */
+
+Transforms.removeMarkOperation = (transform, path, offset, length, mark) => {
+  const inverse = [{
+    type: 'add_mark',
+    path,
+    offset,
+    length,
+    mark,
+  }]
+
+  const operation = {
+    type: 'remove_mark',
+    path,
+    offset,
+    length,
+    mark,
+    inverse,
+  }
+
+  transform.applyOperation(operation)
+}
+
+/**
+ * Remove a node by `path`.
+ *
+ * @param {Transform} transform
+ * @param {Array} path
+ */
+
+Transforms.removeNodeOperation = (transform, path) => {
+  const { state } = transform
+  const { document } = state
+  const node = document.assertPath(path)
+  const inversePath = path.slice(0, -1)
+  const inverseIndex = path[path.length - 1]
+
+  const inverse = [{
+    type: 'insert_node',
+    path: inversePath,
+    index: inverseIndex,
+    node,
+  }]
+
+  const operation = {
+    type: 'remove_node',
+    path,
+    inverse,
+  }
+
+  transform.applyOperation(operation)
+}
+
+/**
+ * Remove text at `offset` and `length` in node by `path`.
+ *
+ * @param {Transform} transform
+ * @param {Array} path
+ * @param {Number} offset
+ * @param {Number} length
+ */
+
+Transforms.removeTextOperation = (transform, path, offset, length) => {
+  const { state } = transform
+  const { document } = state
+  const node = document.assertPath(path)
+  const ranges = node.getRanges()
+  const inverse = []
+
+  // Loop the ranges of text in the node, creating inverse insert operations for
+  // each of the ranges that overlap with the remove operation. This is
+  // necessary because insert's can only have a single set of marks associated
+  // with them, but removes can remove many.
+  ranges.reduce((start, range) => {
+    const { text, marks } = range
+    const end = start + text.length
+    if (start > offset + length) return end
+    if (end <= offset) return end
+
+    const endOffset = Math.min(end, offset + length)
+    const string = text.slice(offset - start, endOffset - start)
+
+    inverse.push({
+      type: 'insert_text',
+      path,
+      offset,
+      text: string,
+      marks,
+    })
+
+    return end
+  }, 0)
+
+  const operation = {
+    type: 'remove_text',
+    path,
+    offset,
+    length,
+    inverse,
+  }
+
+  transform.applyOperation(operation)
+}
+
+/**
+ * Set `properties` on mark on text at `offset` and `length` in node by `path`.
+ *
+ * @param {Transform} transform
+ * @param {Array} path
+ * @param {Number} offset
+ * @param {Number} length
+ * @param {Mark} mark
+ * @param {Mark} newMark
+ */
+
+Transforms.setMarkOperation = (transform, path, offset, length, mark, newMark) => {
+  const inverse = [{
+    type: 'set_mark',
+    path,
+    offset,
+    length,
+    mark: newMark,
+    newMark: mark
+  }]
+
+  const operation = {
+    type: 'set_mark',
+    path,
+    offset,
+    length,
+    mark,
+    newMark,
+    inverse,
+  }
+
+  transform.applyOperation(operation)
+}
+
+/**
+ * Set `properties` on a node by `path`.
+ *
+ * @param {Transform} transform
+ * @param {Array} path
+ * @param {Object} properties
+ */
+
+Transforms.setNodeOperation = (transform, path, properties) => {
+  const { state } = transform
+  const { document } = state
+  const node = document.assertPath(path)
+  const inverseProps = {}
+
+  for (const k in properties) {
+    inverseProps[k] = node[k]
+  }
+
+  const inverse = [{
+    type: 'set_node',
+    path,
+    properties: inverseProps
+  }]
+
+  const operation = {
+    type: 'set_node',
+    path,
+    properties,
+    inverse,
+  }
+
+  transform.applyOperation(operation)
+}
+
+/**
+ * Set the selection to a new `selection`.
+ *
+ * @param {Transform} transform
+ * @param {Mixed} selection
+ */
+
+Transforms.setSelectionOperation = (transform, properties, options = {}) => {
+  properties = Normalize.selectionProperties(properties)
+
+  const { state } = transform
+  const { document, selection } = state
+  const prevProps = {}
+  const props = {}
+
+  // Remove any properties that are already equal to the current selection. And
+  // create a dictionary of the previous values for all of the properties that
+  // are being changed, for the inverse operation.
+  for (const k in properties) {
+    if (!options.snapshot && properties[k] == selection[k]) continue
+    props[k] = properties[k]
+    prevProps[k] = selection[k]
+  }
+
+  // If the selection moves, clear any marks, unless the new selection
+  // does change the marks in some way
+  const moved = [
+    'anchorKey',
+    'anchorOffset',
+    'focusKey',
+    'focusOffset',
+  ].some(p => props.hasOwnProperty(p))
+
+  if (
+    selection.marks &&
+    properties.marks == selection.marks &&
+    moved
+  ) {
+    props.marks = null
+  }
+
+  // Resolve the selection keys into paths.
+  if (props.anchorKey) {
+    props.anchorPath = document.getPath(props.anchorKey)
+    delete props.anchorKey
+  }
+
+  if (prevProps.anchorKey) {
+    prevProps.anchorPath = document.getPath(prevProps.anchorKey)
+    delete prevProps.anchorKey
+  }
+
+  if (props.focusKey) {
+    props.focusPath = document.getPath(props.focusKey)
+    delete props.focusKey
+  }
+
+  if (prevProps.focusKey) {
+    prevProps.focusPath = document.getPath(prevProps.focusKey)
+    delete prevProps.focusKey
+  }
+
+  // Define an inverse of the operation for undoing.
+  const inverse = [{
+    type: 'set_selection',
+    properties: prevProps
+  }]
+
+  // Define the operation.
+  const operation = {
+    type: 'set_selection',
+    properties: props,
+    inverse,
+  }
+
+  // Apply the operation.
+  transform.applyOperation(operation)
+}
+
+/**
+ * Split a node by `path` at `offset`.
+ *
+ * @param {Transform} transform
+ * @param {Array} path
+ * @param {Number} offset
+ */
+
+Transforms.splitNodeAtOffsetOperation = (transform, path, offset) => {
+  const inversePath = path.slice()
+  inversePath[path.length - 1] += 1
+
+  const inverse = [{
+    type: 'join_node',
+    path: inversePath,
+    withPath: path,
+    // We will split down to the text nodes, so we must join nodes recursively.
+    deep: true
+  }]
+
+  const operation = {
+    type: 'split_node',
+    path,
+    offset,
+    count: null,
+    inverse,
+  }
+
+  transform.applyOperation(operation)
+}
+
+/**
+ * Split a node by `path` after its 'count' child.
+ *
+ * @param {Transform} transform
+ * @param {Array} path
+ * @param {Number} count
+ */
+
+Transforms.splitNodeOperation = (transform, path, count) => {
+  const inversePath = path.slice()
+  inversePath[path.length - 1] += 1
+
+  const inverse = [{
+    type: 'join_node',
+    path: inversePath,
+    withPath: path,
+    deep: false
+  }]
+
+  const operation = {
+    type: 'split_node',
+    path,
+    offset: null,
+    count,
+    inverse,
+  }
+
+  transform.applyOperation(operation)
+}
+
+/**
+ * Export.
+ *
+ * @type {Object}
+ */
+
+export default Transforms

--- a/src/lib/slate/utils/Readme.md
+++ b/src/lib/slate/utils/Readme.md
@@ -1,0 +1,2 @@
+
+This directory contains a series of utilities that Slate uses internally. They're pulled out here to re-use code and to enforce consistency. You'll have to read the source to see what they do, but it's all commented so don't worry!

--- a/src/lib/slate/utils/extend-selection.js
+++ b/src/lib/slate/utils/extend-selection.js
@@ -1,0 +1,45 @@
+
+/**
+ * Extends the given selection to a given node and offset
+ *
+ * @param {Selection} selection Selection instance
+ * @param {Element} el Node to extend to
+ * @param {Number} offset Text offset to extend to
+ * @returns {Selection} Mutated Selection instance
+ */
+
+function extendSelection(selection, el, offset) {
+  // Use native method when possible
+  if (typeof selection.extend === 'function') return selection.extend(el, offset)
+
+  // See https://gist.github.com/tyler-johnson/0a3e8818de3f115b2a2dc47468ac0099
+  const range = document.createRange()
+  const anchor = document.createRange()
+  anchor.setStart(selection.anchorNode, selection.anchorOffset)
+
+  const focus = document.createRange()
+  focus.setStart(el, offset)
+
+  const v = focus.compareBoundaryPoints(Range.START_TO_START, anchor)
+  if (v >= 0) { // Focus is after anchor
+    range.setStart(selection.anchorNode, selection.anchorOffset)
+    range.setEnd(el, offset)
+  } else { // Anchor is after focus
+    range.setStart(el, offset)
+    range.setEnd(selection.anchorNode, selection.anchorOffset)
+  }
+
+  selection.removeAllRanges()
+  selection.addRange(range)
+
+  return selection
+}
+
+
+/**
+ * Export.
+ *
+ * @type {Function}
+ */
+
+export default extendSelection

--- a/src/lib/slate/utils/find-closest-node.js
+++ b/src/lib/slate/utils/find-closest-node.js
@@ -1,0 +1,32 @@
+
+/**
+ * Find the closest ancestor of a DOM `element` that matches a given selector.
+ *
+ * @param {Element} node
+ * @param {String} selector
+ * @return {Element}
+ */
+
+function findClosestNode(node, selector) {
+  if (typeof node.closest === 'function') return node.closest(selector)
+
+  // See https://developer.mozilla.org/en-US/docs/Web/API/Element/closest#Polyfill
+  const matches = (node.document || node.ownerDocument).querySelectorAll(selector)
+  let i
+  let parentNode = node
+  do {
+    i = matches.length
+    while (--i >= 0 && matches.item(i) !== parentNode);
+  }
+  while ((i < 0) && (parentNode = parentNode.parentElement))
+
+  return parentNode
+}
+
+/**
+ * Export.
+ *
+ * @type {Function}
+ */
+
+export default findClosestNode

--- a/src/lib/slate/utils/find-deepest-node.js
+++ b/src/lib/slate/utils/find-deepest-node.js
@@ -1,0 +1,21 @@
+
+/**
+ * Find the deepest descendant of a DOM `element`.
+ *
+ * @param {Element} node
+ * @return {Element}
+ */
+
+function findDeepestNode(element) {
+  return element.firstChild
+    ? findDeepestNode(element.firstChild)
+    : element
+}
+
+/**
+ * Export.
+ *
+ * @type {Function}
+ */
+
+export default findDeepestNode

--- a/src/lib/slate/utils/find-dom-node.js
+++ b/src/lib/slate/utils/find-dom-node.js
@@ -1,0 +1,27 @@
+
+/**
+ * Find the DOM node for a `node`.
+ *
+ * @param {Node} node
+ * @return {Element}
+ */
+
+function findDOMNode(node) {
+  const el = window.document.querySelector(`[data-key="${node.key}"]`)
+
+  if (!el) {
+    throw new Error(`Unable to find a DOM node for "${node.key}". This is
+often because of forgetting to add \`props.attributes\` to a component
+returned from \`renderNode\`.`)
+  }
+
+  return el
+}
+
+/**
+ * Export.
+ *
+ * @type {Function}
+ */
+
+export default findDOMNode

--- a/src/lib/slate/utils/generate-key.js
+++ b/src/lib/slate/utils/generate-key.js
@@ -1,0 +1,63 @@
+
+/**
+ * An auto-incrementing index for generating keys.
+ *
+ * @type {Number}
+ */
+
+let n
+
+/**
+ * The global key generating function.
+ *
+ * @type {Function}
+ */
+
+let generate
+
+/**
+ * Generate a key.
+ *
+ * @return {String}
+ */
+
+function generateKey() {
+  return generate()
+}
+
+/**
+ * Set a different unique ID generating `function`.
+ *
+ * @param {Function} func
+ */
+
+function setKeyGenerator(func) {
+  generate = func
+}
+
+/**
+ * Reset the key generating function to its initial state.
+ */
+
+function resetKeyGenerator() {
+  n = 0
+  generate = () => `${n++}`
+}
+
+/**
+ * Set the initial state.
+ */
+
+resetKeyGenerator()
+
+/**
+ * Export.
+ *
+ * @type {Object}
+ */
+
+export {
+  generateKey as default,
+  setKeyGenerator,
+  resetKeyGenerator
+}

--- a/src/lib/slate/utils/get-point.js
+++ b/src/lib/slate/utils/get-point.js
@@ -1,0 +1,41 @@
+
+import OffsetKey from './offset-key'
+
+/**
+ * Get a point from a native selection's DOM `element` and `offset`.
+ *
+ * @param {Element} element
+ * @param {Number} offset
+ * @param {State} state
+ * @param {Editor} editor
+ * @return {Object}
+ */
+
+function getPoint(element, offset, state, editor) {
+  const { document } = state
+  const schema = editor.getSchema()
+
+  // If we can't find an offset key, we can't get a point.
+  const offsetKey = OffsetKey.findKey(element, offset)
+  if (!offsetKey) return null
+
+  // COMPAT: If someone is clicking from one Slate editor into another, the
+  // select event fires two, once for the old editor's `element` first, and
+  // then afterwards for the correct `element`. (2017/03/03)
+  const { key } = offsetKey
+  const node = document.getDescendant(key)
+  if (!node) return null
+
+  const decorators = document.getDescendantDecorators(key, schema)
+  const ranges = node.getRanges(decorators)
+  const point = OffsetKey.findPoint(offsetKey, ranges)
+  return point
+}
+
+/**
+ * Export.
+ *
+ * @type {Function}
+ */
+
+export default getPoint

--- a/src/lib/slate/utils/get-transfer-data.js
+++ b/src/lib/slate/utils/get-transfer-data.js
@@ -1,0 +1,89 @@
+
+import Base64 from '../serializers/base-64'
+import TYPES from '../constants/types'
+
+/**
+ * Fragment matching regexp for HTML nodes.
+ *
+ * @type {RegExp}
+ */
+
+const FRAGMENT_MATCHER = / data-slate-fragment="([^\s]+)"/
+
+/**
+ * Get the data and type from a native data `transfer`.
+ *
+ * @param {DataTransfer} transfer
+ * @return {Object}
+ */
+
+function getTransferData(transfer) {
+  let fragment = transfer.getData(TYPES.FRAGMENT) || null
+  let node = transfer.getData(TYPES.NODE) || null
+  const html = transfer.getData('text/html') || null
+  const rich = transfer.getData('text/rtf') || null
+  const text = transfer.getData('text/plain') || null
+  let files
+
+  // If there isn't a fragment, but there is HTML, check to see if the HTML is
+  // actually an encoded fragment.
+  if (
+    !fragment &&
+    html &&
+    ~html.indexOf(' data-slate-fragment="')
+  ) {
+    const matches = FRAGMENT_MATCHER.exec(html)
+    const [ full, encoded ] = matches // eslint-disable-line no-unused-vars
+    if (encoded) fragment = encoded
+  }
+
+  // Decode a fragment or node if they exist.
+  if (fragment) fragment = Base64.deserializeNode(fragment)
+  if (node) node = Base64.deserializeNode(node)
+
+  // Get and normalize files if they exist.
+  if (transfer.items && transfer.items.length) {
+    files = Array.from(transfer.items)
+      .map(item => item.kind == 'file' ? item.getAsFile() : null)
+      .filter(exists => exists)
+  } else if (transfer.files && transfer.files.length) {
+    files = Array.from(transfer.files)
+  }
+
+  // Determine the type of the data.
+  const data = { files, fragment, html, node, rich, text }
+  data.type = getTransferType(data)
+  return data
+}
+
+/**
+ * Get the type of a transfer from its `data`.
+ *
+ * @param {Object} data
+ * @return {String}
+ */
+
+function getTransferType(data) {
+  if (data.fragment) return 'fragment'
+  if (data.node) return 'node'
+
+  // COMPAT: Microsoft Word adds an image of the selected text to the data.
+  // Since files are preferred over HTML or text, this would cause the type to
+  // be considered `files`. But it also adds rich text data so we can check
+  // for that and properly set the type to `html` or `text`. (2016/11/21)
+  if (data.rich && data.html) return 'html'
+  if (data.rich && data.text) return 'text'
+
+  if (data.files && data.files.length) return 'files'
+  if (data.html) return 'html'
+  if (data.text) return 'text'
+  return 'unknown'
+}
+
+/**
+ * Export.
+ *
+ * @type {Function}
+ */
+
+export default getTransferData

--- a/src/lib/slate/utils/is-in-range.js
+++ b/src/lib/slate/utils/is-in-range.js
@@ -1,0 +1,31 @@
+
+/**
+ * Check if an `index` of a `text` node is in a `range`.
+ *
+ * @param {Number} index
+ * @param {Text} text
+ * @param {Selection} range
+ * @return {Boolean}
+ */
+
+function isInRange(index, text, range) {
+  const { startKey, startOffset, endKey, endOffset } = range
+
+  if (text.key == startKey && text.key == endKey) {
+    return startOffset <= index && index < endOffset
+  } else if (text.key == startKey) {
+    return startOffset <= index
+  } else if (text.key == endKey) {
+    return index < endOffset
+  } else {
+    return true
+  }
+}
+
+/**
+ * Export.
+ *
+ * @type {Function}
+ */
+
+export default isInRange

--- a/src/lib/slate/utils/is-react-component.js
+++ b/src/lib/slate/utils/is-react-component.js
@@ -1,0 +1,23 @@
+
+/**
+ * Check if an `object` is a React component.
+ *
+ * @param {Object} object
+ * @return {Boolean}
+ */
+
+function isReactComponent(object) {
+  return (
+    object &&
+    object.prototype &&
+    object.prototype.isReactComponent
+  )
+}
+
+/**
+ * Export.
+ *
+ * @type {Function}
+ */
+
+export default isReactComponent

--- a/src/lib/slate/utils/memoize.js
+++ b/src/lib/slate/utils/memoize.js
@@ -1,0 +1,197 @@
+
+import Map from 'es6-map'
+import IS_DEV from '../constants/is-dev'
+
+/**
+ * GLOBAL: True if memoization should is enabled. Only effective when `IS_DEV`.
+ *
+ * @type {Boolean}
+ */
+
+let ENABLED = true
+
+/**
+ * GLOBAL: Changing this cache key will clear all previous cached results.
+ * Only effective when `IS_DEV`.
+ *
+ * @type {Number}
+ */
+
+let CACHE_KEY = 0
+
+/**
+ * The leaf node of a cache tree. Used to support variable argument length. A
+ * unique object, so that native Maps will key it by reference.
+ *
+ * @type {Object}
+ */
+
+const LEAF = {}
+
+/**
+ * A value to represent a memoized undefined value. Allows efficient value
+ * retrieval using Map.get only.
+ *
+ * @type {Object}
+ */
+
+const UNDEFINED = {}
+
+/**
+ * Default value for unset keys in native Maps
+ *
+ * @type {Undefined}
+ */
+
+const UNSET = undefined
+
+/**
+ * Memoize all of the `properties` on a `object`.
+ *
+ * @param {Object} object
+ * @param {Array} properties
+ * @return {Record}
+ */
+
+function memoize(object, properties, options = {}) {
+  const { takesArguments = true } = options
+
+  for (const property of properties) {
+    const original = object[property]
+
+    if (!original) {
+      throw new Error(`Object does not have a property named "${property}".`)
+    }
+
+    object[property] = function (...args) {
+      if (IS_DEV) {
+        // If memoization is disabled, call into the original method.
+        if (!ENABLED) return original.apply(this, args)
+
+        // If the cache key is different, previous caches must be cleared.
+        if (CACHE_KEY !== this.__cache_key) {
+          this.__cache_key = CACHE_KEY
+          this.__cache = new Map()
+        }
+      }
+
+      if (!this.__cache) {
+        this.__cache = new Map()
+      }
+
+      let cachedValue
+      let keys
+
+      if (takesArguments) {
+        keys = [property, ...args]
+        cachedValue = getIn(this.__cache, keys)
+      } else {
+        cachedValue = this.__cache.get(property)
+      }
+
+      // If we've got a result already, return it.
+      if (cachedValue !== UNSET) {
+        return cachedValue === UNDEFINED ? undefined : cachedValue
+      }
+
+      // Otherwise calculate what it should be once and cache it.
+      const value = original.apply(this, args)
+      const v = value === undefined ? UNDEFINED : value
+
+      if (takesArguments) {
+        this.__cache = setIn(this.__cache, keys, v)
+      } else {
+        this.__cache.set(property, v)
+      }
+
+      return value
+    }
+  }
+}
+
+/**
+ * Get a value at a key path in a tree of Map.
+ *
+ * If not set, returns UNSET.
+ * If the set value is undefined, returns UNDEFINED.
+ *
+ * @param {Map} map
+ * @param {Array} keys
+ * @return {Any|UNSET|UNDEFINED}
+ */
+
+function getIn(map, keys) {
+  for (const key of keys) {
+    map = map.get(key)
+    if (map === UNSET) return UNSET
+  }
+
+  return map.get(LEAF)
+}
+
+/**
+ * Set a value at a key path in a tree of Map, creating Maps on the go.
+ *
+ * @param {Map} map
+ * @param {Array} keys
+ * @param {Any} value
+ * @return {Map}
+ */
+
+function setIn(map, keys, value) {
+  let parent = map
+  let child
+
+  for (const key of keys) {
+    child = parent.get(key)
+
+    // If the path was not created yet...
+    if (child === UNSET) {
+      child = new Map()
+      parent.set(key, child)
+    }
+
+    parent = child
+  }
+
+  // The whole path has been created, so set the value to the bottom most map.
+  child.set(LEAF, value)
+  return map
+}
+
+/**
+ * In DEV mode, clears the previously memoized values, globally.
+ *
+ * @return {Void}
+ */
+
+function __clear() {
+  CACHE_KEY++
+
+  if (CACHE_KEY >= Number.MAX_SAFE_INTEGER) {
+    CACHE_KEY = 0
+  }
+}
+
+/**
+ * In DEV mode, enable or disable the use of memoize values, globally.
+ *
+ * @param {Boolean} enabled
+ * @return {Void}
+ */
+
+function __enable(enabled) {
+  ENABLED = enabled
+}
+
+/**
+ * Export.
+ *
+ * @type {Object}
+ */
+
+export {
+  memoize as default,
+  __clear,
+  __enable
+}

--- a/src/lib/slate/utils/noop.js
+++ b/src/lib/slate/utils/noop.js
@@ -1,0 +1,16 @@
+
+/**
+ * Noop.
+ *
+ * @return {Void}
+ */
+
+function noop() {}
+
+/**
+ * Export.
+ *
+ * @type {Function}
+ */
+
+export default noop

--- a/src/lib/slate/utils/normalize-node-and-offset.js
+++ b/src/lib/slate/utils/normalize-node-and-offset.js
@@ -1,0 +1,89 @@
+
+/**
+ * From a DOM selection's `node` and `offset`, normalize so that it always
+ * refers to a text node.
+ *
+ * @param {Element} node
+ * @param {Number} offset
+ * @return {Object}
+ */
+
+function normalizeNodeAndOffset(node, offset) {
+  // If it's an element node, its offset refers to the index of its children
+  // including comment nodes, so try to find the right text child node.
+  if (node.nodeType == 1 && node.childNodes.length) {
+    const isLast = offset == node.childNodes.length
+    const direction = isLast ? 'backward' : 'forward'
+    const index = isLast ? offset - 1 : offset
+    node = getEditableChild(node, index, direction)
+
+    // If the node has children, traverse until we have a leaf node. Leaf nodes
+    // can be either text nodes, or other void DOM nodes.
+    while (node.nodeType == 1 && node.childNodes.length) {
+      const i = isLast ? node.childNodes.length - 1 : 0
+      node = getEditableChild(node, i, direction)
+    }
+
+    // Determine the new offset inside the text node.
+    offset = isLast ? node.textContent.length : 0
+  }
+
+  // Return the node and offset.
+  return { node, offset }
+}
+
+/**
+ * Get the nearest editable child at `index` in a `parent`, preferring
+ * `direction`.
+ *
+ * @param {Element} parent
+ * @param {Number} index
+ * @param {String} direction ('forward' or 'backward')
+ * @return {Element|Null}
+ */
+
+function getEditableChild(parent, index, direction) {
+  const { childNodes } = parent
+  let child = childNodes[index]
+  let i = index
+  let triedForward = false
+  let triedBackward = false
+
+  // While the child is a comment node, or an element node with no children,
+  // keep iterating to find a sibling non-void, non-comment node.
+  while (
+    (child.nodeType == 8) ||
+    (child.nodeType == 1 && child.childNodes.length == 0) ||
+    (child.nodeType == 1 && child.getAttribute('contenteditable') == 'false')
+  ) {
+    if (triedForward && triedBackward) break
+
+    if (i >= childNodes.length) {
+      triedForward = true
+      i = index - 1
+      direction = 'backward'
+      continue
+    }
+
+    if (i < 0) {
+      triedBackward = true
+      i = index + 1
+      direction = 'forward'
+      continue
+    }
+
+    child = childNodes[i]
+    if (direction == 'forward') i++
+    if (direction == 'backward') i--
+  }
+
+  return child || null
+}
+
+/**
+ * Export.
+ *
+ * @type {Function}
+ */
+
+export default normalizeNodeAndOffset

--- a/src/lib/slate/utils/normalize.js
+++ b/src/lib/slate/utils/normalize.js
@@ -1,0 +1,218 @@
+
+import Block from '../models/block'
+import Document from '../models/document'
+import Inline from '../models/inline'
+import Data from '../models/data'
+import Mark from '../models/mark'
+import Selection from '../models/selection'
+import Text from '../models/text'
+import warn from './warn'
+import typeOf from 'type-of'
+
+/**
+ * Normalize a block argument `value`.
+ *
+ * @param {Block|String|Object} value
+ * @return {Block}
+ */
+
+function block(value) {
+  if (value instanceof Block) return value
+
+  switch (typeOf(value)) {
+    case 'string':
+    case 'object':
+      return Block.create(nodeProperties(value))
+
+    default:
+      throw new Error(`Invalid \`block\` argument! It must be a block, an object, or a string. You passed: "${value}".`)
+  }
+}
+
+/**
+ * Normalize an inline argument `value`.
+ *
+ * @param {Inline|String|Object} value
+ * @return {Inline}
+ */
+
+function inline(value) {
+  if (value instanceof Inline) return value
+  var getClassOf = Function.prototype.call.bind(Object.prototype.toString);
+
+  switch (typeOf(value)) {
+    case 'string':
+    case 'object':
+      return Inline.create(nodeProperties(value))
+
+    default:
+      throw new Error(`Invalid \`inline\` argument! It must be an inline, an object, or a string. You passed: "${value}".`)
+  }
+}
+
+/**
+ * Normalize a key argument `value`.
+ *
+ * @param {String|Node} value
+ * @return {String}
+ */
+
+function key(value) {
+  if (typeOf(value) == 'string') return value
+
+  warn('An object was passed to a Node method instead of a `key` string. This was previously supported, but is being deprecated because it can have a negative impact on performance. The object in question was:', value)
+  if (value instanceof Block) return value.key
+  if (value instanceof Document) return value.key
+  if (value instanceof Inline) return value.key
+  if (value instanceof Text) return value.key
+
+  throw new Error(`Invalid \`key\` argument! It must be either a block, an inline, a text, or a string. You passed: "${value}".`)
+}
+
+/**
+ * Normalize a mark argument `value`.
+ *
+ * @param {Mark|String|Object} value
+ * @return {Mark}
+ */
+
+function mark(value) {
+  if (value instanceof Mark) return value
+
+  switch (typeOf(value)) {
+    case 'string':
+    case 'object':
+      return Mark.create(markProperties(value))
+
+    default:
+      throw new Error(`Invalid \`mark\` argument! It must be a mark, an object, or a string. You passed: "${value}".`)
+  }
+}
+
+/**
+ * Normalize a mark properties argument `value`.
+ *
+ * @param {String|Object|Mark} value
+ * @return {Object}
+ */
+
+function markProperties(value = {}) {
+  const ret = {}
+
+  switch (typeOf(value)) {
+    case 'string':
+      ret.type = value
+      break
+
+    case 'object':
+      for (const k in value) {
+        if (k == 'data') {
+          if (value[k] !== undefined) ret[k] = Data.create(value[k])
+        } else {
+          ret[k] = value[k]
+        }
+      }
+      break
+
+    default:
+      throw new Error(`Invalid mark \`properties\` argument! It must be an object, a string or a mark. You passed: "${value}".`)
+  }
+
+  return ret
+}
+
+/**
+ * Normalize a node properties argument `value`.
+ *
+ * @param {String|Object|Node} value
+ * @return {Object}
+ */
+
+function nodeProperties(value = {}) {
+  const ret = {}
+
+  switch (typeOf(value)) {
+    case 'string':
+      ret.type = value
+      break
+
+    case 'object':
+      if (value.isVoid !== undefined) ret.isVoid = !!value.isVoid
+      for (const k in value) {
+        if (k == 'data') {
+          if (value[k] !== undefined) ret[k] = Data.create(value[k])
+        } else {
+          ret[k] = value[k]
+        }
+      }
+      break
+
+    default:
+      throw new Error(`Invalid node \`properties\` argument! It must be an object, a string or a node. You passed: "${value}".`)
+  }
+  return ret
+}
+
+/**
+ * Normalize a selection argument `value`.
+ *
+ * @param {Selection|Object} value
+ * @return {Selection}
+ */
+
+function selection(value) {
+  if (value instanceof Selection) return value
+
+  switch (typeOf(value)) {
+    case 'object':
+      return Selection.create(value)
+
+    default:
+      throw new Error(`Invalid \`selection\` argument! It must be a selection or an object. You passed: "${value}".`)
+  }
+}
+
+/**
+ * Normalize a selection properties argument `value`.
+ *
+ * @param {Object|Selection} value
+ * @return {Object}
+ */
+
+function selectionProperties(value = {}) {
+  const ret = {}
+
+  switch (typeOf(value)) {
+    case 'object':
+      if (value.anchorKey !== undefined) ret.anchorKey = value.anchorKey
+      if (value.anchorOffset !== undefined) ret.anchorOffset = value.anchorOffset
+      if (value.focusKey !== undefined) ret.focusKey = value.focusKey
+      if (value.focusOffset !== undefined) ret.focusOffset = value.focusOffset
+      if (value.isBackward !== undefined) ret.isBackward = !!value.isBackward
+      if (value.isFocused !== undefined) ret.isFocused = !!value.isFocused
+      if (value.marks !== undefined) ret.marks = value.marks
+      break
+
+    default:
+      throw new Error(`Invalid selection \`properties\` argument! It must be an object or a selection. You passed: "${value}".`)
+  }
+
+  return ret
+}
+
+/**
+ * Export.
+ *
+ * @type {Object}
+ */
+
+export default {
+  block,
+  inline,
+  key,
+  mark,
+  markProperties,
+  nodeProperties,
+  selection,
+  selectionProperties,
+}

--- a/src/lib/slate/utils/offset-key.js
+++ b/src/lib/slate/utils/offset-key.js
@@ -1,0 +1,166 @@
+
+import normalizeNodeAndOffset from './normalize-node-and-offset'
+import findClosestNode from './find-closest-node'
+
+/**
+ * Offset key parser regex.
+ *
+ * @type {RegExp}
+ */
+
+const PARSER = /^(\w+)(?:-(\d+))?$/
+
+/**
+ * Offset key attribute name.
+ *
+ * @type {String}
+ */
+
+const ATTRIBUTE = 'data-offset-key'
+
+/**
+ * Offset key attribute selector.
+ *
+ * @type {String}
+ */
+
+const SELECTOR = `[${ATTRIBUTE}]`
+
+/**
+ * Void node selection.
+ *
+ * @type {String}
+ */
+
+const VOID_SELECTOR = '[data-slate-void]'
+
+/**
+ * Find the start and end bounds from an `offsetKey` and `ranges`.
+ *
+ * @param {Number} index
+ * @param {List<Range>} ranges
+ * @return {Object}
+ */
+
+function findBounds(index, ranges) {
+  const range = ranges.get(index)
+  const start = ranges
+    .slice(0, index)
+    .reduce((memo, r) => {
+      return memo += r.text.length
+    }, 0)
+
+  return {
+    start,
+    end: start + range.text.length
+  }
+}
+
+/**
+ * From a DOM node, find the closest parent's offset key.
+ *
+ * @param {Element} rawNode
+ * @param {Number} rawOffset
+ * @return {Object}
+ */
+
+function findKey(rawNode, rawOffset) {
+  let { node, offset } = normalizeNodeAndOffset(rawNode, rawOffset)
+  const { parentNode } = node
+
+  // Find the closest parent with an offset key attribute.
+  let closest = findClosestNode(parentNode, SELECTOR)
+
+  // For void nodes, the element with the offset key will be a cousin, not an
+  // ancestor, so find it by going down from the nearest void parent.
+  if (!closest) {
+    const closestVoid = findClosestNode(parentNode, VOID_SELECTOR)
+    if (!closestVoid) return null
+    closest = closestVoid.querySelector(SELECTOR)
+    offset = closest.textContent.length
+  }
+
+  // Get the string value of the offset key attribute.
+  const offsetKey = closest.getAttribute(ATTRIBUTE)
+
+  // If we still didn't find an offset key, abort.
+  if (!offsetKey) return null
+
+  // Return the parsed the offset key.
+  const parsed = parse(offsetKey)
+  return {
+    key: parsed.key,
+    index: parsed.index,
+    offset
+  }
+}
+
+/**
+ * Find the selection point from an `offsetKey` and `ranges`.
+ *
+ * @param {Object} offsetKey
+ * @param {List<Range>} ranges
+ * @return {Object}
+ */
+
+function findPoint(offsetKey, ranges) {
+  let { key, index, offset } = offsetKey
+  const { start, end } = findBounds(index, ranges)
+
+  // Don't let the offset be outside of the start and end bounds.
+  offset = start + offset
+  offset = Math.max(offset, start)
+  offset = Math.min(offset, end)
+
+  return {
+    key,
+    index,
+    start,
+    end,
+    offset
+  }
+}
+
+/**
+ * Parse an offset key `string`.
+ *
+ * @param {String} string
+ * @return {Object}
+ */
+
+function parse(string) {
+  const matches = PARSER.exec(string)
+  if (!matches) throw new Error(`Invalid offset key string "${string}".`)
+  const [ original, key, index ] = matches // eslint-disable-line no-unused-vars
+  return {
+    key,
+    index: parseInt(index, 10)
+  }
+}
+
+/**
+ * Stringify an offset key `object`.
+ *
+ * @param {Object} object
+ *   @property {String} key
+ *   @property {Number} index
+ * @return {String}
+ */
+
+function stringify(object) {
+  return `${object.key}-${object.index}`
+}
+
+/**
+ * Export.
+ *
+ * @type {Object}
+ */
+
+export default {
+  findBounds,
+  findKey,
+  findPoint,
+  parse,
+  stringify
+}

--- a/src/lib/slate/utils/scroll-to-selection.js
+++ b/src/lib/slate/utils/scroll-to-selection.js
@@ -1,0 +1,39 @@
+
+import getWindow from 'get-window'
+import isBackward from 'selection-is-backward'
+
+/**
+ * Scroll the current selection's focus point into view if needed.
+ *
+ * @param {Selection} selection
+ */
+
+function scrollToSelection(selection) {
+  if (!selection.anchorNode) return
+
+  const window = getWindow(selection.anchorNode)
+  const backward = isBackward(selection)
+  const range = selection.getRangeAt(0)
+  const rect = range.getBoundingClientRect()
+  const { innerWidth, innerHeight, pageYOffset, pageXOffset } = window
+  const top = (backward ? rect.top : rect.bottom) + pageYOffset
+  const left = (backward ? rect.left : rect.right) + pageXOffset
+
+  const x = left < pageXOffset || innerWidth + pageXOffset < left
+    ? left - innerWidth / 2
+    : pageXOffset
+
+  const y = top < pageYOffset || innerHeight + pageYOffset < top
+    ? top - innerHeight / 2
+    : pageYOffset
+
+  window.scrollTo(x, y)
+}
+
+/**
+ * Export.
+ *
+ * @type {Function}
+ */
+
+export default scrollToSelection

--- a/src/lib/slate/utils/string.js
+++ b/src/lib/slate/utils/string.js
@@ -1,0 +1,198 @@
+
+import { reverse } from 'esrever'
+
+/**
+ * Surrogate pair start and end points.
+ *
+ * @type {Number}
+ */
+
+const SURROGATE_START = 0xD800
+const SURROGATE_END = 0xDFFF
+
+/**
+ * A regex to match space characters.
+ *
+ * @type {RegExp}
+ */
+
+const SPACE = /\s/
+
+/**
+ * A regex to match chameleon characters, that count as word characters as long
+ * as they are inside of a word.
+ *
+ * @type {RegExp}
+ */
+
+const CHAMELEON = /['\u2018\u2019]/
+
+/**
+ * A regex that matches punctuation.
+ *
+ * @type {RegExp}
+ */
+
+const PUNCTUATION = /[\u0021-\u0023\u0025-\u002A\u002C-\u002F\u003A\u003B\u003F\u0040\u005B-\u005D\u005F\u007B\u007D\u00A1\u00A7\u00AB\u00B6\u00B7\u00BB\u00BF\u037E\u0387\u055A-\u055F\u0589\u058A\u05BE\u05C0\u05C3\u05C6\u05F3\u05F4\u0609\u060A\u060C\u060D\u061B\u061E\u061F\u066A-\u066D\u06D4\u0700-\u070D\u07F7-\u07F9\u0830-\u083E\u085E\u0964\u0965\u0970\u0AF0\u0DF4\u0E4F\u0E5A\u0E5B\u0F04-\u0F12\u0F14\u0F3A-\u0F3D\u0F85\u0FD0-\u0FD4\u0FD9\u0FDA\u104A-\u104F\u10FB\u1360-\u1368\u1400\u166D\u166E\u169B\u169C\u16EB-\u16ED\u1735\u1736\u17D4-\u17D6\u17D8-\u17DA\u1800-\u180A\u1944\u1945\u1A1E\u1A1F\u1AA0-\u1AA6\u1AA8-\u1AAD\u1B5A-\u1B60\u1BFC-\u1BFF\u1C3B-\u1C3F\u1C7E\u1C7F\u1CC0-\u1CC7\u1CD3\u2010-\u2027\u2030-\u2043\u2045-\u2051\u2053-\u205E\u207D\u207E\u208D\u208E\u2329\u232A\u2768-\u2775\u27C5\u27C6\u27E6-\u27EF\u2983-\u2998\u29D8-\u29DB\u29FC\u29FD\u2CF9-\u2CFC\u2CFE\u2CFF\u2D70\u2E00-\u2E2E\u2E30-\u2E3B\u3001-\u3003\u3008-\u3011\u3014-\u301F\u3030\u303D\u30A0\u30FB\uA4FE\uA4FF\uA60D-\uA60F\uA673\uA67E\uA6F2-\uA6F7\uA874-\uA877\uA8CE\uA8CF\uA8F8-\uA8FA\uA92E\uA92F\uA95F\uA9C1-\uA9CD\uA9DE\uA9DF\uAA5C-\uAA5F\uAADE\uAADF\uAAF0\uAAF1\uABEB\uFD3E\uFD3F\uFE10-\uFE19\uFE30-\uFE52\uFE54-\uFE61\uFE63\uFE68\uFE6A\uFE6B\uFF01-\uFF03\uFF05-\uFF0A\uFF0C-\uFF0F\uFF1A\uFF1B\uFF1F\uFF20\uFF3B-\uFF3D\uFF3F\uFF5B\uFF5D\uFF5F-\uFF65]/
+
+/**
+ * Is a character `code` in a surrogate character.
+ *
+ * @param {Number} code
+ * @return {Boolean}
+ */
+
+function isSurrogate(code) {
+  return SURROGATE_START <= code && code <= SURROGATE_END
+}
+
+/**
+ * Is a character a word character? Needs the `remaining` characters too.
+ *
+ * @param {String} char
+ * @param {String|Void} remaining
+ * @return {Boolean}
+ */
+
+function isWord(char, remaining) {
+  if (SPACE.test(char)) return false
+
+  // If it's a chameleon character, recurse to see if the next one is or not.
+  if (CHAMELEON.test(char)) {
+    let next = remaining.charAt(0)
+    const length = getCharLength(next)
+    next = remaining.slice(0, length)
+    const rest = remaining.slice(length)
+    if (isWord(next, rest)) return true
+  }
+
+  if (PUNCTUATION.test(char)) return false
+  return true
+}
+
+/**
+ * Get the length of a `character`.
+ *
+ * @param {String} char
+ * @return {Number}
+ */
+
+function getCharLength(char) {
+  return isSurrogate(char.charCodeAt(0))
+    ? 2
+    : 1
+}
+
+/**
+ * Get the offset to the end of the first character in `text`.
+ *
+ * @param {String} text
+ * @return {Number}
+ */
+
+function getCharOffset(text) {
+  const char = text.charAt(0)
+  return getCharLength(char)
+}
+
+/**
+ * Get the offset to the end of the character before an `offset` in `text`.
+ *
+ * @param {String} text
+ * @param {Number} offset
+ * @return {Number}
+ */
+
+function getCharOffsetBackward(text, offset) {
+  text = text.slice(0, offset)
+  text = reverse(text)
+  return getCharOffset(text)
+}
+
+/**
+ * Get the offset to the end of the character after an `offset` in `text`.
+ *
+ * @param {String} text
+ * @param {Number} offset
+ * @return {Number}
+ */
+
+function getCharOffsetForward(text, offset) {
+  text = text.slice(offset)
+  return getCharOffset(text)
+}
+
+/**
+ * Get the offset to the end of the first word in `text`.
+ *
+ * @param {String} text
+ * @return {Number}
+ */
+
+function getWordOffset(text) {
+  let length = 0
+  let i = 0
+  let started = false
+  let char
+
+  while (char = text.charAt(i)) {
+    const l = getCharLength(char)
+    char = text.slice(i, i + l)
+    const rest = text.slice(i + l)
+
+    if (isWord(char, rest)) {
+      started = true
+      length += l
+    } else if (!started) {
+      length += l
+    } else {
+      break
+    }
+
+    i += l
+  }
+
+  return length
+}
+
+/**
+ * Get the offset to the end of the word before an `offset` in `text`.
+ *
+ * @param {String} text
+ * @param {Number} offset
+ * @return {Number}
+ */
+
+function getWordOffsetBackward(text, offset) {
+  text = text.slice(0, offset)
+  text = reverse(text)
+  const o = getWordOffset(text)
+  return o
+}
+
+/**
+ * Get the offset to the end of the word after an `offset` in `text`.
+ *
+ * @param {String} text
+ * @param {Number} offset
+ * @return {Number}
+ */
+
+function getWordOffsetForward(text, offset) {
+  text = text.slice(offset)
+  const o = getWordOffset(text)
+  return o
+}
+
+/**
+ * Export.
+ *
+ * @type {Object}
+ */
+
+export default {
+  getCharOffsetForward,
+  getCharOffsetBackward,
+  getWordOffsetBackward,
+  getWordOffsetForward
+}

--- a/src/lib/slate/utils/warn.js
+++ b/src/lib/slate/utils/warn.js
@@ -1,0 +1,27 @@
+
+import IS_DEV from '../constants/is-dev'
+
+/**
+ * Log a development warning.
+ *
+ * @param {String} message
+ * @param {Any} ...args
+ */
+
+function warn(message, ...args) {
+  if (!IS_DEV) {
+    return
+  }
+
+  if (typeof console !== 'undefined') {
+    console.warn(`Warning: ${message}`, ...args) // eslint-disable-line no-console
+  }
+}
+
+/**
+ * Export.
+ *
+ * @type {Function}
+ */
+
+export default warn

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -272,7 +272,6 @@ class FluxNotesEditor extends React.Component {
     }
 
     onInput = (event, data) => {
-        this.handleSummaryUpdate(data.newText) 
         // Create an updated state with the text replaced.
         var nextState = this.state.state.transform().select({
           anchorKey: data.anchorKey,

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Slate from 'slate';
+import Slate from '../lib/slate';
 import Lang from 'lodash';
 import ContextPortal from '../context/ContextPortal';
 // versions 0.20.3-0.20.7 of Slate seem to have an issue.
@@ -270,6 +270,19 @@ class FluxNotesEditor extends React.Component {
             state: state
         });
     }
+
+    onInput = (event, data) => {
+        // Create an updated state with the text replaced.
+        var nextState = this.state.state.transform().select({
+          anchorKey: data.anchorKey,
+          anchorOffset: data.anchorOffset,
+          focusKey: data.focusKey,
+          focusOffset: data.focusOffset
+        }).delete().insertText(data.newText, data.marks).select(data.after).apply();
+
+        // Change the current state.
+        this.onChange(nextState);
+    }
     
     isBlock1BeforeBlock2(key1, offset1, key2, offset2, state) {
         if (Lang.isUndefined(state)) {
@@ -425,7 +438,7 @@ class FluxNotesEditor extends React.Component {
         this.setState({ state });
     
     }        
-    
+
     render = () => {
         const CreatorsPortal = this.suggestionsPluginCreators.SuggestionPortal;
         const InsertersPortal = this.suggestionsPluginInserters.SuggestionPortal;
@@ -492,6 +505,7 @@ class FluxNotesEditor extends React.Component {
                             state={this.state.state}
                             ref={function(c) { editor = c; }}
                             onChange={this.onChange}
+                            onInput={this.onInput}
                             onSelectionChange={this.onSelectionChange}
                             schema={schema}
                         />

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -196,7 +196,7 @@ class FluxNotesEditor extends React.Component {
     
     autoReplaceTransform(shortcutC, transform, e, data, matches) {
         // need to use Transform object provided to this method, which AutoReplace .apply()s after return.
-        this.insertShortcut(shortcutC, matches.before[0], "", transform);
+        return this.insertShortcut(shortcutC, matches.before[0], "", transform).insertText(' ');
     }
     
     openPortalToSelectValueForShortcut(shortcut, needToDelete, transform) {

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -262,7 +262,7 @@ class FluxNotesEditor extends React.Component {
         if (Lang.isNull(shortcut)) return transform.focus();
         let result = this.structuredFieldPlugin.transforms.insertStructuredField(transform, shortcut); //2nd param needs to be Shortcut Object, how to create?
         //console.log(result[0]);
-        return result[0];
+        return result[0];   
     }
 
     onChange = (state) => {
@@ -272,16 +272,16 @@ class FluxNotesEditor extends React.Component {
     }
 
     onInput = (event, data) => {
+        this.handleSummaryUpdate(data.newText) 
         // Create an updated state with the text replaced.
         var nextState = this.state.state.transform().select({
           anchorKey: data.anchorKey,
           anchorOffset: data.anchorOffset,
           focusKey: data.focusKey,
           focusOffset: data.focusOffset
-        }).delete().insertText(data.newText, data.marks).select(data.after).apply();
+        }).delete()
 
-        // Change the current state.
-        this.onChange(nextState);
+        this.handleSummaryUpdate(data.newText, nextState)
     }
     
     isBlock1BeforeBlock2(key1, offset1, key2, offset2, state) {
@@ -332,10 +332,11 @@ class FluxNotesEditor extends React.Component {
     /*
      * Handle updates when we have a new
      */
-    handleSummaryUpdate = (itemToBeInserted) => {
+    handleSummaryUpdate = (itemToBeInserted, currentTransform=undefined) => {
         let state;
         const currentState = this.state.state;
-        let transform = currentState.transform();
+        
+        let transform = (currentTransform) ? currentTransform : currentState.transform();
         let remainder = itemToBeInserted;
         let start, before, end, after;
         

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -1,6 +1,6 @@
 import InserterShortcut from '../shortcuts/InserterShortcut';
 import React from 'react';
-import Slate from 'slate';
+import Slate from '../lib/slate';
 import Lang from 'lodash';
 import getWindow from 'get-window';
 
@@ -322,7 +322,6 @@ function insertStructuredField(opts, transform, shortcut) {
 
     // Create the structured-field node
     const sf = createStructuredField(opts, shortcut);
-
     shortcut.setKey(sf.key);
     if (sf.kind === 'block') {
 		return [transform.insertBlock(sf), sf.key];
@@ -341,15 +340,15 @@ function insertStructuredField(opts, transform, shortcut) {
  */
 function createStructuredField(opts, shortcut) {
 	let nodes = [];
-
-    let sf = Slate.Inline.create({
+    const properties = {
         type:  opts.typeStructuredField,
         nodes: nodes,
-		isVoid: true,
-		data: {
-			shortcut: shortcut
-		}
-    });
+        isVoid: true,
+        data: {
+            shortcut: shortcut
+        }
+    };
+    let sf = Slate.Inline.create(properties);
     structuredFieldMap.set(sf.key, shortcut);
 	return sf;
 }


### PR DESCRIPTION
Pull request provides initial implementation for dragon diction integration. By modifying the Slate.js source code, we are able to pass the Slate Editor an onInput function that can handle structured phrase parsing.  So far 3 bugs with dictation that have been identified (and for which JIRA's have been logged): 

1. Entering in "new line" through the mic will a) overwrite everything on the current line with whatever follows the last "new line" keyword, and b) often un-syncs Slate's model of editor content and actual editor content, resulting in text that you cannot delete/edit. 
2. Insertions in the middle of an existing line of text will insert properly, but the cursor will be pulled to the end of the line.  
3. Using the '@' symbol between two words results in a concatenation "previousWord@nextWord" that resembles email formatting, likely because Dragon assumes you're writing an email address. 

N.B. that issues 1) and 2) are a product of how we do insertions in onInput. Our implementation is currently limited by our inability to access the chunk of text Dragon is inserting. If someone can find a way to access that information from the event we're handling, or figure out how to infer it indirectly, these issues should resolve seamlessly. 

_Pull requests into Flux require the following: Submitter and reviewer should ✅ when done. For items that are not-applicable, note it's not-applicable (N/A) and ✅._

# Submitter: Dylan 

### Documentation

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- [x] N/A Cheat sheet is updated
- [x] Demo script is updated 
      As of now, I think the best place for this would be in the second half of the demo when we're doing structured data insertions. The '#' doesn't have the same issues that the '@' has, and we shouldn't need to use any new lines if we're at the end of the demonstration. 
- [x] Documentation on Wiki has been updated 
- [x] N/A Additional technical components and libraries are documented and added to wiki as needed

### NoteParser

- [x] N/A Note parser has been updated if structured phrases change

### Code Quality

- [x] 4-space indents - convert any tabs to spaces
      This is a bizarre case because the source code I copied over has not been reformatted; that would make a future pull request way harder. I think because of this that we should get a pass on this. Please?
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

### Tests

- [x] Existing tests passed
      I'm leaning towards relying on manual tests for dictation, but I'm open to other options.  
- [x] N/A Added UI tests for slim mode 
- [x] N/A Added UI tests for full mode
- [x] N/A Added backend tests for fluxNotes code
- [x] N/A Added note parser examples to test new functionality


# Reviewer 1: Julia

- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] N/A The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code


# Reviewer 2: Name

- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
