### PR TITLE
Rounded tox button; now supports clicking tox button to disable; refactor disease status 

### DIFF
--- a/src/forms/ProgressionForm.css
+++ b/src/forms/ProgressionForm.css
@@ -13,6 +13,7 @@
 
 .button_multi_select_not_selected {
 }
+
 .button_multi_select_selected {
     background-color: #297DA2 !important;
     color: #fff !important;

--- a/src/forms/ProgressionForm.jsx
+++ b/src/forms/ProgressionForm.jsx
@@ -19,21 +19,26 @@ class ProgressionForm extends Component {
         };
     }
 
-    componentWillMount() {
+    /*
+     * Sets default asOfDate, updates props accordingly.
+     */
+    componentWillMount = () => {
         // Default the asOfDate to use in slim mode copy button
         this.props.updateValue("asOfDate", new moment().format('D MMM YYYY'));
     }
 
-    currentlySelected(item, i) {
-        return (item === i ? true : false);
-    }
-
+    /*
+     * Handles updating the Disease Status 'status'.
+     */
     handleStatusSelection = (e, i) => {
         e.preventDefault();
         const newStatus = this.state.statusOptions[i].name;
         this.props.updateValue("status", newStatus);
     }
 
+    /*
+     * Handles updating the Disease Status 'reason'.
+     */
     handleReasonSelection = (reason, i) => {
         // set active button state array
         let newArray = this.state.reasonButtonsActiveState;
@@ -66,10 +71,16 @@ class ProgressionForm extends Component {
         }
     }
 
+    /*
+     * Handles updating the Disease Status 'reference Date'.
+     */
     handleReferenceDateChange = (selectedReferenceDate) => {
         this.props.updateValue("referenceDateDate", selectedReferenceDate);
-    };
+    }
 
+    /* 
+     * Render the Disease Status 'status' button for the given status
+     */
     renderStatusButtonGroup = (status, i) => {
         const marginSize = "10px";
         const statusName = status.name;
@@ -89,17 +100,20 @@ class ProgressionForm extends Component {
                             marginLeft: marginSize,
                             height: "75px",
                             width: "180px",
-                            padding: "20px 0 20px 0",
                             backgroundColor: "white",
                             textTransform: "none"
                         }}
-                        disabled={this.currentlySelected(this.props.progression.status, this.state.statusOptions[i].name)}
-                >{statusName}
+                        disabled={this.props.progression.status === this.state.statusOptions[i].name}
+                >
+                    {statusName}
                 </Button>
             </div>
         );
     }
 
