### PR TITLE
New component notes panel

### DIFF
--- a/src/dashboardViews/PostEncounterView.jsx
+++ b/src/dashboardViews/PostEncounterView.jsx
@@ -4,6 +4,7 @@ import { Row, Col } from 'react-flexbox-grid';
 import FluxNotesEditor from '../notes/FluxNotesEditor';
 import ContextTray from '../context/ContextTray';
 import SummaryPanel from '../panels/SummaryPanel';
+import NotesPanel from '../panels/NotesPanel';
 import './PostEncounterView.css';
 
 class PostEncounterView extends Component { 
@@ -19,33 +20,21 @@ class PostEncounterView extends Component {
                             />
                         </div>
                     </Col>
+                    <Col sm={8} className="fitted-panel panel-content dashboard-panel">
+                        <NotesPanel
+                            handleSelectionChange={this.props.handleSelectionChange}
+                            newCurrentShortcut={this.props.newCurrentShortcut}
+                            itemInserted={this.props.itemInserted}
+                            summaryItemToBeInserted={this.props.appState.SummaryItemToInsert}
+                            patient={this.props.appState.patient}
+                            contextManager={this.props.contextManager}
+                            shortcutManager={this.props.shortcutManager}
+                            updateErrors={this.props.updateErrors}
+                            errors={this.props.appState.errors}
 
-                    <Col sm={5} >
-                        <div className="fitted-panel panel-content dashboard-panel">
-                            <FluxNotesEditor
-                                onSelectionChange={this.props.handleSelectionChange}
-                                newCurrentShortcut={this.props.newCurrentShortcut}
-                                itemInserted={this.props.itemInserted}
-                                itemToBeInserted={this.props.appState.SummaryItemToInsert}
-                                patient={this.props.appState.patient}
-                                contextManager={this.props.contextManager}
-                                shortcutManager={this.props.shortcutManager}
-                                updateErrors={this.props.updateErrors}
-                                errors={this.props.appState.errors}
-                            />
-                        </div>
-                    </Col>
-
-                    <Col sm={3}>
-                        <div className="fitted-panel panel-content dashboard-panel">
-                            <ContextTray
-                                ref={(comp) => { this.contextTray = comp; }}
-                                patient={this.props.appState.patient}
-                                contextManager={this.props.contextManager}
-                                shortcutManager={this.props.shortcutManager}
-                                onShortcutClicked={this.props.handleSummaryItemSelected}
-                            />
-                        </div>
+                            ref={(comp) => { this.contextTray = comp; }}
+                            handleSummaryItemSelected={this.props.handleSummaryItemSelected}
+                        />
                     </Col>
                 </Row>
             </div>
@@ -53,7 +42,7 @@ class PostEncounterView extends Component {
     }
 }
 
-PostEncounterView.proptypes = { 
+PostEncounterView.proptypes = {
     possibleClinicalEvents: PropTypes.array.isRequired,
     dataAccess: PropTypes.object.isRequired,
     summaryMetadata: PropTypes.object.isRequired,

--- a/src/dashboardViews/PostEncounterView.jsx
+++ b/src/dashboardViews/PostEncounterView.jsx
@@ -1,8 +1,6 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import { Row, Col } from 'react-flexbox-grid';
-import FluxNotesEditor from '../notes/FluxNotesEditor';
-import ContextTray from '../context/ContextTray';
 import SummaryPanel from '../panels/SummaryPanel';
 import NotesPanel from '../panels/NotesPanel';
 import './PostEncounterView.css';
@@ -20,7 +18,7 @@ class PostEncounterView extends Component {
                             />
                         </div>
                     </Col>
-                    <Col sm={8} className="fitted-panel panel-content dashboard-panel">
+                    <Col sm={8}>
                         <NotesPanel
                             handleSelectionChange={this.props.handleSelectionChange}
                             newCurrentShortcut={this.props.newCurrentShortcut}
@@ -31,8 +29,7 @@ class PostEncounterView extends Component {
                             shortcutManager={this.props.shortcutManager}
                             updateErrors={this.props.updateErrors}
                             errors={this.props.appState.errors}
-
-                            ref={(comp) => { this.contextTray = comp; }}
+                            ref2={(comp) => { this.contextTray = comp; }}
                             handleSummaryItemSelected={this.props.handleSummaryItemSelected}
                         />
                     </Col>

--- a/src/dashboardViews/PostEncounterView.jsx
+++ b/src/dashboardViews/PostEncounterView.jsx
@@ -29,7 +29,6 @@ class PostEncounterView extends Component {
                             shortcutManager={this.props.shortcutManager}
                             updateErrors={this.props.updateErrors}
                             errors={this.props.appState.errors}
-                            ref2={(comp) => { this.contextTray = comp; }}
                             handleSummaryItemSelected={this.props.handleSummaryItemSelected}
                         />
                     </Col>

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -1,0 +1,46 @@
+import React, {Component} from 'react';
+import { Row, Col } from 'react-flexbox-grid';
+import FluxNotesEditor from '../notes/FluxNotesEditor';
+import ContextTray from '../context/ContextTray';
+
+import './NotesPanel.css';
+
+class NotesPanel extends Component {
+    render () {
+        return (
+            <div>
+                <Row center="xs">
+                <Col sm={7} >
+                    <div className="fitted-panel panel-content dashboard-panel">
+                        <FluxNotesEditor
+                            onSelectionChange={this.props.handleSelectionChange}
+                            newCurrentShortcut={this.props.newCurrentShortcut}
+                            itemInserted={this.props.itemInserted}
+                            itemToBeInserted={this.props.summaryItemToBeInserted}
+                            patient={this.props.patient}
+                            contextManager={this.props.contextManager}
+                            shortcutManager={this.props.shortcutManager}
+                            updateErrors={this.props.updateErrors}
+                            errors={this.props.errors}
+                        />
+                    </div>
+                </Col>
+
+                <Col sm={5}>
+                    <div className="fitted-panel panel-content dashboard-panel">
+                        <ContextTray
+                            ref={(comp) => { this.contextTray = comp; }}
+                            patient={this.props.patient}
+                            contextManager={this.props.contextManager}
+                            shortcutManager={this.props.shortcutManager}
+                            onShortcutClicked={this.props.handleSummaryItemSelected}
+                        />
+                    </div>
+                </Col>
+                    </Row>
+            </div>
+        );
+    }
+}
+
+export default NotesPanel;

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -29,7 +29,6 @@ class NotesPanel extends Component {
                 <Col sm={5}>
                     <div className="fitted-panel panel-content dashboard-panel">
                         <ContextTray
-                            ref={this.props.ref2}
                             patient={this.props.patient}
                             contextManager={this.props.contextManager}
                             shortcutManager={this.props.shortcutManager}

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -29,7 +29,7 @@ class NotesPanel extends Component {
                 <Col sm={5}>
                     <div className="fitted-panel panel-content dashboard-panel">
                         <ContextTray
-                            ref={(comp) => { this.contextTray = comp; }}
+                            ref={this.props.ref2}
                             patient={this.props.patient}
                             contextManager={this.props.contextManager}
                             shortcutManager={this.props.shortcutManager}


### PR DESCRIPTION
Made a new component called "NotesPanel" that contains FluxNotesEditor and ContextTray components


_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- N/A Cheat sheet is updated
- N/A Demo script is updated 
- N/A Documentation on Wiki has been updated 
- N/A Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- N/A Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- N/A Added UI tests for slim mode 
- N/A Added UI tests for full mode
- N/A Added backend tests for fluxNotes code
- N/A Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
