### PR TITLE
Update object model to replace hyphens with underscores in identifier names (+choice fix)

### DIFF
--- a/src/model/shr/base/Request.js
+++ b/src/model/shr/base/Request.js
@@ -60,34 +60,19 @@ class Request extends Action {
   }
 
   /**
-   * Getter for shr.base.RequestedPerformerType (option in a choice field).
+   * Getter for Choice<shr.base.RequestedPerformerType | shr.base.RequestedPerformer>.
    * NOTE: Choice fields are deprecated.  This is a stop-gap solution.
    */
-  get requestedPerformerType() {
+  get requestedPerformerTypeOrRequestedPerformer() {
     return this._requestedPerformerTypeOrRequestedPerformer;
   }
 
   /**
-   * Setter for shr.base.RequestedPerformerType (option in a choice field).
+   * Setter for Choice<shr.base.RequestedPerformerType | shr.base.RequestedPerformer>.
    * NOTE: Choice fields are deprecated.  This is a stop-gap solution.
    */
-  set requestedPerformerType(requestedPerformerTypeVal) {
-    this._requestedPerformerTypeOrRequestedPerformer = requestedPerformerTypeVal;
-  }
-  /**
-   * Getter for shr.base.RequestedPerformer (option in a choice field).
-   * NOTE: Choice fields are deprecated.  This is a stop-gap solution.
-   */
-  get requestedPerformer() {
-    return this._requestedPerformerTypeOrRequestedPerformer;
-  }
-
-  /**
-   * Setter for shr.base.RequestedPerformer (option in a choice field).
-   * NOTE: Choice fields are deprecated.  This is a stop-gap solution.
-   */
-  set requestedPerformer(requestedPerformerVal) {
-    this._requestedPerformerTypeOrRequestedPerformer = requestedPerformerVal;
+  set requestedPerformerTypeOrRequestedPerformer(choiceVal) {
+    this._requestedPerformerTypeOrRequestedPerformer = choiceVal;
   }
 
   /**

--- a/src/model/shr/demographics/FamilialRelationship.js
+++ b/src/model/shr/demographics/FamilialRelationship.js
@@ -30,34 +30,19 @@ class FamilialRelationship {
   }
 
   /**
-   * Getter for shr.actor.RelatedPerson (option in a choice field).
+   * Getter for Choice<shr.actor.RelatedPerson | shr.actor.Practitioner>.
    * NOTE: Choice fields are deprecated.  This is a stop-gap solution.
    */
-  get relatedPerson() {
+  get relatedPersonOrPractitioner() {
     return this._relatedPersonOrPractitioner;
   }
 
   /**
-   * Setter for shr.actor.RelatedPerson (option in a choice field).
+   * Setter for Choice<shr.actor.RelatedPerson | shr.actor.Practitioner>.
    * NOTE: Choice fields are deprecated.  This is a stop-gap solution.
    */
-  set relatedPerson(relatedPersonVal) {
-    this._relatedPersonOrPractitioner = relatedPersonVal;
-  }
-  /**
-   * Getter for shr.actor.Practitioner (option in a choice field).
-   * NOTE: Choice fields are deprecated.  This is a stop-gap solution.
-   */
-  get practitioner() {
-    return this._relatedPersonOrPractitioner;
-  }
-
-  /**
-   * Setter for shr.actor.Practitioner (option in a choice field).
-   * NOTE: Choice fields are deprecated.  This is a stop-gap solution.
-   */
-  set practitioner(practitionerVal) {
-    this._relatedPersonOrPractitioner = practitionerVal;
+  set relatedPersonOrPractitioner(choiceVal) {
+    this._relatedPersonOrPractitioner = choiceVal;
   }
 
   /**

--- a/src/model/shr/lab/TestRequest.js
+++ b/src/model/shr/lab/TestRequest.js
@@ -46,7 +46,7 @@ class TestRequest extends Request {
   }
 
   /**
-   * Getter for shr.lab.SpecimenType (option in a choice field).
+   * Getter for Choice<TBD<Specimen> | shr.lab.SpecimenType>.
    * NOTE: Choice fields are deprecated.  This is a stop-gap solution.
    */
   get specimenType() {
@@ -54,11 +54,11 @@ class TestRequest extends Request {
   }
 
   /**
-   * Setter for shr.lab.SpecimenType (option in a choice field).
+   * Setter for Choice<TBD<Specimen> | shr.lab.SpecimenType>.
    * NOTE: Choice fields are deprecated.  This is a stop-gap solution.
    */
-  set specimenType(specimenTypeVal) {
-    this._specimenType = specimenTypeVal;
+  set specimenType(choiceVal) {
+    this._specimenType = choiceVal;
   }
 
 }

--- a/src/model/shr/medication/Adherence.js
+++ b/src/model/shr/medication/Adherence.js
@@ -1,6 +1,21 @@
 /** Generated from SHR definition for shr.medication.Adherence */
 class Adherence {
 
+  /**
+   * Getter for Choice<TBD<MedicationTreatment> | TBD<SupplementTreatment>>[].
+   * NOTE: Choice fields are deprecated.  This is a stop-gap solution.
+   */
+  get () {
+    return this._;
+  }
+
+  /**
+   * Setter for Choice<TBD<MedicationTreatment> | TBD<SupplementTreatment>>[].
+   * NOTE: Choice fields are deprecated.  This is a stop-gap solution.
+   */
+  set (choiceVal) {
+    this._ = choiceVal;
+  }
 
   /**
    * Getter for shr.medication.AdherenceLevel

--- a/src/model/shr/oncology/CancerGrowthPotential.js
+++ b/src/model/shr/oncology/CancerGrowthPotential.js
@@ -48,29 +48,29 @@ class CancerGrowthPotential extends Observation {
   /**
    * Getter for shr.oncology.Ki-67LabelingIndex
    */
-  get ki-67LabelingIndex() {
-    return this._ki-67LabelingIndex;
+  get ki_67LabelingIndex() {
+    return this._ki_67LabelingIndex;
   }
 
   /**
    * Setter for shr.oncology.Ki-67LabelingIndex
    */
-  set ki-67LabelingIndex(ki-67LabelingIndexVal) {
-    this._ki-67LabelingIndex = ki-67LabelingIndexVal;
+  set ki_67LabelingIndex(ki_67LabelingIndexVal) {
+    this._ki_67LabelingIndex = ki_67LabelingIndexVal;
   }
 
   /**
    * Getter for shr.oncology.S-PhaseFraction
    */
-  get s-PhaseFraction() {
-    return this._s-PhaseFraction;
+  get s_PhaseFraction() {
+    return this._s_PhaseFraction;
   }
 
   /**
    * Setter for shr.oncology.S-PhaseFraction
    */
-  set s-PhaseFraction(s-PhaseFractionVal) {
-    this._s-PhaseFraction = s-PhaseFractionVal;
+  set s_PhaseFraction(s_PhaseFractionVal) {
+    this._s_PhaseFraction = s_PhaseFractionVal;
   }
 
 }

--- a/src/model/shr/oncology/Ki_67LabelingIndex.js
+++ b/src/model/shr/oncology/Ki_67LabelingIndex.js
@@ -1,7 +1,7 @@
 import ObservationComponent from '../observation/ObservationComponent';
 
 /** Generated from SHR definition for shr.oncology.Ki-67LabelingIndex */
-class Ki-67LabelingIndex extends ObservationComponent {
+class Ki_67LabelingIndex extends ObservationComponent {
 
   /**
    * Convenience getter for value (accesses this.quantity)
@@ -33,4 +33,4 @@ class Ki-67LabelingIndex extends ObservationComponent {
 
 }
 
-export default Ki-67LabelingIndex;
+export default Ki_67LabelingIndex;

--- a/src/model/shr/oncology/M_Stage.js
+++ b/src/model/shr/oncology/M_Stage.js
@@ -1,7 +1,7 @@
 import ObservationComponent from '../observation/ObservationComponent';
 
-/** Generated from SHR definition for shr.oncology.T-Stage */
-class T-Stage extends ObservationComponent {
+/** Generated from SHR definition for shr.oncology.M-Stage */
+class M_Stage extends ObservationComponent {
 
   /**
    * Convenience getter for value (accesses this.codeableConcept)
@@ -33,4 +33,4 @@ class T-Stage extends ObservationComponent {
 
 }
 
-export default T-Stage;
+export default M_Stage;

--- a/src/model/shr/oncology/N_Stage.js
+++ b/src/model/shr/oncology/N_Stage.js
@@ -1,7 +1,7 @@
 import ObservationComponent from '../observation/ObservationComponent';
 
-/** Generated from SHR definition for shr.oncology.M-Stage */
-class M-Stage extends ObservationComponent {
+/** Generated from SHR definition for shr.oncology.N-Stage */
+class N_Stage extends ObservationComponent {
 
   /**
    * Convenience getter for value (accesses this.codeableConcept)
@@ -33,4 +33,4 @@ class M-Stage extends ObservationComponent {
 
 }
 
-export default M-Stage;
+export default N_Stage;

--- a/src/model/shr/oncology/S_PhaseFraction.js
+++ b/src/model/shr/oncology/S_PhaseFraction.js
@@ -1,7 +1,7 @@
 import ObservationComponent from '../observation/ObservationComponent';
 
 /** Generated from SHR definition for shr.oncology.S-PhaseFraction */
-class S-PhaseFraction extends ObservationComponent {
+class S_PhaseFraction extends ObservationComponent {
 
   /**
    * Convenience getter for value (accesses this.quantity)
@@ -33,4 +33,4 @@ class S-PhaseFraction extends ObservationComponent {
 
 }
 
-export default S-PhaseFraction;
+export default S_PhaseFraction;

--- a/src/model/shr/oncology/TNMStage.js
+++ b/src/model/shr/oncology/TNMStage.js
@@ -76,43 +76,43 @@ class TNMStage extends Observation {
   /**
    * Getter for shr.oncology.T-Stage
    */
-  get t-Stage() {
-    return this._t-Stage;
+  get t_Stage() {
+    return this._t_Stage;
   }
 
   /**
    * Setter for shr.oncology.T-Stage
    */
-  set t-Stage(t-StageVal) {
-    this._t-Stage = t-StageVal;
+  set t_Stage(t_StageVal) {
+    this._t_Stage = t_StageVal;
   }
 
   /**
    * Getter for shr.oncology.N-Stage
    */
-  get n-Stage() {
-    return this._n-Stage;
+  get n_Stage() {
+    return this._n_Stage;
   }
 
   /**
    * Setter for shr.oncology.N-Stage
    */
-  set n-Stage(n-StageVal) {
-    this._n-Stage = n-StageVal;
+  set n_Stage(n_StageVal) {
+    this._n_Stage = n_StageVal;
   }
 
   /**
    * Getter for shr.oncology.M-Stage
    */
-  get m-Stage() {
-    return this._m-Stage;
+  get m_Stage() {
+    return this._m_Stage;
   }
 
   /**
    * Setter for shr.oncology.M-Stage
    */
-  set m-Stage(m-StageVal) {
-    this._m-Stage = m-StageVal;
+  set m_Stage(m_StageVal) {
+    this._m_Stage = m_StageVal;
   }
 
 }

--- a/src/model/shr/oncology/T_Stage.js
+++ b/src/model/shr/oncology/T_Stage.js
@@ -1,7 +1,7 @@
 import ObservationComponent from '../observation/ObservationComponent';
 
-/** Generated from SHR definition for shr.oncology.N-Stage */
-class N-Stage extends ObservationComponent {
+/** Generated from SHR definition for shr.oncology.T-Stage */
+class T_Stage extends ObservationComponent {
 
   /**
    * Convenience getter for value (accesses this.codeableConcept)
@@ -33,4 +33,4 @@ class N-Stage extends ObservationComponent {
 
 }
 
-export default N-Stage;
+export default T_Stage;


### PR DESCRIPTION
updates object model for Chris' choice fix and for my fix to replace hyphens with underscores in identifier names

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [N/A] Manually tested in Chrome
- [N/A] Manually tested in IE

**Documentation**

- [X] This pull request describes why these changes were made
- [X] Recognizes any potential shortcomings/bugs in the description 
- [N/A] Cheat sheet is updated
- [N/A] Demo script is updated 
- [N/A] Documentation on Wiki has been updated 
- [N/A] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [N/A] Note parser has been updated if structured phrases change

**Code Quality**

- [X] 4-space indents - convert any tabs to spaces
- [X] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [X] Code is commented

**Tests**

- [X] Existing tests passed
- [N/A] Added UI tests for slim mode 
- [N/A] Added UI tests for full mode
- [N/A] Added backend tests for fluxNotes code
- [N/A] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Laura

- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
