### PR TITLE
Added hashtag in between rationale values in copy content.

### DIFF
--- a/src/shortcuts/CreatorBase.jsx
+++ b/src/shortcuts/CreatorBase.jsx
@@ -156,7 +156,7 @@ export default class CreatorBase extends Shortcut {
                     haveAValue = true;
                     result += before;
                     if (Lang.isArray(value)) {
-                        result += value.join(", ");
+                        result += value.join(", #");
                     } else {
                         result += value;
                     }
@@ -171,7 +171,7 @@ export default class CreatorBase extends Shortcut {
                     haveAValue = true;
                 }
                 if (Lang.isArray(value)) {
-                    result += value.join(", ");
+                    result += value.join(", #");
                 } else {
                     result += value;
                 }

--- a/src/shortcuts/Shortcuts.json
+++ b/src/shortcuts/Shortcuts.json
@@ -112,7 +112,7 @@
                                     {   "title":"Rationale for status", "type":"checkboxes", "values": {"category":"progression", "valueSet":"reason"}}
                                   ]
                 },
-    "structuredPhrase": "#disease status${% is #${status}}${% #based on #${reasons}}${% relative to #reference date #${referenceDateDate}}${% #as of #${asOfDateDate}}",
+    "structuredPhrase": "#disease status${% is #${status}}${% based on #${reasons}}${% relative to #reference date #${referenceDateDate}}${% #as of #${asOfDateDate}}",
     "contextValueObjectEntryType": "http://standardhealthrecord.org/oncology/BreastCancer",
     "knownParentContexts": "ConditionInserter",
     "description": "Determination of disease status is based on a number of complex variables which include objective measures like tumor growth, symptomatic criteria, patient reports information, and subjective evaluations.",


### PR DESCRIPTION
This was a simple fix for a bug we found during the burndown, just had to add a "#" when joining the array values.  

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] N/A Recognizes any potential shortcomings/bugs in the description 
- [x] N/A Cheat sheet is updated
- [x] N/A Demo script is updated 
- [x] N/A Documentation on Wiki has been updated 
- [x] N/A Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [x] N/A Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- [x] N/A Added UI tests for slim mode 
- [x] N/A Added UI tests for full mode
- [x] N/A Added backend tests for fluxNotes code
- [x] N/A Added note parser examples to test new functionality


## Reviewer 1: Nicole

- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
