### PR TITLE
Changed patient ID to match the shrId GUID in the hard-coded patient.…

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "react-tap-event-plugin": "2.0.1",
     "react-test-renderer": "15.6.2",
     "run-script-os": "1.0.2",
-    "shr_rest_client": "^0.0.4",
+    "shr_rest_client": "^0.0.5",
     "slate": "0.20.2",
     "slate-auto-replace": "0.5.0",
     "testcafe": "0.17.1"

--- a/src/dataaccess/DataAccess.jsx
+++ b/src/dataaccess/DataAccess.jsx
@@ -3,7 +3,7 @@ import NewPatientOnlyDataSource from './NewPatientOnlyDataSource';
 import RestApiDataSource from './RestApiDataSource';
 
 export default class DataAccess {
-    static DEMO_PATIENT_ID = "-1";
+    static DEMO_PATIENT_ID = "788dcbc3-ed18-470c-89ef-35ff91854c7d";
     
     constructor(dataSourceName) {
         if (dataSourceName === 'HardCodedReadOnlyDataSource') {

--- a/src/dataaccess/HardCodedPatient.json
+++ b/src/dataaccess/HardCodedPatient.json
@@ -38,6 +38,7 @@
 			"organization": { "value": "MITRE"},
 			"identifierType": "MRN",
 			"value": "026-DH-678944",
+            "fictionalPerson": true,
 			"originalCreationDate": "13 JAN 2012",
 			"lastUpdateDate": "13 JAN 2012"
 		},

--- a/yarn.lock
+++ b/yarn.lock
@@ -6107,9 +6107,9 @@ shortid@^2.2.4, shortid@^2.2.6:
   version "2.2.8"
   resolved "https://registry.yarnpkg.com/shortid/-/shortid-2.2.8.tgz#033b117d6a2e975804f6f0969dbe7d3d0b355131"
 
-shr_rest_client@^0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/shr_rest_client/-/shr_rest_client-0.0.4.tgz#8ff740a3575905e85c45bb3d2733a7c8ce50e748"
+shr_rest_client@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/shr_rest_client/-/shr_rest_client-0.0.5.tgz#a3adcae82574bb4886a08ae099e66eefc46411ee"
   dependencies:
     superagent "3.5.2"
 


### PR DESCRIPTION
… This allows the database to search by shrId. The change to package.json is due to an update to shr_rest_client to request the ID provided rather than a hardcoded -1. There should no longer be any magic values of -1 for an ID.
In the longer term, we may want the application to be able to search for patients by other identifiers, such as MRN. In that case, we will need another API call to search by MRN with corresponding database access code to return a patient with the provided MRN.
This pull request is also taking advantage of the FictionalPerson attribute in SHR to indicate that the hard-coded patient is fictional.

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [X] Manually tested in Chrome
- [X] Manually tested in IE

**Documentation**

- [X] This pull request describes why these changes were made
- [ ] Recognizes any potential shortcomings/bugs in the description 
- [x] **N/A**  Cheat sheet is updated
- [x] **N/A** Demo script is updated 
- [x] **N/A** Documentation on Wiki has been updated 
- [x] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [X] **N/A** Note parser has been updated if structured phrases change

**Code Quality**

- [X] 4-space indents - convert any tabs to spaces
- [X] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [X] Code is commented

**Tests**

- [X] Existing tests passed
- [X] **N/A** Added UI tests for slim mode 
- [X] **N/A** Added UI tests for full mode
- [X]**N/A** Added backend tests for fluxNotes code
- [X] **N/A** Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
