### PR TITLE
Update search text value when clicking adverse event buttons.

### DIFF
--- a/src/forms/ToxicityForm.jsx
+++ b/src/forms/ToxicityForm.jsx
@@ -90,6 +90,9 @@ class ToxicityForm extends Component {
             this.props.updateValue("adverseEvent", null);
         } else {
             this.props.updateValue("adverseEvent", titlecase(newAdverseEvent));
+            this.setState({
+                searchText: titlecase(newAdverseEvent),
+            });
         }
 
         // Make sure grade is possible with given new tox


### PR DESCRIPTION
Very small change to update the search text value when clicking one of the adverse event buttons.

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- [x] N/A Cheat sheet is updated
- [x] N/A Demo script is updated 
- [x] N/A Documentation on Wiki has been updated 
- [x] N/A Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [x] N/A Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] N/A Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] N/A Code is commented

**Tests**

- [x] Existing tests passed
- [x] N/A Added UI tests for slim mode 
- [x] N/A Added UI tests for full mode
- [x] N/A Added backend tests for fluxNotes code
- [x] N/A Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
