### PR TITLE
Remove paper and add Dotted Line Divder

### DIFF
--- a/src/context/ContextTray.jsx
+++ b/src/context/ContextTray.jsx
@@ -110,7 +110,7 @@ class ContextTray extends Component {
           panelContent2 = "";
 		}
         return (
-            <div id="forms-panel">
+            <div id="forms-panel" className="dashboard-panel panel-content trio">
                 {panelContent}
                 {panelContent2}
             </div>

--- a/src/context/ContextTray.jsx
+++ b/src/context/ContextTray.jsx
@@ -110,7 +110,7 @@ class ContextTray extends Component {
           panelContent2 = "";
 		}
         return (
-            <div id="forms-panel" className="dashboard-panel panel-content">
+            <div id="forms-panel" className="dashboard-panel">
                 {panelContent}
                 {panelContent2}
             </div>

--- a/src/context/ContextTray.jsx
+++ b/src/context/ContextTray.jsx
@@ -110,7 +110,7 @@ class ContextTray extends Component {
           panelContent2 = "";
 		}
         return (
-            <div id="forms-panel" className="dashboard-panel panel-content trio">
+            <div id="forms-panel" className="dashboard-panel panel-content">
                 {panelContent}
                 {panelContent2}
             </div>

--- a/src/dashboardViews/PostEncounterView.css
+++ b/src/dashboardViews/PostEncounterView.css
@@ -6,6 +6,11 @@
     /*min-height: 810px !important;*/
 }
 
+#post-encounter-view-content .right-border-box { 
+    border-right: 2px dashed #ddd;
+}
+
+
 #post-encounter-view-content .full-panel { 
     height: auto;
 }

--- a/src/dashboardViews/PostEncounterView.jsx
+++ b/src/dashboardViews/PostEncounterView.jsx
@@ -1,6 +1,5 @@
 import React, {Component} from 'react';
 import { Row, Col } from 'react-flexbox-grid';
-import Paper from 'material-ui/Paper';
 import FluxNotesEditor from '../notes/FluxNotesEditor';
 import ContextTray from '../context/ContextTray';
 import SummaryPanel from '../panels/SummaryPanel'

