### PR TITLE
Used date picker lib in slim mode

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,11 @@ _Pull requests into Flux require the following. Submitter and reviewer should :w
 
 ## Submitter:
 
+**Running the Application**
+
+- [ ] Manually tested in Chrome
+- [ ] Manually tested in IE
+
 **Documentation**
 
 - [ ] This pull request describes why these changes were made

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react-autosuggest": "9.3.2",
     "react-calendar-timeline": "0.14.0",
     "react-copy-to-clipboard": "5.0.0",
+    "react-day-picker": "6.2.1",
     "react-dom": "15.5.4",
     "react-flexbox-grid": "1.1.3",
     "react-ga": "2.2.0",

--- a/src/forms/ClinicalTrialForm.jsx
+++ b/src/forms/ClinicalTrialForm.jsx
@@ -102,6 +102,7 @@ class ClinicalTrialForm extends Component {
                     <span className="helper-text"> mm/dd/yyyy</span>
                 </p>
                 <DayPickerInput
+                    id="enrollment-date"
                     value={formattedDate}
                     onDayChange={ (e) => this.handleDateChange(e, "enrollmentDate")}
                     format={DATE_FORMAT}
@@ -114,6 +115,7 @@ class ClinicalTrialForm extends Component {
                     <span className="helper-text"> mm/dd/yyyy</span>
                 </p>
                 <DayPickerInput
+                    id="end-date"
                     value={formattedDate}
                     onDayChange={ (e) => this.handleDateChange(e, "endDate")}
                     format={DATE_FORMAT}

--- a/src/forms/ClinicalTrialForm.jsx
+++ b/src/forms/ClinicalTrialForm.jsx
@@ -16,7 +16,8 @@ class ClinicalTrialForm extends Component {
         
         this.state = {
             trials: this.clinicalTrialsList.getAllTrials(),
-            selectedDate: null
+            selectedEnrollmentDate: null,
+            selectedEndDate: null
         };
     }
     
@@ -32,10 +33,16 @@ class ClinicalTrialForm extends Component {
 
     handleDateChange = (selectedDate, value) => {
 
-        this.setState({
-            selectedDate
-        });
-
+         if (value === "enrollmentDate") {
+            this.setState({
+                selectedEnrollmentDate: selectedDate
+            });
+        }
+        else if (value === "endDate") {
+            this.setState({
+                selectedEndDate: selectedDate
+            });
+        }
         this.props.updateValue(value, selectedDate);
     };
     

--- a/src/forms/ClinicalTrialForm.jsx
+++ b/src/forms/ClinicalTrialForm.jsx
@@ -1,10 +1,13 @@
 import React, {Component} from 'react';
 import Divider from 'material-ui/Divider';
 import Button from 'material-ui/Button';
-import TextField from 'material-ui/TextField';
 import moment from 'moment';
+import DayPickerInput from 'react-day-picker/DayPickerInput';
+import 'react-day-picker/lib/style.css';
 import ClinicalTrialsList from '../clinicalTrials/ClinicalTrialsList';
 import './ClinicalTrialForm.css';
+
+const DATE_FORMAT = 'MM/DD/YYYY';
 
 class ClinicalTrialForm extends Component {
     constructor(props) {
@@ -12,7 +15,8 @@ class ClinicalTrialForm extends Component {
         this.clinicalTrialsList = new ClinicalTrialsList();
         
         this.state = {
-            trials: this.clinicalTrialsList.getAllTrials()
+            trials: this.clinicalTrialsList.getAllTrials(),
+            selectedDate: null
         };
     }
     
@@ -25,15 +29,15 @@ class ClinicalTrialForm extends Component {
         const newTrial = this.state.trials[i].id;
         this.props.updateValue("title", newTrial);
     }
-    
-    handleDateSelection = (event, value) => {
-        const date = event.target.value;
-        let formattedDate = null;
-        if (date) {
-            formattedDate = new moment(date).format('D MMM YYYY');
-        }
-        this.props.updateValue(value, formattedDate);
-    }
+
+    handleDateChange = (selectedDate, value) => {
+
+        this.setState({
+            selectedDate
+        });
+
+        this.props.updateValue(value, selectedDate);
+    };
     
     renderTrialButtonGroup = (trial, i) => {
         const marginSize = "10px";
@@ -66,6 +70,9 @@ class ClinicalTrialForm extends Component {
     }
     
     render() {
+        const {selectedDate} = this.state;
+        const formattedDate = selectedDate ? moment(selectedDate).format(DATE_FORMAT) : '';
+
         return (
             <div>
                 <h1>Clinical Trial</h1>
@@ -94,10 +101,11 @@ class ClinicalTrialForm extends Component {
                     {ClinicalTrialsList.getDescription("enrollmentDate")}
                     <span className="helper-text"> mm/dd/yyyy</span>
                 </p>
-                <TextField
-                    id="enrollment-date"
-                    type="date"
-                    onChange={(e) => this.handleDateSelection(e, "enrollmentDate")}
+                <DayPickerInput
+                    value={formattedDate}
+                    onDayChange={ (e) => this.handleDateChange(e, "enrollmentDate")}
+                    format={DATE_FORMAT}
+                    placeholder={DATE_FORMAT}
                 />
                 
                 <h4 className="header-spacing">End Date <span className="helper-text"> (Optional)</span></h4>
@@ -105,10 +113,11 @@ class ClinicalTrialForm extends Component {
                     {ClinicalTrialsList.getDescription("endDate")}
                     <span className="helper-text"> mm/dd/yyyy</span>
                 </p>
-                <TextField
-                    id="end-date"
-                    type="date"
-                    onChange={(e) => this.handleDateSelection(e, "endDate")}
+                <DayPickerInput
+                    value={formattedDate}
+                    onDayChange={ (e) => this.handleDateChange(e, "endDate")}
+                    format={DATE_FORMAT}
+                    placeholder={DATE_FORMAT}
                 />
             </div>
         )

--- a/src/forms/DeceasedForm.jsx
+++ b/src/forms/DeceasedForm.jsx
@@ -2,22 +2,31 @@ import React, {Component} from 'react';
 import Divider from 'material-ui/Divider';
 import TextField from 'material-ui/TextField';
 import moment from 'moment';
+import DayPickerInput from 'react-day-picker/DayPickerInput';
+import 'react-day-picker/lib/style.css';
 import './ProgressionForm.css';
 
+const DAY_FORMAT = 'MM/DD/YYYY';
 
 class DeceasedForm extends Component {
 
-    handleDateSelection = (event) => {
-        const date = event.target.value;
-        let formattedDate = null;
-        if (date) {
-            formattedDate = new moment(date).format('D MM YYYY');
-        }
-        this.props.updateValue("date", formattedDate);
-    }
+    state = {
+        selectedDay: undefined,
+        isDisabled: false
+    };
+
+    handleDayChange = (selectedDay, modifiers) => {
+        this.setState({
+            selectedDay,
+            isDisabled: modifiers.disabled,
+        });
+
+        this.props.updateValue("date", selectedDay);
+    };
 
     render() {
-        var formattedDateOfDeath = null;
+        const {selectedDay, isDisabled} = this.state;
+        const formattedDay = selectedDay ? moment(selectedDay).format(DAY_FORMAT) : '';
 
         let dateOfDeathSection = (
             <div>
@@ -26,11 +35,12 @@ class DeceasedForm extends Component {
                     The date of the patient's death.
                     <span className="helper-text"> mm/dd/yyyy</span>
                 </p>
-                <TextField
-                    id="date-of-death"
-                    type="date"
-                    defaultValue={formattedDateOfDeath}
-                    onChange={this.handleDateSelection}
+
+                <DayPickerInput
+                    value={formattedDay}
+                    onDayChange={this.handleDayChange}
+                    format={DAY_FORMAT}
+                    placeholder={DAY_FORMAT}
                 />
             </div>
         );
@@ -42,10 +52,11 @@ class DeceasedForm extends Component {
                     An indication that the person is no longer living as of the date specified below.
                     <br/>
                     <br/>
-                    Based on your selections below, the copy button at the bottom will copy a <a href="deceasedSheet.pdf" target="_blank">formatted phrase</a> to paste in your EHR.
+                    Based on your selections below, the copy button at the bottom will copy a <a
+                    href="deceasedSheet.pdf" target="_blank">formatted phrase</a> to paste in your EHR.
                 </p>
                 <Divider className="divider"/>
-                    {dateOfDeathSection}
+                {dateOfDeathSection}
             </div>
         );
     }

--- a/src/forms/DeceasedForm.jsx
+++ b/src/forms/DeceasedForm.jsx
@@ -14,10 +14,10 @@ class DeceasedForm extends Component {
         isDisabled: false
     };
 
-    handleDayChange = (selectedDay, modifiers) => {
+    handleDayChange = (selectedDay) => {
+
         this.setState({
-            selectedDay,
-            isDisabled: modifiers.disabled,
+            selectedDay
         });
 
         this.props.updateValue("date", selectedDay);

--- a/src/forms/DeceasedForm.jsx
+++ b/src/forms/DeceasedForm.jsx
@@ -1,17 +1,16 @@
 import React, {Component} from 'react';
 import Divider from 'material-ui/Divider';
-import TextField from 'material-ui/TextField';
 import moment from 'moment';
 import DayPickerInput from 'react-day-picker/DayPickerInput';
 import 'react-day-picker/lib/style.css';
-import './ProgressionForm.css';
+import './DeceasedForm.css';
 
 const DAY_FORMAT = 'MM/DD/YYYY';
 
 class DeceasedForm extends Component {
 
     state = {
-        selectedDay: undefined,
+        selectedDay: null,
         isDisabled: false
     };
 
@@ -25,7 +24,7 @@ class DeceasedForm extends Component {
     };
 
     render() {
-        const {selectedDay, isDisabled} = this.state;
+        const {selectedDay} = this.state;
         const formattedDay = selectedDay ? moment(selectedDay).format(DAY_FORMAT) : '';
 
         let dateOfDeathSection = (

--- a/src/forms/DeceasedForm.jsx
+++ b/src/forms/DeceasedForm.jsx
@@ -36,6 +36,7 @@ class DeceasedForm extends Component {
                 </p>
 
                 <DayPickerInput
+                    id="date-of-death"
                     value={formattedDay}
                     onDayChange={this.handleDayChange}
                     format={DAY_FORMAT}

--- a/src/forms/ProgressionForm.jsx
+++ b/src/forms/ProgressionForm.jsx
@@ -18,8 +18,7 @@ class ProgressionForm extends Component {
             statusOptions: progressionLookup.getStatusOptions(),
             reasonOptions: progressionLookup.getReasonOptions(),
             reasonButtonsActiveState: [],
-            selectedReferenceDate: null,
-            isReferenceDateInputDisabled: false
+            selectedReferenceDate: null
         };
     }
     
@@ -75,10 +74,9 @@ class ProgressionForm extends Component {
         }
     }
 
-    handleReferenceDateChange = (selectedReferenceDate, modifiers) => {
+    handleReferenceDateChange = (selectedReferenceDate) => {
         this.setState({
-            selectedReferenceDate,
-            isReferenceDateInputDisabled: modifiers.disabled,
+            selectedReferenceDate
         });
         this.props.updateValue("referenceDateDate", selectedReferenceDate);
     };

--- a/src/forms/ProgressionForm.jsx
+++ b/src/forms/ProgressionForm.jsx
@@ -1,12 +1,14 @@
 import React, {Component} from 'react';
 import Divider from 'material-ui/Divider';
 import Button from 'material-ui/Button';
-import TextField from 'material-ui/TextField';
 import Lang from 'lodash';
 import moment from 'moment';
 import progressionLookup from '../lib/progression_lookup';
+import DayPickerInput from 'react-day-picker/DayPickerInput';
+import 'react-day-picker/lib/style.css';
 import './ProgressionForm.css';
 
+const DATE_FORMAT = 'MM/DD/YYYY';
 
 class ProgressionForm extends Component {
     constructor(props) {
@@ -15,7 +17,9 @@ class ProgressionForm extends Component {
         this.state = {
             statusOptions: progressionLookup.getStatusOptions(),
             reasonOptions: progressionLookup.getReasonOptions(),
-            reasonButtonsActiveState: []
+            reasonButtonsActiveState: [],
+            selectedReferenceDate: null,
+            isReferenceDateInputDisabled: false
         };
     }
     
@@ -71,14 +75,13 @@ class ProgressionForm extends Component {
         }
     }
 
-    handleDateSelection = (event) => {
-        const date = event.target.value;
-        let formattedDate = null;
-        if (date) {
-            formattedDate = new moment(date).format('D MMM YYYY');
-        }
-        this.props.updateValue("referenceDateDate", formattedDate);
-    }
+    handleReferenceDateChange = (selectedReferenceDate, modifiers) => {
+        this.setState({
+            selectedReferenceDate,
+            isReferenceDateInputDisabled: modifiers.disabled,
+        });
+        this.props.updateValue("referenceDateDate", selectedReferenceDate);
+    };
 
     renderStatusButtonGroup = (status, i) => {
         const marginSize = "10px";
@@ -143,10 +146,15 @@ class ProgressionForm extends Component {
         const clinicallyRelevantTime = this.props.progression.clinicallyRelevantTime;
         var formattedClinicallyRelevantTime = null;
 
+        const {selectedReferenceDate} = this.state;
+        const formattedReferenceDate = selectedReferenceDate ? moment(selectedReferenceDate).format(DATE_FORMAT) : '';
+
         if (clinicallyRelevantTime != null) {
-            formattedClinicallyRelevantTime = new moment(clinicallyRelevantTime, "D MMM YYYY ").format("YYYY-MM-DD");
+            formattedClinicallyRelevantTime = new moment(clinicallyRelevantTime, "D MMM YYYY ").format(DATE_FORMAT);
+        } else {
+            formattedClinicallyRelevantTime = DATE_FORMAT;
         }
-        
+
         let referenceDateSection = null;
         if (Lang.isUndefined(this.props.referenceDateEnabled) || this.props.referenceDateEnabled) {
             referenceDateSection = (
@@ -156,11 +164,12 @@ class ProgressionForm extends Component {
                         {progressionLookup.getDescription("referenceDate")}
                         <span className="helper-text"> mm/dd/yyyy</span>
                     </p>
-                    <TextField
-                        id="reference-date"
-                        type="date"
-                        defaultValue={formattedClinicallyRelevantTime}
-                        onChange={this.handleDateSelection}
+
+                    <DayPickerInput
+                        value={formattedReferenceDate}
+                        onDayChange={this.handleReferenceDateChange}
+                        format={DATE_FORMAT}
+                        placeholder={formattedClinicallyRelevantTime}
                     />
                 </div>
             );

--- a/src/viewer/ShortcutViewer.css
+++ b/src/viewer/ShortcutViewer.css
@@ -14,7 +14,7 @@
 }
 
 #panel-content {
-    margin-bottom: 170px;
+    margin-bottom: 400px;
 }
 
 #copy-component {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5409,6 +5409,13 @@ react-copy-to-clipboard@5.0.0:
     copy-to-clipboard "^3"
     prop-types "^15.5.8"
 
+react-day-picker@6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/react-day-picker/-/react-day-picker-6.2.1.tgz#fc22b809db792386d1468d3f46d725ad91e04db9"
+  dependencies:
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+
 react-dev-utils@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-0.5.2.tgz#50d0b962d3a94b6c2e8f2011ed6468e4124bc410"


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

Originally, slim mode was using an html date picker for selecting dates in slim mode (specifically for reference date in disease status form, enrollment date and end date for clinical enrollment form, and date of death on the deceased form). The date picker component does not render in IE. To fix this, replaced the html date picker component with the react-day-picker component (https://github.com/gpbl/react-day-picker) 

## Submitter:

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- [x] N/A Cheat sheet is updated
- [x] N/A Demo script is updated 
- [x] Documentation on Wiki has been updated 
- [x] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [x] N/A Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- [x] N/A Added UI tests for slim mode 
- [x] N/A Added UI tests for full mode
- [x] N/A Added backend tests for fluxNotes code
- [x] N/A Added note parser examples to test new functionality


## Reviewer 1: Dan Lee

- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code


## Reviewer 2: Laura

- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
