### PR TITLE
Adverse event buttons

### DIFF
--- a/src/apps/AppManager.jsx
+++ b/src/apps/AppManager.jsx
@@ -16,9 +16,10 @@ class AppManager {
                 display: 'Flux Notes Lite (for PATINA endpoints)',
                 app: SlimApp,
                 shortcutConfigurations: {
-                    'Disease Status': { referenceDateEnabled: false },
+                    'Disease Status': { referenceDateEnabled: true },
                     'Toxicity': {   gradesToDisplay: [2,3,4,5],
-                                    gradesPrompt: ' PATINA only calculates its endpoint based on adverse events of grades 2 through 5; therefore, only those are shown below. ' }
+                                    gradesPrompt: ' PATINA only calculates its endpoint based on adverse events of grades 2 through 5; therefore, only those are shown below. ',
+                                    topAdverseEvents: true }
                 },
                 isExact: true
             }, {

--- a/src/apps/AppManager.jsx
+++ b/src/apps/AppManager.jsx
@@ -19,7 +19,8 @@ class AppManager {
                     'Disease Status': { referenceDateEnabled: true },
                     'Toxicity': {   gradesToDisplay: [2,3,4,5],
                                     gradesPrompt: ' PATINA only calculates its endpoint based on adverse events of grades 2 through 5; therefore, only those are shown below. ',
-                                    topAdverseEvents: true }
+                                    topAdverseEvents: ['Febrile neutropenia', 'Fatigue', 'Generalized muscle weakness', 'Anemia', 'Diarrhea', 'Nausea', 'Platelet count decreased', 'Anorexia', 'Constipation', 
+                    'Bullous dermatitis', 'Upper respiratory infection', 'Vomiting', 'Hot flashes', 'Arthralgia', 'Osteoporosis', 'Fever', 'Infusion related reaction', 'Headache', 'Cough', 'Dyspnea']}
                 },
                 isExact: true
             }, {

--- a/src/apps/AppManager.jsx
+++ b/src/apps/AppManager.jsx
@@ -16,7 +16,7 @@ class AppManager {
                 display: 'Flux Notes Lite (for PATINA endpoints)',
                 app: SlimApp,
                 shortcutConfigurations: {
-                    'Disease Status': { referenceDateEnabled: true },
+                    'Disease Status': { referenceDateEnabled: false },
                     'Toxicity': {   gradesToDisplay: [2,3,4,5],
                                     gradesPrompt: ' PATINA only calculates its endpoint based on adverse events of grades 2 through 5; therefore, only those are shown below. ',
                                     topAdverseEvents: ['Febrile neutropenia', 'Fatigue', 'Generalized muscle weakness', 'Anemia', 'Diarrhea', 'Nausea', 'Platelet count decreased', 'Anorexia', 'Constipation', 

--- a/src/forms/ToxicityForm.css
+++ b/src/forms/ToxicityForm.css
@@ -221,7 +221,7 @@
 .btn-group-adverse-event,
 .btn-group-attribution {
     display: flex;
-    justify-content: space-evenly;
+    justify-content: left;
     flex-wrap: wrap;
     margin-top: 40px;
 }
@@ -234,6 +234,7 @@
     padding: 20px 0;
     background-color: white;
     text-transform: none;
+    border-radius: 10px;
 }
 
 .btn-group-adverse-event button:hover,

--- a/src/forms/ToxicityForm.css
+++ b/src/forms/ToxicityForm.css
@@ -1,5 +1,4 @@
-
-.grade-menu-item { 
+.grade-menu-item {
     display: flex; /* or inline-flex */
     padding: 15px 0;
     border-bottom: 1px solid rgba(224, 224, 224, 1);
@@ -9,16 +8,16 @@
     box-shadow: rgba(0, 0, 0, 0.12) -1px 0px 1px 0px, rgba(0, 0, 0, 0.12) 1px 0px 1px 0px;
 }
 
-.grade-menu-item:hover { 
+.grade-menu-item:hover {
     background-color: rgba(0,0,0,0.08);
     cursor: pointer;
 }
 
-.grade-menu-item:first-child { 
+.grade-menu-item:first-child {
     border-top: 1px solid rgba(224, 224, 224, 1);
 }
 
-.grade-menu-item .grade-menu-item-name { 
+.grade-menu-item .grade-menu-item-name {
     margin: 0 0 0 20px;
     min-width: 95px;
     display: inline-block;
@@ -36,22 +35,22 @@
     margin: -5px 20px -5px 20px;
 }
 
-.grade-menu-item .grade-menu-item-description { 
+.grade-menu-item .grade-menu-item-description {
     margin: 0 20px 0 0;
     display: inline-block;
     max-width: 75%;
 }
 
-.grade-menu-item.selected { 
+.grade-menu-item.selected {
     background-color: rgb(41, 125, 162);
     border: rgb(41, 125, 162);
     color: rgba(255,255,255,1);
 }
 
-.grade-menu-item.disabled { 
+.grade-menu-item.disabled {
     color: rgba(224, 224, 224, 1);
 }
-.grade-menu-item.disabled:hover { 
+.grade-menu-item.disabled:hover {
     background-color: initial;
     cursor: default;
 }
@@ -127,8 +126,8 @@
     transition-delay: 0.5s;
 }
 
-/* 
- * Autosuggest styling 
+/*
+ * Autosuggest styling
  */
 .react-autosuggest__container {
     position: relative;
@@ -215,4 +214,31 @@
 .helper-text {
     color: #b1b1b1;
 }
+
+/*
+ * Button styling
+ */
+.btn-group-adverse-event,
+.btn-group-attribution {
+    display: flex;
+    justify-content: space-evenly;
+    flex-wrap: wrap;
+    margin-top: 40px;
+}
+
+.btn-group-adverse-event button,
+.btn-group-attribution button {
+    margin: 5px;
+    height: 75px;
+    width: 180px;
+    padding: 20px 0;
+    background-color: white;
+    text-transform: none;
+}
+
+.btn-group-adverse-event button:hover,
+.btn-group-attribution button:hover {
+    background-color: rgba(224, 224, 224, 0.5);
+}
+
 

--- a/src/forms/ToxicityForm.jsx
+++ b/src/forms/ToxicityForm.jsx
@@ -55,7 +55,7 @@ class ToxicityForm extends Component {
     }
 
     currentlySelectedAdverseEvent = (adverseEvent) => {
-        return this.props.toxicity.adverseEvent.codeableConcept.coding[0].displayText.value === adverseEvent.name ? 'button_selected' : '';
+        return this.props.object.adverseEvent === adverseEvent.name ? 'button_selected' : '';
     }
 
     /*
@@ -259,11 +259,36 @@ class ToxicityForm extends Component {
 
     render() {
         let potentialToxicity = Lang.isNull(this.props.object) ? new ToxicReactionToTreatment() : this.props.object;
+        let topAdverseEventSection = null;
         const inputProps = {
             placeholder: 'Enter symptom',
             value: this.state.searchText,
             onChange: this.handleUpdateAdverseEventInput
         };
+        if (Lang.isUndefined(this.props.topAdverseEvents) || this.props.topAdverseEvents) {
+            topAdverseEventSection =(
+            <div className="btn-group-adverse-event">
+                {toxicityLookup.getAdverseEventOptions().slice(0,20).map((adverseEvent, i) => {
+                    if (adverseEvent.description === null) {
+                        return "";
+                    }
+                    const tooltipClass = (adverseEvent.description.length > 100) ? "tooltiptext large" : "tooltiptext";
+                    return (
+                        <div key={adverseEvent.name} className="tooltip">
+                            <span id={adverseEvent.name} className={tooltipClass}>{adverseEvent.description}</span>
+                            <Button raised
+                                key={i}
+                                label={adverseEvent.name}
+                                onClick={() => this.handleAdverseEventSelection(adverseEvent.name)}
+                                className={this.currentlySelectedAdverseEvent(adverseEvent)}
+                            >{adverseEvent.name}
+                            </Button>
+                        </div>
+                    )
+                })}
+            </div>
+            );
+        }
 
         let gradesToDisplay = this.state.gradeOptions
         if (!Lang.isUndefined(this.props.gradesToDisplay)) {
@@ -301,27 +326,7 @@ class ToxicityForm extends Component {
                         renderSuggestion={this.renderSuggestion}
                         inputProps={inputProps}
                     />
-
-                    <div className="btn-group-adverse-event">
-                        {toxicityLookup.getAdverseEventOptions().slice(0,20).map((adverseEvent, i) => {
-                            if (adverseEvent.description === null) {
-                                return "";
-                            }
-                            const tooltipClass = (adverseEvent.description.length > 100) ? "tooltiptext large" : "tooltiptext";
-                            return (
-                                <div key={adverseEvent.name} className="tooltip">
-                                    <span id={adverseEvent.name} className={tooltipClass}>{adverseEvent.description}</span>
-                                    <Button raised
-                                        key={i}
-                                        label={adverseEvent.name}
-                                        onClick={() => this.handleAdverseEventSelection(adverseEvent.name)}
-                                        className={this.currentlySelectedAdverseEvent(adverseEvent)}
-                                    >{adverseEvent.name}
-                                    </Button>
-                                </div>
-                            )
-                        })}
-                    </div>
+                    {topAdverseEventSection}
                     <h4 className="header-spacing">Grade</h4>
                     <p id="data-element-description">
                         {toxicityLookup.getDescription("grade")}

--- a/src/forms/ToxicityForm.jsx
+++ b/src/forms/ToxicityForm.jsx
@@ -53,7 +53,6 @@ class ToxicityForm extends Component {
         // What it is checking might need to change if the toxicity.attribution structure changes in Patient
         return this.props.object.causeCategory === attribution.name;
     }
-    
     /*
      * Handle updating the attribution value on toxicity
      */
@@ -76,6 +75,10 @@ class ToxicityForm extends Component {
             this.props.updateValue("grade", grade);
         }
     }
+    currentlySelectedAdverseEvent = (adverseEvent) => {
+        // What it is checking might need to change if the toxicity.attribution structure changes in Patient
+        return this.props.toxicity.adverseEvent.causeCategory.value.coding[0].displayText.value===adverseEvent.name ? 'button_selected' : '';
+    }    
 
     /* 
      * When a valid adverse event is selected, update potential toxicity 
@@ -196,7 +199,7 @@ class ToxicityForm extends Component {
             });
             const currentAdverseEvent = Array.find(adverseEventOptionsLowerCase, {name: adverseEventNameLowerCase})
             gradeDescription = currentAdverseEvent[currentGradeLevel];
-        }
+        }       
         return (
             <div
                 className={gradeMenuClass}
@@ -266,9 +269,7 @@ class ToxicityForm extends Component {
         
         let customGradePrompt = "";
         if (!Lang.isUndefined(this.props.gradesPrompt)) {
-            customGradePrompt = this.props.gradesPrompt;
-        }
-
+            customGradePrompt = this.props.gradesPrompt;          
         return (
             <div>
                 <h1>Toxicity</h1>
@@ -293,8 +294,37 @@ class ToxicityForm extends Component {
                     getSuggestionValue={this.getSuggestionValue}
                     renderSuggestion={this.renderSuggestion}
                     inputProps={inputProps}
-                />
-
+                />  
+                <div className="btn-group-adverse-event">
+                    {toxicityLookup.getAdverseEventOptions().slice(0,20).map((adverseEvent, i) => {
+                        const buttonClass = this.currentlySelectedAdverseEvent(adverseEvent);
+                        if (adverseEvent.description === null) {
+                            return "";
+                        }                      
+                        const tooltipClass = (adverseEvent.description.length > 100) ? "tooltiptext large" : "tooltiptext";
+                        return (
+                            <div key={adverseEvent.name} className="tooltip">
+                                <span id={adverseEvent.name} className={tooltipClass}>{adverseEvent.description}</span>
+                                <Button raised
+                                    key={i}
+                                    label={adverseEvent.name}
+                                    className={buttonClass}
+                                    style={{
+                                        marginBottom: "10px",
+                                        marginLeft: "10px",
+                                        height: "75px",
+                                        width: "180px",
+                                        padding: "20px 0 20px 0",
+                                        backgroundColor: "white",
+                                        textTransform: "none"
+                                    }}
+                                    onClick={ () => this.handleAdverseEventSelection(adverseEvent.name)}
+                                >{adverseEvent.name}
+                                </Button>
+                            </div>
+                        )
+                    })}
+                </div>                
                 <h4 className="header-spacing">Grade</h4>
                 <p id="data-element-description">
                     {toxicityLookup.getDescription("grade")}
@@ -325,7 +355,10 @@ class ToxicityForm extends Component {
             </div>
         );
     }
+    }
 }
+
+
 
 export default ToxicityForm;
 

--- a/src/forms/ToxicityForm.jsx
+++ b/src/forms/ToxicityForm.jsx
@@ -265,7 +265,7 @@ class ToxicityForm extends Component {
             value: this.state.searchText,
             onChange: this.handleUpdateAdverseEventInput
         };
-        let topAdverseEvents = this.props.topAdverseEvents;
+ 
         if (!Lang.isUndefined(this.props.topAdverseEvents) && this.props.topAdverseEvents.length > 0){
             let topAdverseEventObjects = this.props.topAdverseEvents.map((adverseEvent, i) => {
                 return toxicityLookup.findAdverseEvent(adverseEvent); 

--- a/src/forms/ToxicityForm.jsx
+++ b/src/forms/ToxicityForm.jsx
@@ -12,7 +12,7 @@ import './ToxicityForm.css';
 class ToxicityForm extends Component {
     constructor(props) {
         super(props);
-        
+
         const adverseEventOptionsIncludingNoSpaces = toxicityLookup.getAdverseEventOptions().map(obj => {
             const objCopy = Lang.clone(obj);
             objCopy.nameNoSpaces = objCopy.name ? objCopy.name.replace(/\s/g,'') : objCopy.name;
@@ -24,12 +24,12 @@ class ToxicityForm extends Component {
             gradeOptions: toxicityLookup.getGradeOptions(),
             adverseEventOptions: adverseEventOptionsIncludingNoSpaces,
             suggestions: [],
-            searchText: '',
+            searchText: ''
         };
     }
 
-    /* 
-     * Reset potential toxicity 
+    /*
+     * Reset potential toxicity
      */
     resetPotentialToxicity = () => {
         this.setState({
@@ -37,7 +37,7 @@ class ToxicityForm extends Component {
         })
     }
 
-    /* 
+    /*
      * Changes the potential toxicity to the provided value
      */
     changePotentialToxicity = ({newValue}) => {
@@ -45,7 +45,7 @@ class ToxicityForm extends Component {
             searchText: newValue
         });
     }
-    
+
     /*
      * Changes the className for the button to highlight selected attribution
      */
@@ -53,6 +53,11 @@ class ToxicityForm extends Component {
         // What it is checking might need to change if the toxicity.attribution structure changes in Patient
         return this.props.object.causeCategory === attribution.name;
     }
+
+    currentlySelectedAdverseEvent = (adverseEvent) => {
+        return this.props.toxicity.adverseEvent.codeableConcept.coding[0].displayText.value === adverseEvent.name ? 'button_selected' : '';
+    }
+
     /*
      * Handle updating the attribution value on toxicity
      */
@@ -64,8 +69,8 @@ class ToxicityForm extends Component {
         }
     }
 
-    /* 
-     * When a valid grade is selected, update potential toxicity 
+    /*
+     * When a valid grade is selected, update potential toxicity
      */
     handleGradeSelection = (e, grade, isSelected) => {
         e.preventDefault();
@@ -74,9 +79,10 @@ class ToxicityForm extends Component {
         } else {
             this.props.updateValue("grade", grade);
         }
-    }   
-    /* 
-     * When a valid adverse event is selected, update potential toxicity 
+    }
+
+    /*
+     * When a valid adverse event is selected, update potential toxicity
      */
     handleAdverseEventSelection = (newAdverseEvent) => {
         // A null or undefined value for newAdverseEvent should trigger the deletion of the current adverseEvent
@@ -85,14 +91,15 @@ class ToxicityForm extends Component {
         } else {
             this.props.updateValue("adverseEvent", titlecase(newAdverseEvent));
         }
+
         // Make sure grade is possible with given new tox
         if (!toxicityLookup.isValidGradeForAdverseEvent(this.props.object.adverseEventGrade, newAdverseEvent)) {
             this.props.updateValue("grade", null);
         }
     }
 
-    /* 
-     * When new text is available for AE selection, update search text 
+    /*
+     * When new text is available for AE selection, update search text
      *  and also update potential toxicity when valid
      */
     handleUpdateAdverseEventInput = (e, {newValue}) => {
@@ -106,7 +113,7 @@ class ToxicityForm extends Component {
         }
     }
 
-    /* 
+    /*
      * Render the adverse event  item for the adverse event suggestion
      */
     getSuggestions = (searchText) => {
@@ -120,7 +127,7 @@ class ToxicityForm extends Component {
         }).slice(0, 7);
     }
 
-    /* 
+    /*
      * When suggestion is clicked, Autosuggest needs to populate the input
      * based on the clicked suggestion. Teach Autosuggest how to calculate the
      * input value for every given suggestion.
@@ -129,7 +136,7 @@ class ToxicityForm extends Component {
         return suggestion.name;
     }
 
-    /* 
+    /*
      * Autosuggest will call this function every time you need to update suggestions.
      * You already implemented this logic above, so just use it.
      */
@@ -139,7 +146,7 @@ class ToxicityForm extends Component {
         });
     }
 
-    /* 
+    /*
      * Autosuggest will call this function every time you need to clear suggestions.
      */
     onSuggestionsClearRequested = () => {
@@ -148,7 +155,7 @@ class ToxicityForm extends Component {
         });
     }
 
-    /* 
+    /*
      * Render the adverse event item for the adverse event suggestion
      */
     renderSuggestion = (suggestion) => {
@@ -164,9 +171,9 @@ class ToxicityForm extends Component {
         );
     }
 
-    /* 
-     * Render the grade menu item for the given grade object, 
-     *  Update grade description if there is a current adverse event 
+    /*
+     * Render the grade menu item for the given grade object,
+     *  Update grade description if there is a current adverse event
      */
     renderGradeMenuItem = (grade, adverseEventName) => {
         const currentGradeLevel = grade.name;
@@ -174,11 +181,13 @@ class ToxicityForm extends Component {
 
         const isSelected = !Lang.isEmpty(this.props.object) && !Lang.isEmpty(this.props.object.adverseEvent) && this.props.object.adverseEventGrade === grade.name
         let gradeMenuClass = "grade-menu-item";
+
         if (isDisabled) {
             gradeMenuClass += " disabled"
         } else if (isSelected) {
             gradeMenuClass += " selected"
         }
+
         let gradeDescription = "";
 
         if (Lang.isUndefined(adverseEventName)) {
@@ -194,7 +203,8 @@ class ToxicityForm extends Component {
             });
             const currentAdverseEvent = Array.find(adverseEventOptionsLowerCase, {name: adverseEventNameLowerCase})
             gradeDescription = currentAdverseEvent[currentGradeLevel];
-        }       
+        }
+
         return (
             <div
                 className={gradeMenuClass}
@@ -254,100 +264,94 @@ class ToxicityForm extends Component {
             value: this.state.searchText,
             onChange: this.handleUpdateAdverseEventInput
         };
-        
+
         let gradesToDisplay = this.state.gradeOptions
         if (!Lang.isUndefined(this.props.gradesToDisplay)) {
             gradesToDisplay = this.state.gradeOptions.filter((g, i) => {
                 return (this.props.gradesToDisplay.includes(i+1));
             });
         }
-        
+
         let customGradePrompt = "";
         if (!Lang.isUndefined(this.props.gradesPrompt)) {
-            customGradePrompt = this.props.gradesPrompt;          
-        return (
-            <div>
-                <h1>Toxicity</h1>
-                <p id="data-element-description">
-                    {toxicityLookup.getDescription("toxicity")}
-                    <br/>
-                    <br/>
-                    Based on your selections below, the copy button at the bottom will copy a <a href="toxicitySheet.pdf" target="_blank">formatted phrase</a> to paste in your EHR.
-                </p>
-                <Divider className="divider"/>
+            customGradePrompt = this.props.gradesPrompt;
 
-                <h4 className="header-spacing">Adverse Event</h4>
-                <p id="data-element-description">
-                    {toxicityLookup.getDescription("adverseEvent")}
-                </p>
+            return (
+                <div>
+                    <h1>Toxicity</h1>
+                    <p id="data-element-description">
+                        {toxicityLookup.getDescription("toxicity")}
+                        <br/>
+                        <br/>
+                        Based on your selections below, the copy button at the bottom will copy a <a href="toxicitySheet.pdf" target="_blank">formatted phrase</a> to paste in your EHR.
+                    </p>
+                    <Divider className="divider"/>
 
-                <Autosuggest
-                    suggestions={this.state.suggestions}
-                    onSuggestionsFetchRequested={this.onSuggestionsFetchRequested}
-                    onSuggestionsClearRequested={this.onSuggestionsClearRequested}
+                    <h4 className="header-spacing">Adverse Event</h4>
+                    <p id="data-element-description">
+                        {toxicityLookup.getDescription("adverseEvent")}
+                    </p>
 
-                    getSuggestionValue={this.getSuggestionValue}
-                    renderSuggestion={this.renderSuggestion}
-                    inputProps={inputProps}
-                />  
-                <div className="btn-group-adverse-event">
-                    {toxicityLookup.getAdverseEventOptions().slice(0,20).map((adverseEvent, i) => {
-                        if (adverseEvent.description === null) {
-                            return "";
-                        }                      
-                        const tooltipClass = (adverseEvent.description.length > 100) ? "tooltiptext large" : "tooltiptext";
-                        return (
-                            <div key={adverseEvent.name} className="tooltip">
-                                <span id={adverseEvent.name} className={tooltipClass}>{adverseEvent.description}</span>
-                                <Button raised
-                                    key={i}
-                                    label={adverseEvent.name}
-                                    style={{
-                                        marginBottom: "10px",
-                                        marginLeft: "10px",
-                                        height: "75px",
-                                        width: "180px",
-                                        padding: "20px 0 20px 0",
-                                        backgroundColor: "white",
-                                        textTransform: "none"
-                                    }}
-                                    onClick={ () => this.handleAdverseEventSelection(adverseEvent.name)}
-                                >{adverseEvent.name}
-                                </Button>
-                            </div>
-                        )
-                    })}
-                </div>                
-                <h4 className="header-spacing">Grade</h4>
-                <p id="data-element-description">
-                    {toxicityLookup.getDescription("grade")}
-                    {customGradePrompt}
-                    <span className="helper-text"> Choose one</span>
-                </p>
-                <div id="grade-menu">
-                    {gradesToDisplay.map((grade, i) => {
-                        if (Lang.isUndefined(potentialToxicity.adverseEvent)) {
-                            return this.renderGradeMenuItem(grade)
-                        } else {
-                            return this.renderGradeMenuItem(grade, potentialToxicity.adverseEvent);
-                        }
-                    })}
+                    <Autosuggest
+                        suggestions={this.state.suggestions}
+                        onSuggestionsFetchRequested={this.onSuggestionsFetchRequested}
+                        onSuggestionsClearRequested={this.onSuggestionsClearRequested}
+
+                        getSuggestionValue={this.getSuggestionValue}
+                        renderSuggestion={this.renderSuggestion}
+                        inputProps={inputProps}
+                    />
+
+                    <div className="btn-group-adverse-event">
+                        {toxicityLookup.getAdverseEventOptions().slice(0,20).map((adverseEvent, i) => {
+                            if (adverseEvent.description === null) {
+                                return "";
+                            }
+                            const tooltipClass = (adverseEvent.description.length > 100) ? "tooltiptext large" : "tooltiptext";
+                            return (
+                                <div key={adverseEvent.name} className="tooltip">
+                                    <span id={adverseEvent.name} className={tooltipClass}>{adverseEvent.description}</span>
+                                    <Button raised
+                                        key={i}
+                                        label={adverseEvent.name}
+                                        onClick={() => this.handleAdverseEventSelection(adverseEvent.name)}
+                                        className={this.currentlySelectedAdverseEvent(adverseEvent)}
+                                    >{adverseEvent.name}
+                                    </Button>
+                                </div>
+                            )
+                        })}
+                    </div>
+                    <h4 className="header-spacing">Grade</h4>
+                    <p id="data-element-description">
+                        {toxicityLookup.getDescription("grade")}
+                        {customGradePrompt}
+                        <span className="helper-text"> Choose one</span>
+                    </p>
+                    <div id="grade-menu">
+                        {gradesToDisplay.map((grade, i) => {
+                            if (Lang.isUndefined(potentialToxicity.adverseEvent)) {
+                                return this.renderGradeMenuItem(grade)
+                            } else {
+                                return this.renderGradeMenuItem(grade, potentialToxicity.adverseEvent);
+                            }
+                        })}
+                    </div>
+
+                    <h4 className="header-spacing">Attribution</h4>
+                    <p id="data-element-description">
+                        {toxicityLookup.getDescription("attribution")}
+                        <span className="helper-text"> Choose one</span>
+                    </p>
+
+                    <div className="btn-group-attribution">
+                        {toxicityLookup.getAttributionOptions().map((attribution, i) => {
+                            return this.renderAttributionButton(attribution, i);
+                        })}
+                    </div>
                 </div>
-                
-                <h4 className="header-spacing">Attribution</h4>
-                <p id="data-element-description">
-                    {toxicityLookup.getDescription("attribution")}
-                    <span className="helper-text"> Choose one</span>
-                </p>
-                
-                <div className="btn-group-attribution">
-                    {toxicityLookup.getAttributionOptions().map((attribution, i) => {
-                        return this.renderAttributionButton(attribution, i); 
-                    })}
-                </div>
-            </div>
-        );
-    }
+            );
+        }
     }
 }
 

--- a/src/forms/ToxicityForm.jsx
+++ b/src/forms/ToxicityForm.jsx
@@ -265,10 +265,14 @@ class ToxicityForm extends Component {
             value: this.state.searchText,
             onChange: this.handleUpdateAdverseEventInput
         };
-        if (Lang.isUndefined(this.props.topAdverseEvents) || this.props.topAdverseEvents) {
-            topAdverseEventSection =(
+        let topAdverseEvents = this.props.topAdverseEvents;
+        if (!Lang.isUndefined(this.props.topAdverseEvents) && this.props.topAdverseEvents.length > 0){
+            let topAdverseEventObjects = this.props.topAdverseEvents.map((adverseEvent, i) => {
+                return toxicityLookup.findAdverseEvent(adverseEvent); 
+            });
+            topAdverseEventSection = (
             <div className="btn-group-adverse-event">
-                {toxicityLookup.getAdverseEventOptions().slice(0,20).map((adverseEvent, i) => {
+                {topAdverseEventObjects.map((adverseEvent, i) => {
                     if (adverseEvent.description === null) {
                         return "";
                     }
@@ -287,7 +291,7 @@ class ToxicityForm extends Component {
                     )
                 })}
             </div>
-            );
+            )
         }
 
         let gradesToDisplay = this.state.gradeOptions
@@ -342,7 +346,6 @@ class ToxicityForm extends Component {
                             }
                         })}
                     </div>
-
                     <h4 className="header-spacing">Attribution</h4>
                     <p id="data-element-description">
                         {toxicityLookup.getDescription("attribution")}

--- a/src/forms/ToxicityForm.jsx
+++ b/src/forms/ToxicityForm.jsx
@@ -74,12 +74,7 @@ class ToxicityForm extends Component {
         } else {
             this.props.updateValue("grade", grade);
         }
-    }
-    currentlySelectedAdverseEvent = (adverseEvent) => {
-        // What it is checking might need to change if the toxicity.attribution structure changes in Patient
-        return this.props.toxicity.adverseEvent.causeCategory.value.coding[0].displayText.value===adverseEvent.name ? 'button_selected' : '';
-    }    
-
+    }   
     /* 
      * When a valid adverse event is selected, update potential toxicity 
      */
@@ -297,7 +292,6 @@ class ToxicityForm extends Component {
                 />  
                 <div className="btn-group-adverse-event">
                     {toxicityLookup.getAdverseEventOptions().slice(0,20).map((adverseEvent, i) => {
-                        const buttonClass = this.currentlySelectedAdverseEvent(adverseEvent);
                         if (adverseEvent.description === null) {
                             return "";
                         }                      
@@ -308,7 +302,6 @@ class ToxicityForm extends Component {
                                 <Button raised
                                     key={i}
                                     label={adverseEvent.name}
-                                    className={buttonClass}
                                     style={{
                                         marginBottom: "10px",
                                         marginLeft: "10px",

--- a/src/lib/toxicreactiontotreatment_lookup.jsx
+++ b/src/lib/toxicreactiontotreatment_lookup.jsx
@@ -71,6 +71,39 @@ const gradeOptions = [
 // V4.0 CTCAE info from CTCAE_4.03_2010-06-14.xls
 const adverseEventOptions = [
     {
+        "MedDRA v12.0 Code": 10016288,
+        "SOC": "Blood and lymphatic system disorders",
+        "name": "Febrile neutropenia",
+        "Grade 1": null,
+        "Grade 2": null,
+        "Grade 3": "ANC <1000/mm3 with a single temperature of >38.3 degrees C (101 degrees F) or a sustained temperature of >=38 degrees C (100.4 degrees F) for more than one hour",
+        "Grade 4": "Life-threatening consequences; urgent intervention indicated",
+        "Grade 5": "Death",
+        "description": "A disorder characterized by an ANC <1000/mm3 and a single temperature of >38.3 degrees C (101 degrees F) or a sustained temperature of >=38 degrees C (100.4 degrees F) for more than one hour"
+    },
+    {
+        "MedDRA v12.0 Code": 10016256,
+        "SOC": "General disorders and administration site conditions",
+        "name": "Fatigue",
+        "Grade 1": "Fatigue relieved by rest",
+        "Grade 2": "Fatigue not relieved by rest; limiting instrumental ADL",
+        "Grade 3": "Fatigue not relieved by rest, limiting self care ADL",
+        "Grade 4": null,
+        "Grade 5": null,
+        "description": "A disorder characterized by a state of generalized weakness with a pronounced inability to summon sufficient energy to accomplish daily activities."
+    },
+    {
+        "MedDRA v12.0 Code": 10062572,
+        "SOC": "Musculoskeletal and connective tissue disorders",
+        "name": "Generalized muscle weakness",
+        "Grade 1": "Symptomatic; weakness perceived by patient but not evident on physical exam",
+        "Grade 2": "Symptomatic; weakness evident on physical exam; weakness limiting instrumental ADL",
+        "Grade 3": "Weakness limiting self care ADL; disabling",
+        "Grade 4": null,
+        "Grade 5": null,
+        "description": "A disorder characterized by a reduction in the strength of muscles in multiple anatomic sites."
+    },
+    {
         "MedDRA v12.0 Code": 10002272,
         "SOC": "Blood and lymphatic system disorders",
         "name": "Anemia",
@@ -80,6 +113,193 @@ const adverseEventOptions = [
         "Grade 4": "Life-threatening consequences; urgent intervention indicated",
         "Grade 5": "Death",
         "description": "A disorder characterized by an reduction in the amount of hemoglobin in 100 ml of blood. Signs and symptoms of anemia may include pallor of the skin and mucous membranes, shortness of breath, palpitations of the heart, soft systolic murmurs, lethargy, and fatigability."
+    },
+    {
+        "MedDRA v12.0 Code": 10012727,
+        "SOC": "Gastrointestinal disorders",
+        "name": "Diarrhea",
+        "Grade 1": "Increase of <4 stools per day over baseline; mild increase in ostomy output compared to baseline",
+        "Grade 2": "Increase of 4 - 6 stools per day over baseline; moderate increase in ostomy output compared to baseline",
+        "Grade 3": "Increase of >=7 stools per day over baseline; incontinence; hospitalization indicated; severe increase in ostomy output compared to baseline; limiting self care ADL",
+        "Grade 4": "Life-threatening consequences; urgent intervention indicated",
+        "Grade 5": "Death",
+        "description": "A disorder characterized by frequent and watery bowel movements."
+    },
+    {
+        "MedDRA v12.0 Code": 10028813,
+        "SOC": "Gastrointestinal disorders",
+        "name": "Nausea",
+        "Grade 1": "Loss of appetite without alteration in eating habits",
+        "Grade 2": "Oral intake decreased without significant weight loss, dehydration or malnutrition",
+        "Grade 3": "Inadequate oral caloric or fluid intake; tube feeding, TPN, or hospitalization indicated",
+        "Grade 4": null,
+        "Grade 5": null,
+        "description": "A disorder characterized by a queasy sensation and/or the urge to vomit."
+    },
+    {
+        "MedDRA v12.0 Code": 10035528,
+        "SOC": "Investigations",
+        "name": "Platelet count decreased",
+        "Grade 1": "<LLN - 75,000/mm3; <LLN - 75.0 x 10e9 /L",
+        "Grade 2": "<75,000 - 50,000/mm3; <75.0 - 50.0 x 10e9 /L",
+        "Grade 3": "<50,000 - 25,000/mm3; <50.0 - 25.0 x 10e9 /L",
+        "Grade 4": "<25,000/mm3; <25.0 x 10e9 /L",
+        "Grade 5": null,
+        "description": "A finding based on laboratory test results that indicate a decrease in number of platelets in a blood specimen."
+    },
+    {
+        "MedDRA v12.0 Code": 10002646,
+        "SOC": "Metabolism and nutrition disorders",
+        "name": "Anorexia",
+        "Grade 1": "Loss of appetite without alteration in eating habits",
+        "Grade 2": "Oral intake altered without significant weight loss or malnutrition; oral nutritional supplements indicated",
+        "Grade 3": "Associated with significant weight loss or malnutrition (e.g., inadequate oral caloric and/or fluid intake); tube feeding or TPN indicated",
+        "Grade 4": "Life-threatening consequences; urgent intervention indicated",
+        "Grade 5": "Death",
+        "description": "A disorder characterized by a loss of appetite."
+    },
+    {
+        "MedDRA v12.0 Code": 10010774,
+        "SOC": "Gastrointestinal disorders",
+        "name": "Constipation",
+        "Grade 1": "Occasional or intermittent symptoms; occasional use of stool softeners, laxatives, dietary modification, or enema",
+        "Grade 2": "Persistent symptoms with regular use of laxatives or enemas; limiting instrumental ADL",
+        "Grade 3": "Obstipation with manual evacuation indicated; limiting self care ADL",
+        "Grade 4": "Life-threatening consequences; urgent intervention indicated",
+        "Grade 5": "Death",
+        "description": "A disorder characterized by irregular and infrequent or difficult evacuation of the bowels."
+    },
+    {
+        "MedDRA v12.0 Code": 10006556,
+        "SOC": "Skin and subcutaneous tissue disorders",
+        "name": "Bullous dermatitis",
+        "Grade 1": "Asymptomatic; blisters covering <10% BSA",
+        "Grade 2": "Blisters covering 10 - 30% BSA; painful blisters; limiting instrumental ADL",
+        "Grade 3": "Blisters covering >30% BSA; limiting self care ADL",
+        "Grade 4": "Blisters covering >30% BSA; associated with fluid or electrolyte abnormalities; ICU care or burn unit indicated",
+        "Grade 5": "Death",
+        "description": "A disorder characterized by inflammation of the skin characterized by the presence of bullae which are filled with fluid."
+    },
+    {
+        "MedDRA v12.0 Code": 10046300,
+        "SOC": "Infections and infestations",
+        "name": "Upper respiratory infection",
+        "Grade 1": null,
+        "Grade 2": "Moderate symptoms; oral intervention indicated (e.g., antibiotic, antifungal, antiviral)",
+        "Grade 3": "IV antibiotic, antifungal, or antiviral intervention indicated; radiologic, endoscopic, or operative intervention indicated",
+        "Grade 4": "Life-threatening consequences; urgent intervention indicated",
+        "Grade 5": "Death",
+        "description": "A disorder characterized by an infectious process involving the upper respiratory tract (nose, paranasal sinuses, pharynx, larynx, or trachea)."
+    },
+    {
+        "MedDRA v12.0 Code": 10047700,
+        "SOC": "Gastrointestinal disorders",
+        "name": "Vomiting",
+        "Grade 1": "1 - 2 episodes (separated by 5 minutes) in 24 hrs",
+        "Grade 2": "3 - 5 episodes (separated by 5 minutes) in 24 hrs",
+        "Grade 3": ">=6 episodes (separated by 5 minutes) in 24 hrs; tube feeding, TPN or hospitalization indicated",
+        "Grade 4": "Life-threatening consequences; urgent intervention indicated",
+        "Grade 5": "Death",
+        "description": "A disorder characterized by the reflexive act of ejecting the contents of the stomach through the mouth."
+    },
+    {
+        "MedDRA v12.0 Code": 10020407,
+        "SOC": "Vascular disorders",
+        "name": "Hot flashes",
+        "Grade 1": "Mild symptoms; intervention not indicated",
+        "Grade 2": "Moderate symptoms; limiting instrumental ADL",
+        "Grade 3": "Severe symptoms; limiting self care ADL",
+        "Grade 4": null,
+        "Grade 5": null,
+        "description": "A disorder characterized by an uncomfortable and temporary sensation of intense body warmth, flushing, sometimes accompanied by sweating upon cooling."
+    },
+    {
+        "MedDRA v12.0 Code": 10003239,
+        "SOC": "Musculoskeletal and connective tissue disorders",
+        "name": "Arthralgia",
+        "Grade 1": "Mild pain",
+        "Grade 2": "Moderate pain; limiting instrumental ADL",
+        "Grade 3": "Severe pain; limiting self care ADL",
+        "Grade 4": null,
+        "Grade 5": null,
+        "description": "A disorder characterized by a sensation of marked discomfort in a joint."
+    },
+    {
+        "MedDRA v12.0 Code": 10031282,
+        "SOC": "Musculoskeletal and connective tissue disorders",
+        "name": "Osteoporosis",
+        "Grade 1": "Radiologic evidence of osteoporosis or Bone Mineral Density (BMD) t-score -1 to -2.5 (osteopenia); no loss of height or intervention indicated",
+        "Grade 2": "BMD t-score <-2.5; loss of height <2 cm; anti-osteoporotic therapy indicated; limiting instrumental ADL",
+        "Grade 3": "Loss of height >=2 cm; hospitalization indicated; limiting self care ADL",
+        "Grade 4": null,
+        "Grade 5": null,
+        "description": "A disorder characterized by reduced bone mass, with a decrease in cortical thickness and in the number and size of the trabeculae of cancellous bone (but normal chemical composition), resulting in increased fracture incidence."
+    },
+    {
+        "MedDRA v12.0 Code": 10016558,
+        "SOC": "General disorders and administration site conditions",
+        "name": "Fever",
+        "Grade 1": "38.0 - 39.0 degrees C  (100.4 - 102.2 degrees F)",
+        "Grade 2": ">39.0 - 40.0 degrees C (102.3 - 104.0 degrees F)",
+        "Grade 3": ">40.0 degrees C (>104.0 degrees F) for <=24 hrs",
+        "Grade 4": ">40.0 degrees C (>104.0 degrees F) for >24 hrs",
+        "Grade 5": "Death",
+        "description": "A disorder characterized by elevation of the body's temperature above the upper limit of normal."
+    },
+    {
+        "MedDRA v12.0 Code": 10051792,
+        "SOC": "General disorders and administration site conditions",
+        "name": "Infusion related reaction",
+        "Grade 1": "Mild transient reaction; infusion interruption not indicated; intervention not indicated",
+        "Grade 2": "Therapy or infusion interruption indicated but responds promptly to symptomatic treatment (e.g., antihistamines, NSAIDS, narcotics, IV fluids); prophylactic medications indicated for <=24 hrs",
+        "Grade 3": "Prolonged (e.g., not rapidly responsive to symptomatic medication and/or brief interruption of infusion); recurrence of symptoms following initial improvement; hospitalization indicated for clinical sequelae",
+        "Grade 4": "Life-threatening consequences; urgent intervention indicated",
+        "Grade 5": "Death",
+        "description": "A disorder characterized by adverse reaction to the infusion of pharmacological or biological substances."
+    },
+    {
+        "MedDRA v12.0 Code": 10019211,
+        "SOC": "Nervous system disorders",
+        "name": "Headache",
+        "Grade 1": "Mild pain",
+        "Grade 2": "Moderate pain; limiting instrumental ADL",
+        "Grade 3": "Severe pain; limiting self care ADL",
+        "Grade 4": null,
+        "Grade 5": null,
+        "description": "A disorder characterized by a sensation of marked discomfort in various parts of the head, not confined to the area of distribution of any nerve."
+    },
+    {
+        "MedDRA v12.0 Code": 10011224,
+        "SOC": "Respiratory, thoracic and mediastinal disorders",
+        "name": "Cough",
+        "Grade 1": "Mild symptoms; nonprescription intervention indicated",
+        "Grade 2": "Moderate symptoms, medical intervention indicated; limiting instrumental ADL",
+        "Grade 3": "Severe symptoms; limiting self care ADL",
+        "Grade 4": null,
+        "Grade 5": null,
+        "description": "A disorder characterized by sudden, often repetitive, spasmodic contraction of the thoracic cavity, resulting in violent release of air from the lungs and usually accompanied by a distinctive sound."
+    },
+    {
+        "MedDRA v12.0 Code": 10013963,
+        "SOC": "Respiratory, thoracic and mediastinal disorders",
+        "name": "Dyspnea",
+        "Grade 1": "Shortness of breath with moderate exertion",
+        "Grade 2": "Shortness of breath with minimal exertion; limiting instrumental ADL",
+        "Grade 3": "Shortness of breath at rest; limiting self care ADL",
+        "Grade 4": "Life-threatening consequences; urgent intervention indicated",
+        "Grade 5": "Death",
+        "description": "A disorder characterized by an uncomfortable sensation of difficulty breathing."
+    },
+    {
+        "MedDRA v12.0 Code": 10069138,
+        "SOC": "Infections and infestations",
+        "name": "Papulopustular rash",
+        "Grade 1": "Papules and/or pustules covering <10% BSA, which may or may not be associated with symptoms of pruritus or tenderness",
+        "Grade 2": "Papules and/or pustules covering 10-30% BSA, which may or may not be associated with symptoms of pruritus or tenderness; associated with psychosocial impact; limiting instrumental ADL",
+        "Grade 3": "Papules and/or pustules covering >30% BSA, which may or may not be associated with symptoms of pruritus or tenderness; limiting self-care ADL; associated with local superinfection with oral antibiotics indicated",
+        "Grade 4": "Papules and/or pustules covering  any % BSA, which may or may not be associated with symptoms of pruritus or tenderness and are associated with extensive superinfection with IV antibiotics indicated; life-threatening consequences",
+        "Grade 5": "Death",
+        "description": "A disorder characterized by an eruption consisting of papules (a small, raised pimple) and pustules (a small pus filled blister), typically appearing in face, scalp, and upper chest and back Unlike acne, this rash does not present with whiteheads or blackheads, and can be symptomatic, with itchy or tender lesions."
     },
     {
         "MedDRA v12.0 Code": 10048580,
@@ -102,17 +322,6 @@ const adverseEventOptions = [
         "Grade 4": "Life-threatening consequences; urgent intervention indicated",
         "Grade 5": "Death",
         "description": "A disorder characterized by systemic pathological activation of blood clotting mechanisms which results in clot formation throughout the body. There is an increase in the risk of hemorrhage as the body is depleted of platelets and coagulation factors."
-    },
-    {
-        "MedDRA v12.0 Code": 10016288,
-        "SOC": "Blood and lymphatic system disorders",
-        "name": "Febrile neutropenia",
-        "Grade 1": null,
-        "Grade 2": null,
-        "Grade 3": "ANC <1000/mm3 with a single temperature of >38.3 degrees C (101 degrees F) or a sustained temperature of >=38 degrees C (100.4 degrees F) for more than one hour",
-        "Grade 4": "Life-threatening consequences; urgent intervention indicated",
-        "Grade 5": "Death",
-        "description": "A disorder characterized by an ANC <1000/mm3 and a single temperature of >38.3 degrees C (101 degrees F) or a sustained temperature of >=38 degrees C (100.4 degrees F) for more than one hour"
     },
     {
         "MedDRA v12.0 Code": 10019491,
@@ -1314,17 +1523,6 @@ const adverseEventOptions = [
         "description": "A disorder characterized by a circumscribed, inflammatory and necrotic erosive lesion on the mucosal surface of the colon."
     },
     {
-        "MedDRA v12.0 Code": 10010774,
-        "SOC": "Gastrointestinal disorders",
-        "name": "Constipation",
-        "Grade 1": "Occasional or intermittent symptoms; occasional use of stool softeners, laxatives, dietary modification, or enema",
-        "Grade 2": "Persistent symptoms with regular use of laxatives or enemas; limiting instrumental ADL",
-        "Grade 3": "Obstipation with manual evacuation indicated; limiting self care ADL",
-        "Grade 4": "Life-threatening consequences; urgent intervention indicated",
-        "Grade 5": "Death",
-        "description": "A disorder characterized by irregular and infrequent or difficult evacuation of the bowels."
-    },
-    {
         "MedDRA v12.0 Code": 10012318,
         "SOC": "Gastrointestinal disorders",
         "name": "Dental caries",
@@ -1334,17 +1532,6 @@ const adverseEventOptions = [
         "Grade 4": null,
         "Grade 5": null,
         "description": "A disorder characterized by the decay of a tooth, in which it becomes softened, discolored and/or porous."
-    },
-    {
-        "MedDRA v12.0 Code": 10012727,
-        "SOC": "Gastrointestinal disorders",
-        "name": "Diarrhea",
-        "Grade 1": "Increase of <4 stools per day over baseline; mild increase in ostomy output compared to baseline",
-        "Grade 2": "Increase of 4 - 6 stools per day over baseline; moderate increase in ostomy output compared to baseline",
-        "Grade 3": "Increase of >=7 stools per day over baseline; incontinence; hospitalization indicated; severe increase in ostomy output compared to baseline; limiting self care ADL",
-        "Grade 4": "Life-threatening consequences; urgent intervention indicated",
-        "Grade 5": "Death",
-        "description": "A disorder characterized by frequent and watery bowel movements."
     },
     {
         "MedDRA v12.0 Code": 10013781,
@@ -1952,17 +2139,6 @@ const adverseEventOptions = [
         "description": "A disorder characterized by inflammation of the oral mucosal."
     },
     {
-        "MedDRA v12.0 Code": 10028813,
-        "SOC": "Gastrointestinal disorders",
-        "name": "Nausea",
-        "Grade 1": "Loss of appetite without alteration in eating habits",
-        "Grade 2": "Oral intake decreased without significant weight loss, dehydration or malnutrition",
-        "Grade 3": "Inadequate oral caloric or fluid intake; tube feeding, TPN, or hospitalization indicated",
-        "Grade 4": null,
-        "Grade 5": null,
-        "description": "A disorder characterized by a queasy sensation and/or the urge to vomit."
-    },
-    {
         "MedDRA v12.0 Code": 10029957,
         "SOC": "Gastrointestinal disorders",
         "name": "Obstruction gastric",
@@ -2359,17 +2535,6 @@ const adverseEventOptions = [
         "description": "A disorder characterized by bleeding from the upper gastrointestinal tract (oral cavity, pharynx, esophagus, and stomach)."
     },
     {
-        "MedDRA v12.0 Code": 10047700,
-        "SOC": "Gastrointestinal disorders",
-        "name": "Vomiting",
-        "Grade 1": "1 - 2 episodes (separated by 5 minutes) in 24 hrs",
-        "Grade 2": "3 - 5 episodes (separated by 5 minutes) in 24 hrs",
-        "Grade 3": ">=6 episodes (separated by 5 minutes) in 24 hrs; tube feeding, TPN or hospitalization indicated",
-        "Grade 4": "Life-threatening consequences; urgent intervention indicated",
-        "Grade 5": "Death",
-        "description": "A disorder characterized by the reflexive act of ejecting the contents of the stomach through the mouth."
-    },
-    {
         "MedDRA v12.0 Code": 10017947,
         "SOC": "Gastrointestinal disorders",
         "name": "Gastrointestinal disorders - Other, specify",
@@ -2458,28 +2623,6 @@ const adverseEventOptions = [
         "description": "A disorder characterized by a sensation of marked discomfort in the face."
     },
     {
-        "MedDRA v12.0 Code": 10016256,
-        "SOC": "General disorders and administration site conditions",
-        "name": "Fatigue",
-        "Grade 1": "Fatigue relieved by rest",
-        "Grade 2": "Fatigue not relieved by rest; limiting instrumental ADL",
-        "Grade 3": "Fatigue not relieved by rest, limiting self care ADL",
-        "Grade 4": null,
-        "Grade 5": null,
-        "description": "A disorder characterized by a state of generalized weakness with a pronounced inability to summon sufficient energy to accomplish daily activities."
-    },
-    {
-        "MedDRA v12.0 Code": 10016558,
-        "SOC": "General disorders and administration site conditions",
-        "name": "Fever",
-        "Grade 1": "38.0 - 39.0 degrees C  (100.4 - 102.2 degrees F)",
-        "Grade 2": ">39.0 - 40.0 degrees C (102.3 - 104.0 degrees F)",
-        "Grade 3": ">40.0 degrees C (>104.0 degrees F) for <=24 hrs",
-        "Grade 4": ">40.0 degrees C (>104.0 degrees F) for >24 hrs",
-        "Grade 5": "Death",
-        "description": "A disorder characterized by elevation of the body's temperature above the upper limit of normal."
-    },
-    {
         "MedDRA v12.0 Code": 10016791,
         "SOC": "General disorders and administration site conditions",
         "name": "Flu like symptoms",
@@ -2511,17 +2654,6 @@ const adverseEventOptions = [
         "Grade 4": "<=28 degrees C; 82.4 degrees F; life-threatening consequences (e.g., coma, hypotension, pulmonary edema, acidemia, ventricular fibrillation)",
         "Grade 5": "Death",
         "description": "A disorder characterized by an abnormally low body temperature. Treatment is required when the body temperature is 35C (95F) or below."
-    },
-    {
-        "MedDRA v12.0 Code": 10051792,
-        "SOC": "General disorders and administration site conditions",
-        "name": "Infusion related reaction",
-        "Grade 1": "Mild transient reaction; infusion interruption not indicated; intervention not indicated",
-        "Grade 2": "Therapy or infusion interruption indicated but responds promptly to symptomatic treatment (e.g., antihistamines, NSAIDS, narcotics, IV fluids); prophylactic medications indicated for <=24 hrs",
-        "Grade 3": "Prolonged (e.g., not rapidly responsive to symptomatic medication and/or brief interruption of infusion); recurrence of symptoms following initial improvement; hospitalization indicated for clinical sequelae",
-        "Grade 4": "Life-threatening consequences; urgent intervention indicated",
-        "Grade 5": "Death",
-        "description": "A disorder characterized by adverse reaction to the infusion of pharmacological or biological substances."
     },
     {
         "MedDRA v12.0 Code": 10064774,
@@ -3351,7 +3483,7 @@ const adverseEventOptions = [
     {
         "MedDRA v12.0 Code": 10055005,
         "SOC": "Infections and infestations",
-        "name": "Ovarian infection",
+        "name": "Ovarian",
         "Grade 1": null,
         "Grade 2": "Localized; local intervention indicated (e.g., topical antibiotic, antifungal, or antiviral)",
         "Grade 3": "IV antibiotic, antifungal, or antiviral intervention indicated; radiologic or operative intervention indicated",
@@ -3369,17 +3501,6 @@ const adverseEventOptions = [
         "Grade 4": "Life-threatening consequences; urgent intervention indicated",
         "Grade 5": "Death",
         "description": "A disorder characterized by an infectious process involving the pancreas."
-    },
-    {
-        "MedDRA v12.0 Code": 10069138,
-        "SOC": "Infections and infestations",
-        "name": "Papulopustular rash",
-        "Grade 1": "Papules and/or pustules covering <10% BSA, which may or may not be associated with symptoms of pruritus or tenderness",
-        "Grade 2": "Papules and/or pustules covering 10-30% BSA, which may or may not be associated with symptoms of pruritus or tenderness; associated with psychosocial impact; limiting instrumental ADL",
-        "Grade 3": "Papules and/or pustules covering >30% BSA, which may or may not be associated with symptoms of pruritus or tenderness; limiting self-care ADL; associated with local superinfection with oral antibiotics indicated",
-        "Grade 4": "Papules and/or pustules covering  any % BSA, which may or may not be associated with symptoms of pruritus or tenderness and are associated with extensive superinfection with IV antibiotics indicated; life-threatening consequences",
-        "Grade 5": "Death",
-        "description": "A disorder characterized by an eruption consisting of papules (a small, raised pimple) and pustules (a small pus filled blister), typically appearing in face, scalp, and upper chest and back Unlike acne, this rash does not present with whiteheads or blackheads, and can be symptomatic, with itchy or tender lesions."
     },
     {
         "MedDRA v12.0 Code": 10034016,
@@ -3633,17 +3754,6 @@ const adverseEventOptions = [
         "Grade 4": "Life-threatening consequences; urgent intervention indicated",
         "Grade 5": "Death",
         "description": "A disorder characterized by an infectious process involving the trachea."
-    },
-    {
-        "MedDRA v12.0 Code": 10046300,
-        "SOC": "Infections and infestations",
-        "name": "Upper respiratory infection",
-        "Grade 1": null,
-        "Grade 2": "Moderate symptoms; oral intervention indicated (e.g., antibiotic, antifungal, antiviral)",
-        "Grade 3": "IV antibiotic, antifungal, or antiviral intervention indicated; radiologic, endoscopic, or operative intervention indicated",
-        "Grade 4": "Life-threatening consequences; urgent intervention indicated",
-        "Grade 5": "Death",
-        "description": "A disorder characterized by an infectious process involving the upper respiratory tract (nose, paranasal sinuses, pharynx, larynx, or trachea)."
     },
     {
         "MedDRA v12.0 Code": 10052298,
@@ -4911,17 +5021,6 @@ const adverseEventOptions = [
         "description": "A finding based on laboratory test results that indicate an decrease in levels of pancreatic enzymes in a biological specimen."
     },
     {
-        "MedDRA v12.0 Code": 10035528,
-        "SOC": "Investigations",
-        "name": "Platelet count decreased",
-        "Grade 1": "<LLN - 75,000/mm3; <LLN - 75.0 x 10e9 /L",
-        "Grade 2": "<75,000 - 50,000/mm3; <75.0 - 50.0 x 10e9 /L",
-        "Grade 3": "<50,000 - 25,000/mm3; <50.0 - 25.0 x 10e9 /L",
-        "Grade 4": "<25,000/mm3; <25.0 x 10e9 /L",
-        "Grade 5": null,
-        "description": "A finding based on laboratory test results that indicate a decrease in number of platelets in a blood specimen."
-    },
-    {
         "MedDRA v12.0 Code": 10040139,
         "SOC": "Investigations",
         "name": "Serum amylase increased",
@@ -5030,17 +5129,6 @@ const adverseEventOptions = [
         "Grade 4": "Life-threatening consequences",
         "Grade 5": "Death",
         "description": "A disorder characterized by abnormally high alkalinity (low hydrogen-ion concentration) of the blood and other body tissues."
-    },
-    {
-        "MedDRA v12.0 Code": 10002646,
-        "SOC": "Metabolism and nutrition disorders",
-        "name": "Anorexia",
-        "Grade 1": "Loss of appetite without alteration in eating habits",
-        "Grade 2": "Oral intake altered without significant weight loss or malnutrition; oral nutritional supplements indicated",
-        "Grade 3": "Associated with significant weight loss or malnutrition (e.g., inadequate oral caloric and/or fluid intake); tube feeding or TPN indicated",
-        "Grade 4": "Life-threatening consequences; urgent intervention indicated",
-        "Grade 5": "Death",
-        "description": "A disorder characterized by a loss of appetite."
     },
     {
         "MedDRA v12.0 Code": 10012174,
@@ -5274,17 +5362,6 @@ const adverseEventOptions = [
         "description": "A disorder characterized by a necrotic process occurring in the soft tissues of the abdominal wall."
     },
     {
-        "MedDRA v12.0 Code": 10003239,
-        "SOC": "Musculoskeletal and connective tissue disorders",
-        "name": "Arthralgia",
-        "Grade 1": "Mild pain",
-        "Grade 2": "Moderate pain; limiting instrumental ADL",
-        "Grade 3": "Severe pain; limiting self care ADL",
-        "Grade 4": null,
-        "Grade 5": null,
-        "description": "A disorder characterized by a sensation of marked discomfort in a joint."
-    },
-    {
         "MedDRA v12.0 Code": 10003246,
         "SOC": "Musculoskeletal and connective tissue disorders",
         "name": "Arthritis",
@@ -5382,17 +5459,6 @@ const adverseEventOptions = [
         "Grade 4": null,
         "Grade 5": null,
         "description": "A disorder characterized by marked discomfort sensation on the lateral side of the body in the region below the ribs and above the hip."
-    },
-    {
-        "MedDRA v12.0 Code": 10062572,
-        "SOC": "Musculoskeletal and connective tissue disorders",
-        "name": "Generalized muscle weakness",
-        "Grade 1": "Symptomatic; weakness perceived by patient but not evident on physical exam",
-        "Grade 2": "Symptomatic; weakness evident on physical exam; weakness limiting instrumental ADL",
-        "Grade 3": "Weakness limiting self care ADL; disabling",
-        "Grade 4": null,
-        "Grade 5": null,
-        "description": "A disorder characterized by a reduction in the strength of muscles in multiple anatomic sites."
     },
     {
         "MedDRA v12.0 Code": 10018761,
@@ -5602,17 +5668,6 @@ const adverseEventOptions = [
         "Grade 4": "Life-threatening consequences; urgent intervention indicated",
         "Grade 5": "Death",
         "description": "A disorder characterized by a necrotic process occurring in the bone of the mandible."
-    },
-    {
-        "MedDRA v12.0 Code": 10031282,
-        "SOC": "Musculoskeletal and connective tissue disorders",
-        "name": "Osteoporosis",
-        "Grade 1": "Radiologic evidence of osteoporosis or Bone Mineral Density (BMD) t-score -1 to -2.5 (osteopenia); no loss of height or intervention indicated",
-        "Grade 2": "BMD t-score <-2.5; loss of height <2 cm; anti-osteoporotic therapy indicated; limiting instrumental ADL",
-        "Grade 3": "Loss of height >=2 cm; hospitalization indicated; limiting self care ADL",
-        "Grade 4": null,
-        "Grade 5": null,
-        "description": "A disorder characterized by reduced bone mass, with a decrease in cortical thickness and in the number and size of the trabeculae of cancellous bone (but normal chemical composition), resulting in increased fracture incidence."
     },
     {
         "MedDRA v12.0 Code": 10033425,
@@ -6042,17 +6097,6 @@ const adverseEventOptions = [
         "Grade 4": "Life-threatening consequences; urgent intervention indicated",
         "Grade 5": "Death",
         "description": "A disorder characterized by involvement of the glossopharyngeal nerve (ninth cranial nerve)."
-    },
-    {
-        "MedDRA v12.0 Code": 10019211,
-        "SOC": "Nervous system disorders",
-        "name": "Headache",
-        "Grade 1": "Mild pain",
-        "Grade 2": "Moderate pain; limiting instrumental ADL",
-        "Grade 3": "Severe pain; limiting self care ADL",
-        "Grade 4": null,
-        "Grade 5": null,
-        "description": "A disorder characterized by a sensation of marked discomfort in various parts of the head, not confined to the area of distribution of any nerve."
     },
     {
         "MedDRA v12.0 Code": 10020508,
@@ -7650,28 +7694,6 @@ const adverseEventOptions = [
         "description": "A disorder characterized by milky pleural effusion (abnormal collection of fluid) resulting from accumulation of lymph fluid in the pleural cavity."
     },
     {
-        "MedDRA v12.0 Code": 10011224,
-        "SOC": "Respiratory, thoracic and mediastinal disorders",
-        "name": "Cough",
-        "Grade 1": "Mild symptoms; nonprescription intervention indicated",
-        "Grade 2": "Moderate symptoms, medical intervention indicated; limiting instrumental ADL",
-        "Grade 3": "Severe symptoms; limiting self care ADL",
-        "Grade 4": null,
-        "Grade 5": null,
-        "description": "A disorder characterized by sudden, often repetitive, spasmodic contraction of the thoracic cavity, resulting in violent release of air from the lungs and usually accompanied by a distinctive sound."
-    },
-    {
-        "MedDRA v12.0 Code": 10013963,
-        "SOC": "Respiratory, thoracic and mediastinal disorders",
-        "name": "Dyspnea",
-        "Grade 1": "Shortness of breath with moderate exertion",
-        "Grade 2": "Shortness of breath with minimal exertion; limiting instrumental ADL",
-        "Grade 3": "Shortness of breath at rest; limiting self care ADL",
-        "Grade 4": "Life-threatening consequences; urgent intervention indicated",
-        "Grade 5": "Death",
-        "description": "A disorder characterized by an uncomfortable sensation of difficulty breathing."
-    },
-    {
         "MedDRA v12.0 Code": 10015090,
         "SOC": "Respiratory, thoracic and mediastinal disorders",
         "name": "Epistaxis",
@@ -8189,17 +8211,6 @@ const adverseEventOptions = [
         "description": "A disorder characterized by an abnormal body smell resulting from the growth of bacteria on the body."
     },
     {
-        "MedDRA v12.0 Code": 10006556,
-        "SOC": "Skin and subcutaneous tissue disorders",
-        "name": "Bullous dermatitis",
-        "Grade 1": "Asymptomatic; blisters covering <10% BSA",
-        "Grade 2": "Blisters covering 10 - 30% BSA; painful blisters; limiting instrumental ADL",
-        "Grade 3": "Blisters covering >30% BSA; limiting self care ADL",
-        "Grade 4": "Blisters covering >30% BSA; associated with fluid or electrolyte abnormalities; ICU care or burn unit indicated",
-        "Grade 5": "Death",
-        "description": "A disorder characterized by inflammation of the skin characterized by the presence of bullae which are filled with fluid."
-    },
-    {
         "MedDRA v12.0 Code": 10013786,
         "SOC": "Skin and subcutaneous tissue disorders",
         "name": "Dry skin",
@@ -8605,17 +8616,6 @@ const adverseEventOptions = [
         "Grade 4": "Life-threatening consequences; urgent intervention indicated",
         "Grade 5": "Death",
         "description": "A disorder characterized by a localized collection of blood, usually clotted, in an organ, space, or tissue, due to a break in the wall of a blood vessel."
-    },
-    {
-        "MedDRA v12.0 Code": 10020407,
-        "SOC": "Vascular disorders",
-        "name": "Hot flashes",
-        "Grade 1": "Mild symptoms; intervention not indicated",
-        "Grade 2": "Moderate symptoms; limiting instrumental ADL",
-        "Grade 3": "Severe symptoms; limiting self care ADL",
-        "Grade 4": null,
-        "Grade 5": null,
-        "description": "A disorder characterized by an uncomfortable and temporary sensation of intense body warmth, flushing, sometimes accompanied by sweating upon cooling."
     },
     {
         "MedDRA v12.0 Code": 10020772,

--- a/test/ui/SlimApp.js
+++ b/test/ui/SlimApp.js
@@ -97,11 +97,11 @@ test('Selecting adverseEvent, then selecting a valid grade updates copy-content'
     }
 });
 test('Changing adverseEvemt via button updates copy-content', async t => {
-    const adverseEventButtons = Selector('.btn-group-attribution').find("span[class^='MuiButton-label']");
+    const adverseEventButtons = Selector('.btn-group-adverse-event').find("span[class^='MuiButton-label']");
     const numButtons = await adverseEventButtons.count;
     for(let i = 0; i < numButtons; i++) {
         await t
-            .click(attributionButtons.nth(i))
+            .click(adverseEventButtons.nth(i))
             .expect(Selector("#copy-content").innerText)
             .contains(await adverseEventButtons.nth(i).innerText);
     }

--- a/test/ui/SlimApp.js
+++ b/test/ui/SlimApp.js
@@ -96,6 +96,16 @@ test('Selecting adverseEvent, then selecting a valid grade updates copy-content'
             .contains(await gradeButtons.nth(i).innerText);
     }
 });
+test('Changing adverseEvemt via button updates copy-content', async t => {
+    const adverseEventButtons = Selector('.btn-group-attribution').find("span[class^='MuiButton-label']");
+    const numButtons = await adverseEventButtons.count;
+    for(let i = 0; i < numButtons; i++) {
+        await t
+            .click(attributionButtons.nth(i))
+            .expect(Selector("#copy-content").innerText)
+            .contains(await adverseEventButtons.nth(i).innerText);
+    }
+});
 test('Changing attribution via button updates copy-content', async t => {
     const attributionButtons = Selector('.btn-group-attribution').find("span[class^='MuiButton-label']");
     const numButtons = await attributionButtons.count;


### PR DESCRIPTION
Added the top 20 adverse events from the PATINA protocol as buttons and updated the app manager so they can be configured only for PATINA based trails.

## Submitter: Laura Clark

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- NA Cheat sheet is updated
- NA Demo script is updated 
- NA Documentation on Wiki has been updated 
- NA Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- NA Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- [x] Added UI tests for slim mode 
- NA Added UI tests for full mode
- NA Added backend tests for fluxNotes code
- NA Added note parser examples to test new functionality


## Reviewer 1: Nicole

- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