--- a/src/dashboardViews/PostEncounterView.jsx
+++ b/src/dashboardViews/PostEncounterView.jsx
@@ -13,7 +13,7 @@ class PostEncounterView extends Component {
         return (
             <div id="post-encounter-view-content">
                 <Row center="xs">
-                    <Col sm={4}>
+                    <Col sm={4} className="right-border-box">
                         <div className="fitted-panel panel-content dashboard-panel">
                             <SummaryPanel 
                                 isWide={false}

--- a/src/dashboardViews/PostEncounterView.jsx
+++ b/src/dashboardViews/PostEncounterView.jsx
@@ -14,16 +14,16 @@ class PostEncounterView extends Component {
             <div id="post-encounter-view-content">
                 <Row center="xs">
                     <Col sm={4}>
-                        <Paper className="fitted-panel panel-content dashboard-panel">
+                        <div className="fitted-panel panel-content dashboard-panel">
                             <SummaryPanel 
                                 isWide={false}
                                 {...this.props}
                             />
-                        </Paper>
+                        </div>
                     </Col>
 
                     <Col sm={5} >
-                        <Paper className="fitted-panel panel-content dashboard-panel">
+                        <div className="fitted-panel panel-content dashboard-panel">
                             <FluxNotesEditor
                                 onSelectionChange={this.props.handleSelectionChange}
                                 newCurrentShortcut={this.props.newCurrentShortcut}
@@ -35,18 +35,18 @@ class PostEncounterView extends Component {
                                 updateErrors={this.props.updateErrors}
                                 errors={this.props.appState.errors}
                             />
-                        </Paper>
+                        </div>
                     </Col>
 
                     <Col sm={3}>
-                        <Paper className="fitted-panel panel-content dashboard-panel">
+                        <div className="fitted-panel panel-content dashboard-panel">
                             <ContextTray
                                 ref={(comp) => { this.contextTray = comp; }}
                                 patient={this.props.appState.patient}
                                 contextManager={this.props.contextManager}
                                 onShortcutClicked={this.props.handleSummaryItemSelected}
                             />
-                        </Paper>
+                        </div>
                     </Col>
                 </Row>
             </div>

--- a/src/index.css
+++ b/src/index.css
@@ -7,7 +7,7 @@ body {
 }
 
 ::-webkit-scrollbar {
-    width: 12px;
+    width: 14px;
     height: 12px;
 }
 
@@ -19,6 +19,6 @@ body {
 
 ::-webkit-scrollbar-thumb {
     border-radius: 10px;
-    background-color: #ddd;
+    background-color: #F3F3F3;
     -webkit-box-shadow: inset 0 0 5px rgba(0,0,0,0.5);
 }

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -488,7 +488,7 @@ class FluxNotesEditor extends React.Component {
          * Render the editor, toolbar, dropdown and description for note
          */
         return (
-            <div id="clinical-notes" className="dashboard-panel" onClick={(event) => { console.log('focusing on editor'); editor.focus(); }}>
+            <div id="clinical-notes" className="dashboard-panel" onClick={(event) => { editor.focus(); }}>
                 {noteDescriptionContent}
                 <div className="MyEditor-root">
                     <EditorToolbar

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -488,7 +488,7 @@ class FluxNotesEditor extends React.Component {
          * Render the editor, toolbar, dropdown and description for note
          */
         return (
-            <div id="clinical-notes" className="dashboard-panel panel-content" onClick={(event) => { console.log('focusing on editor'); editor.focus(); }}>
+            <div id="clinical-notes" className="dashboard-panel" onClick={(event) => { console.log('focusing on editor'); editor.focus(); }}>
                 {noteDescriptionContent}
                 <div className="MyEditor-root">
                     <EditorToolbar

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -488,7 +488,7 @@ class FluxNotesEditor extends React.Component {
          * Render the editor, toolbar, dropdown and description for note
          */
         return (
-            <div id="clinical-notes" onClick={(event) => { editor.focus(); }}>
+            <div id="clinical-notes" className="dashboard-panel panel-content trio" onClick={(event) => { console.log('focusing on editor'); editor.focus(); }}>
                 {noteDescriptionContent}
                 <div className="MyEditor-root">
                     <EditorToolbar

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -488,7 +488,7 @@ class FluxNotesEditor extends React.Component {
          * Render the editor, toolbar, dropdown and description for note
          */
         return (
-            <div id="clinical-notes" className="dashboard-panel panel-content trio" onClick={(event) => { console.log('focusing on editor'); editor.focus(); }}>
+            <div id="clinical-notes" className="dashboard-panel panel-content" onClick={(event) => { console.log('focusing on editor'); editor.focus(); }}>
                 {noteDescriptionContent}
                 <div className="MyEditor-root">
                     <EditorToolbar

--- a/src/summary/DataSummaryPanel.jsx
+++ b/src/summary/DataSummaryPanel.jsx
@@ -103,7 +103,7 @@ class DataSummaryPanel extends Component {
         const { tabValue } = this.state;
 
         return (
-            <div id="condition-summary-section" className="dashboard-panel panel-content trio">
+            <div id="condition-summary-section" className="dashboard-panel panel-content">
                 <Tabs
                     value={tabValue}
                     onChange={this.selectTab}

--- a/src/summary/DataSummaryPanel.jsx
+++ b/src/summary/DataSummaryPanel.jsx
@@ -103,7 +103,7 @@ class DataSummaryPanel extends Component {
         const { tabValue } = this.state;
 
         return (
-            <div id="condition-summary-section">
+            <div id="condition-summary-section" className="dashboard-panel panel-content trio">
                 <Tabs
                     value={tabValue}
                     onChange={this.selectTab}

--- a/src/timeline/TimelinePanel.jsx
+++ b/src/timeline/TimelinePanel.jsx
@@ -142,7 +142,7 @@ class TimelinePanel extends Component {
 
   render() {
     return (
-      <div id="timeline">
+      <div id="timeline" className="dashboard-panel panel-content">
         <HoverItem
           title={this.state.hoverItem.title}
           text={this.state.hoverItem.text}

--- a/src/timeline/TimelinePanel.jsx
+++ b/src/timeline/TimelinePanel.jsx
@@ -142,7 +142,7 @@ class TimelinePanel extends Component {
 
   render() {
     return (
-      <div id="timeline" className="dashboard-panel panel-content">
+      <div id="timeline" className="dashboard-panel">
         <HoverItem
           title={this.state.hoverItem.title}
           text={this.state.hoverItem.text}

--- a/src/viewer/ShortcutViewer.css
+++ b/src/viewer/ShortcutViewer.css
@@ -13,7 +13,7 @@
     overflow-y: scroll;
 }
 
-#panel-content {
+#viewer-panel-content {
     margin-bottom: 400px;
 }
 
@@ -21,7 +21,7 @@
     position: fixed;
     bottom: 0px;
     left: 25vw;
-    width: calc(75vw - 12px);
+    width: calc(75vw - 14px);
     background-color: #ffffff;
     border-top: 1px solid #d9d9d9 !important;
     text-align: left;

--- a/src/viewer/ShortcutViewer.jsx
+++ b/src/viewer/ShortcutViewer.jsx
@@ -83,7 +83,7 @@ class ShortcutViewer extends Component {
         return (
             <div>
                 <div id="shortcut-viewer">
-                    <div id="panel-content">
+                    <div id="viewer-panel-content">
                         {panelContent}
                     </div>
                     {copyComponent}


### PR DESCRIPTION
Remove Paper component when displaying pre-encounter mode panels and add dotted line to more accurately reflect mockups. 

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- [x] **N/A** Cheat sheet is updated
- [x] **N/A** Demo script is updated 
- [x] **N/A** Documentation on Wiki has been updated 
- [x] **N/A** Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [x] **N/A** Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- [x] **N/A** Added UI tests for slim mode 
- [x] **N/A** Added UI tests for full mode
- [x] **N/A** Added backend tests for fluxNotes code
- [x] **N/A** Added note parser examples to test new functionality


## Reviewer 1: Julia

- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