+    /* 
+     * Render the Disease Status 'reason' button for the given reason
+     */
     renderReasonButtonGroup = (reason, i) => {
 
         let reasonName = reason.name;

--- a/src/forms/ToxicityForm.jsx
+++ b/src/forms/ToxicityForm.jsx
@@ -51,15 +51,18 @@ class ToxicityForm extends Component {
      */
     currentlySelectedAttribution = (attribution) => {
         // What it is checking might need to change if the toxicity.attribution structure changes in Patient
-        return this.props.toxicity.causeCategory === attribution.name ? 'button_selected' : '';
+        return this.props.toxicity.causeCategory === attribution.name;
     }
     
     /*
      * Handle updating the attribution value on toxicity
      */
-    handleAttributionSelection = (attribution) => {
-        // TODO: Possibly add appropriate null checks
-        this.props.updateValue("attribution", attribution.name);
+    handleAttributionSelection = (attribution, isSelected) => {
+        if (isSelected) {
+            this.props.updateValue("attribution", null);
+        } else {
+            this.props.updateValue("attribution", attribution.name);
+        }
     }
 
     /* 
@@ -117,7 +120,7 @@ class ToxicityForm extends Component {
             const descriptionNoSpaces = (Lang.isEmpty(event.descriptionNoSpaces)) ? "" : event.descriptionNoSpaces;
             return (nameNoSpaces.toLowerCase().indexOf(inputValue) >= 0 || descriptionNoSpaces.toLowerCase().indexOf(inputValue) >= 0)
         }).slice(0, 7);
-    };
+    }
 
     /* 
      * When suggestion is clicked, Autosuggest needs to populate the input
@@ -125,8 +128,8 @@ class ToxicityForm extends Component {
      * input value for every given suggestion.
      */
     getSuggestionValue = (suggestion) => {
-        return suggestion.name
-    };
+        return suggestion.name;
+    }
 
     /* 
      * Autosuggest will call this function every time you need to update suggestions.
@@ -136,7 +139,7 @@ class ToxicityForm extends Component {
         this.setState({
             suggestions: this.getSuggestions(value)
         });
-    };
+    }
 
     /* 
      * Autosuggest will call this function every time you need to clear suggestions.
@@ -145,7 +148,7 @@ class ToxicityForm extends Component {
         this.setState({
             suggestions: []
         });
-    };
+    }
 
     /* 
      * Render the adverse event item for the adverse event suggestion
@@ -211,6 +214,37 @@ class ToxicityForm extends Component {
                 <div className="grade-menu-item-description">
                     {gradeDescription}
                 </div>
+            </div>
+        )
+    }
+
+    /* 
+     * Render the attribution button for the given attribution object, 
+     */
+    renderAttributionButton = (attribution, i) => { 
+        const isSelected = this.currentlySelectedAttribution(attribution);
+        const buttonClass = isSelected ? 'button_selected' : ''
+        const tooltipClass = (attribution.description.length > 100) ? "tooltiptext large" : "tooltiptext";
+        const marginSize = "10px";  
+        return (
+            <div key={attribution.name} className="tooltip">
+                <span id={attribution.name} className={tooltipClass}>{attribution.description}</span>
+                <Button raised
+                    key={i}
+                    label={attribution.name}
+                    className={buttonClass}
+                    style={{
+                        marginBottom: marginSize,
+                        marginLeft: marginSize,
+                        borderRadius: "10px",
+                        height: "75px",
+                        width: "180px",
+                        backgroundColor: "white",
+                        textTransform: "none"
+                    }}
+                    onClick={ () => this.handleAttributionSelection(attribution, isSelected)}
+                >{attribution.name}
+                </Button>
             </div>
         )
     }
@@ -285,27 +319,7 @@ class ToxicityForm extends Component {
                 
                 <div className="btn-group-attribution">
                     {toxicityLookup.getAttributionOptions().map((attribution, i) => {
-                        const buttonClass = this.currentlySelectedAttribution(attribution);
-                        const tooltipClass = (attribution.description.length > 100) ? "tooltiptext large" : "tooltiptext";
-                        return (
-                            <div key={attribution.name} className="tooltip">
-                                <span id={attribution.name} className={tooltipClass}>{attribution.description}</span>
-                                <Button raised
-                                    key={i}
-                                    label={attribution.name}
-                                    className={buttonClass}
-                                    style={{
-                                        margin: 0.5,
-                                        height: "75px",
-                                        width: "180px",
-                                        backgroundColor: "white",
-                                        textTransform: "none"
-                                    }}
-                                    onClick={ () => this.handleAttributionSelection(attribution)}
-                                >{attribution.name}
-                                </Button>
-                            </div>
-                        )
+                        return this.renderAttributionButton(attribution, i); 
                     })}
                 </div>
             </div>


### PR DESCRIPTION
Pretty self-explanatory. 

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- [x] **N/A** Cheat sheet is updated
- [x] **N/A** Demo script is updated 
- [x] **N/A** Documentation on Wiki has been updated 
- [x] **N/A** Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [x] **N/A** Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- [x] **N/A** Added UI tests for slim mode 
- [x] **N/A** Added UI tests for full mode
- [x] **N/A** Added backend tests for fluxNotes code
- [x] **N/A** Added note parser examples to test new functionality


## Reviewer 1: Mike T

- [X] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [X] The tests appropriately test the new code, including edge cases
- [X] You have tried to break the code


## Reviewer 2: Julia

- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] N/A The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
