### PR TITLE
Fixed parent context issue when switching between contexts

### DIFF
--- a/src/shortcuts/CreatorBase.jsx
+++ b/src/shortcuts/CreatorBase.jsx
@@ -50,9 +50,9 @@ export default class CreatorBase extends Shortcut {
 
         const knownParent = this.metadata["knownParentContexts"];
 
-        if (contextManager.getActiveContextOfType(knownParent)) {
+        if (knownParent) {
             this.parentContext = contextManager.getActiveContextOfType(knownParent);
-        } else if (contextManager.getCurrentContext()) {
+        } else   {
             this.parentContext = contextManager.getCurrentContext();
         }
 

--- a/src/shortcuts/CreatorChild.jsx
+++ b/src/shortcuts/CreatorChild.jsx
@@ -25,7 +25,15 @@ export default class CreatorChild extends Shortcut {
             }
         }
         //let entryType = this.metadata["contextValueObjectEntryType"];
-        this.parentContext = contextManager.getCurrentContext();
+
+        const knownParent = this.metadata["knownParentContexts"];
+
+        if (contextManager.getActiveContextOfType(knownParent)){
+            this.parentContext = contextManager.getActiveContextOfType(knownParent);
+        } else if (contextManager.getCurrentContext()) {
+            this.parentContext = contextManager.getCurrentContext();
+        }
+
         //console.log("set parent context to " + this.parentContext);
         if (!Lang.isUndefined(this.parentContext)) {
             this.parentContext.addChild(this);

--- a/src/shortcuts/CreatorChild.jsx
+++ b/src/shortcuts/CreatorChild.jsx
@@ -8,13 +8,13 @@ export default class CreatorChild extends Shortcut {
         super();
         this.metadata = metadata;
     }
-    
-	getPrefixCharacter() {
-		return "#";
-	}
+
+    getPrefixCharacter() {
+        return "#";
+    }
 
     initialize(contextManager, trigger) {
-		super.initialize(contextManager);
+        super.initialize(contextManager);
         let text = this.determineText(contextManager);
         if (!Lang.isUndefined(text)) {
 //            console.log(text);
@@ -28,7 +28,7 @@ export default class CreatorChild extends Shortcut {
 
         const knownParent = this.metadata["knownParentContexts"];
 
-        if (contextManager.getActiveContextOfType(knownParent)){
+        if (contextManager.getActiveContextOfType(knownParent)) {
             this.parentContext = contextManager.getActiveContextOfType(knownParent);
         } else if (contextManager.getCurrentContext()) {
             this.parentContext = contextManager.getCurrentContext();
@@ -40,9 +40,9 @@ export default class CreatorChild extends Shortcut {
         }
         var found = false;
 //        console.log(trigger);
-/*        const triggerNoPrefix = trigger.substring(1);
-        console.log("trigger no prefix = " + triggerNoPrefix);*/
-        for(var i = 0; i < this.metadata.stringTriggers.length; i++) {
+        /*        const triggerNoPrefix = trigger.substring(1);
+         console.log("trigger no prefix = " + triggerNoPrefix);*/
+        for (var i = 0; i < this.metadata.stringTriggers.length; i++) {
 //            console.log("  is string trigger? " + this.metadata.stringTriggers[i].name);
             if (this.metadata.stringTriggers[i].name === trigger) {
                 found = true;
@@ -54,16 +54,18 @@ export default class CreatorChild extends Shortcut {
             this.clearValueSelectionOptions();
         }
     }
-    
+
     onBeforeDeleted() {
         let result = super.onBeforeDeleted();
-        if(result && !Lang.isUndefined(this.parentContext)) {
+        if (result && !Lang.isUndefined(this.parentContext)) {
             if (this.metadata["subtype"] && this.metadata["subtype"] === "list") {
                 //console.log("onBeforeDeleted of a list item");
                 const parentAttributeName = this.metadata.parentAttribute;
                 let currentList = this.parentContext.getAttributeValue(parentAttributeName);
                 let oneToDelete = this.text;
-                let newList = currentList.filter((item) => { return item !== oneToDelete });
+                let newList = currentList.filter((item) => {
+                    return item !== oneToDelete
+                });
                 this.parentContext.setAttributeValue(parentAttributeName, newList, false);
             } else {
                 this.parentContext.setAttributeValue(this.metadata.parentAttribute, null, false);
@@ -72,7 +74,7 @@ export default class CreatorChild extends Shortcut {
         }
         return result;
     }
-    
+
     // This returns a placeholder object to trigger opening the Context Portal.
     // return 'date-id' opens calendar.
     determineText(contextManager) {
@@ -82,11 +84,11 @@ export default class CreatorChild extends Shortcut {
             return this.metadata.picker;
         } else {
             return this.getValueSet(this.metadata.picker).map((item) => {
-                return {"key": item.id, "context":item.name, "object": item};
+                return {"key": item.id, "context": item.name, "object": item};
             });
         }
     }
-    
+
     getValueSet(spec) {
         let args = spec["args"];
         let category = spec["category"];
@@ -104,7 +106,7 @@ export default class CreatorChild extends Shortcut {
         if (text.startsWith('#')) {
             text = text.substring(1);
         }
-		this.text = text;
+        this.text = text;
         //console.log("CreatorChild.setText: " + this.metadata.picker);
         let value = text;
         if (this.metadata.picker === 'date-id') {
@@ -115,32 +117,32 @@ export default class CreatorChild extends Shortcut {
             this.parentContext.setAttributeValue(this.metadata.parentAttribute, value, false);
         }
     }
-    
+
     getText() {
         return `#${this.text}`;
     }
-    
+
     getShortcutType() {
         return this.metadata["id"];
         //throw new Error("getShortcutType on CreatorChild called.");
         //return "#" + this.metadata.stringTriggers[0].name;
     }
-    
+
     validateInCurrentContext(contextManager) {
         let errors = [];
         return errors;
     }
-    
+
     static getStringTriggers() {
         throw new Error("getStringTriggers on CreatorChild called.");
         // if it's a function, we need to call it
         //return this.metadata.stringTriggers;
     }
-    
+
     static getTriggerRegExp() {
         return new RegExp(this.metadata.regexpTrigger);
     }
-    
+
     static getDescription() {
         return this.metadata.description;
     }

--- a/src/shortcuts/CreatorChild.jsx
+++ b/src/shortcuts/CreatorChild.jsx
@@ -28,9 +28,9 @@ export default class CreatorChild extends Shortcut {
 
         const knownParent = this.metadata["knownParentContexts"];
 
-        if (contextManager.getActiveContextOfType(knownParent)) {
+        if (knownParent) {
             this.parentContext = contextManager.getActiveContextOfType(knownParent);
-        } else if (contextManager.getCurrentContext()) {
+        } else {
             this.parentContext = contextManager.getCurrentContext();
         }
 

--- a/src/shortcuts/CreatorIntermediary.jsx
+++ b/src/shortcuts/CreatorIntermediary.jsx
@@ -14,14 +14,19 @@ export default class CreatorIntermediary extends Shortcut {
     
 	initialize(contextManager) {
 		super.initialize(contextManager);
-        
+
         const knownParent = this.metadata["knownParentContexts"];
-        this.parentContext = contextManager.getActiveContextOfType(knownParent);
+
+        if (contextManager.getActiveContextOfType(knownParent)){
+            this.parentContext = contextManager.getActiveContextOfType(knownParent);
+        } else if (contextManager.getCurrentContext()) {
+            this.parentContext = contextManager.getCurrentContext();
+        }
+
         if (!Lang.isUndefined(this.parentContext)) {
             this.parentContext.setAttributeValue(this.metadata["parentAttribute"], true, false);
             this.parentContext.addChild(this);
         }
-
 	}
     
     isContext() {

--- a/src/shortcuts/CreatorIntermediary.jsx
+++ b/src/shortcuts/CreatorIntermediary.jsx
@@ -6,18 +6,18 @@ export default class CreatorIntermediary extends Shortcut {
         super();
         this.metadata = metadata;
         this.text = "#" + this.metadata["name"];
-        
+
         // get attribute descriptions
         this.onUpdate = onUpdate;
-		this.setAttributeValue = this.setAttributeValue.bind(this);
+        this.setAttributeValue = this.setAttributeValue.bind(this);
     }
-    
-	initialize(contextManager) {
-		super.initialize(contextManager);
+
+    initialize(contextManager) {
+        super.initialize(contextManager);
 
         const knownParent = this.metadata["knownParentContexts"];
 
-        if (contextManager.getActiveContextOfType(knownParent)){
+        if (contextManager.getActiveContextOfType(knownParent)) {
             this.parentContext = contextManager.getActiveContextOfType(knownParent);
         } else if (contextManager.getCurrentContext()) {
             this.parentContext = contextManager.getCurrentContext();
@@ -27,11 +27,12 @@ export default class CreatorIntermediary extends Shortcut {
             this.parentContext.setAttributeValue(this.metadata["parentAttribute"], true, false);
             this.parentContext.addChild(this);
         }
-	}
-    
+    }
+
     isContext() {
         return this.metadata.isContext;
     }
+
     shouldBeInContext() {
         //console.log(this.getShortcutType() + " " + this.getLabel());
         const voaList = this.metadata["valueObjectAttributes"];
@@ -63,7 +64,7 @@ export default class CreatorIntermediary extends Shortcut {
         });
         return result;
     }
-    
+
     getShortcutType() {
         return this.metadata["id"];
     }
@@ -75,11 +76,11 @@ export default class CreatorIntermediary extends Shortcut {
         return result;
     }
 
-	getAttributeValue(name) {
+    getAttributeValue(name) {
         //console.log("getAttribute of " + this.metadata["id"] + " called " + name);
         //"valueObjectAttributes": [  {"name":"date", "toParentAttribute":"asOfDateDate"} ],
         const voaList = this.metadata["valueObjectAttributes"];
-        let result = voaList.filter(function( item ) {
+        let result = voaList.filter(function (item) {
             return item.name === name;
         });
         if (result && result[0]) {
@@ -89,9 +90,9 @@ export default class CreatorIntermediary extends Shortcut {
         }
     }
 
-	setAttributeValue(name, value, publishChanges = true) {
+    setAttributeValue(name, value, publishChanges = true) {
         const voaList = this.metadata["valueObjectAttributes"];
-        let result = voaList.filter(function( item ) {
+        let result = voaList.filter(function (item) {
             return item.name === name;
         });
         if (result && result[0]) {
@@ -105,11 +106,11 @@ export default class CreatorIntermediary extends Shortcut {
     getLabel() {
         return this.metadata["name"];
     }
-    
+
     getText() {
         return "#" + this.metadata["name"];
     }
-    
+
     getId() {
         return this.metadata["id"];
     }

--- a/src/shortcuts/CreatorIntermediary.jsx
+++ b/src/shortcuts/CreatorIntermediary.jsx
@@ -17,9 +17,9 @@ export default class CreatorIntermediary extends Shortcut {
 
         const knownParent = this.metadata["knownParentContexts"];
 
-        if (contextManager.getActiveContextOfType(knownParent)) {
+        if (knownParent) {
             this.parentContext = contextManager.getActiveContextOfType(knownParent);
-        } else if (contextManager.getCurrentContext()) {
+        } else {
             this.parentContext = contextManager.getCurrentContext();
         }
 

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -105,7 +105,7 @@ class SummaryMetadata {
                                         } else {
                                             return p.evidence.map(function (ev) {
                                                 return ev;
-                                            }).join();
+                                            }).join(', ');
                                         }
                                     }
                                 }

--- a/test/ui/FullApp.js
+++ b/test/ui/FullApp.js
@@ -133,6 +133,34 @@ test("Typing '#deceased' in the editor results in a structured data insertion an
         .contains(deceasedChild);
 });
 
+test("Switching contexts without closing a context chooses the correct parent context and successfully enters information in editor", async t => {
+    const editor = Selector("div[data-slate-editor='true']");
+    const contextPanelElements = Selector(".context-options-list").find('button');
+    const structuredField = editor.find("span[class='structured-field']");
+    const conditionButton = await contextPanelElements.withText(/@condition/ig);
+    const textToType = ["#toxicity ", "#nausea ", "#staging ", "#T0 "];
+    
+    await t
+        .click(conditionButton);
+    let correctCondition = Selector(".context-portal").find('li').withText('Invasive ductal carcinoma of breast');
+    await t
+        .click(correctCondition)
+        .typeText(editor, ' ');
+    for (let i = 0; i < textToType.length; i++) {
+        await t 
+            .typeText(editor, textToType[i]);
+    };
+    
+    // We will skip checking for the inserted condition. Add a placeholder so indexes line up.
+    textToType.splice(0, 0, 'condition placeholder');
+    const structuredFieldCount = await structuredField.count;
+    for (let i = 1; i < structuredFieldCount; i++) {
+        await t
+            .expect(structuredField.nth(i).innerText)
+            .contains(textToType[i]);
+    }
+});
+
 fixture('Patient Mode - Context Panel')
     .page(startPage);
 


### PR DESCRIPTION
This PR addresses jira issues 734 and 735. Edited the code so that parent context is set correctly (get context by type rather than just grabbing current context).

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- N/A Cheat sheet is updated
- N/A Demo script is updated 
- N/A Documentation on Wiki has been updated 
- N/A Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- N/A Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- N/A Added UI tests for slim mode 
- N/A Added UI tests for full mode
- N/A Added backend tests for fluxNotes code
- N/A Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
