### PR TITLE
support PATINA customization of grades shown as options and of prompt

### DIFF
--- a/src/apps/AppManager.jsx
+++ b/src/apps/AppManager.jsx
@@ -16,7 +16,9 @@ class AppManager {
                 display: 'Flux Notes Lite (for PATINA endpoints)',
                 app: SlimApp,
                 shortcutConfigurations: {
-                    'Disease Status': { referenceDateEnabled: false }
+                    'Disease Status': { referenceDateEnabled: false },
+                    'Toxicity': {   gradesToDisplay: [2,3,4,5],
+                                    gradesPrompt: ' PATINA only calculates its endpoint based on adverse events of grades 2 through 5; therefore, only those are shown below. ' }
                 },
                 isExact: true
             }, {

--- a/src/forms/ToxicityForm.jsx
+++ b/src/forms/ToxicityForm.jsx
@@ -222,6 +222,18 @@ class ToxicityForm extends Component {
             value: this.state.searchText,
             onChange: this.handleUpdateAdverseEventInput
         };
+        
+        let gradesToDisplay = this.state.gradeOptions
+        if (!Lang.isUndefined(this.props.gradesToDisplay)) {
+            gradesToDisplay = this.state.gradeOptions.filter((g, i) => {
+                return (this.props.gradesToDisplay.includes(i+1));
+            });
+        }
+        
+        let customGradePrompt = "";
+        if (!Lang.isUndefined(this.props.gradesPrompt)) {
+            customGradePrompt = this.props.gradesPrompt;
+        }
 
         return (
             <div>
@@ -252,10 +264,11 @@ class ToxicityForm extends Component {
                 <h4 className="header-spacing">Grade</h4>
                 <p id="data-element-description">
                     {toxicityLookup.getDescription("grade")}
+                    {customGradePrompt}
                     <span className="helper-text"> Choose one</span>
                 </p>
                 <div id="grade-menu">
-                    {this.state.gradeOptions.map((grade, i) => {
+                    {gradesToDisplay.map((grade, i) => {
                         if (Lang.isUndefined(potentialToxicity.adverseEvent.value.coding[0].displayText.value)) {
                             return this.renderGradeMenuItem(grade)
                         } else {

--- a/src/lib/toxicreactiontotreatment_lookup.jsx
+++ b/src/lib/toxicreactiontotreatment_lookup.jsx
@@ -8772,7 +8772,7 @@ exports.getDescription = (dataElement) => {
     case "adverseEvent":
         return "Any unfavorable and unintended sign, symptom, or disease temporally associated with the use of a medical treatment or procedure that may or may not be considered related to the medical treatment or procedure.";
     case "grade": 
-        return "The severity of the adverse event. The CTCAE displays Grades 1 through 5 with unique clinical descriptions of severity for each adverse event.";
+        return "The severity of the adverse event. The CTCAE defines Grades 1 through 5 with unique clinical descriptions of severity for each adverse event.";
     case "attribution":
         return "The relationship of the event or cause to the adverse event.";
     default: 


### PR DESCRIPTION
Sorry this came up at meetings today and I wanted to make sure it got into next update of fluxnotes.org/patina so I put it in this sprint. It was a quick change.

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [X] Manually tested in Chrome
- [X] Manually tested in IE

**Documentation**

- [X] This pull request describes why these changes were made
- [X] Recognizes any potential shortcomings/bugs in the description 
- [X] Cheat sheet is updated
- [X] Demo script is updated 
- [X] Documentation on Wiki has been updated 
- [X] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [X] Note parser has been updated if structured phrases change

**Code Quality**

- [X] 4-space indents - convert any tabs to spaces
- [X] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [X] Code is commented

**Tests**

- [X] Existing tests passed
- [X] Added UI tests for slim mode 
- [X] Added UI tests for full mode
- [X] Added backend tests for fluxNotes code
- [X] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
