### PR TITLE
Fix auto replace end of line bug

### DIFF
--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -126,9 +126,11 @@ class FluxNotesEditor extends React.Component {
         allShortcuts.forEach((shortcutC) => {
             triggerRegExp = shortcutC.getTriggerRegExp();
             if (!Lang.isNull(triggerRegExp)) {
+                // Modify regex to ensure this pattern only gets replaced if it's right before the cursor.
+                const triggerRegExpModified = new RegExp(triggerRegExp.toString().replace(/\/(.*)\//, '$1$'));
                 this.plugins.push(AutoReplace({
                     "trigger": 'space',
-                    "before": triggerRegExp,
+                    "before": triggerRegExpModified,
                     "transform": this.autoReplaceTransform.bind(this, shortcutC)
                 }));
             }

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -109,7 +109,7 @@ class FluxNotesEditor extends React.Component {
         let autoReplaceAfters = [];
         let allShortcuts = this.props.shortcutManager.getAllShortcutClasses();
         allShortcuts.forEach((shortcutC) => {
-            const shortcutNamesList = shortcutC.getStringTriggers().map(trigger => trigger.name);
+            const shortcutNamesList = shortcutC.getStringTriggers().map(trigger => `${trigger.name}$`);
             autoReplaceAfters = autoReplaceAfters.concat(shortcutNamesList);
         });
         this.autoReplaceBeforeRegExp = new RegExp("(" + autoReplaceAfters.join("|") + ")", 'i');


### PR DESCRIPTION
Returning to complete partially-typed structured phrases will no longer insert structured values in the wrong place or delete unexpected characters on insertion. The bug before could be reproduced by doing the following: 

1. Type "@nam is currently presenting with"
2. Add 'e' to partially complete shortcut, so you should have "@name is currently presenting with" typed out.
3. Go to the end of the line.
4. Type a space.

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

## Submitter:

**Documentation**

- [x] This pull request describes why these changes were made
- [x] **N/A** Recognizes any potential shortcomings/bugs in the description 
- [x] **N/A** Cheat sheet is updated
- [x] **N/A** Demo script is updated 
- [x] **N/A** Documentation on Wiki has been updated 
- [x] **N/A** Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [x] **N/A**Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] **N/A** Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- [x] **N/A** Added UI tests for slim mode 
- [x] **N/A** Added UI tests for full mode
- [x] **N/A** Added backend tests for fluxNotes code
- [x] **N/A** Added note parser examples to test new functionality


## Reviewer 1: Julia

- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
