### PR TITLE
Dragon demo changes

### DIFF
--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -116,7 +116,7 @@ class FluxNotesEditor extends React.Component {
         const structuredFieldPluginOptions = {
             contextManager: this.contextManager,
             updateErrors: this.updateErrors,
-            insertText: this.handleSummaryUpdate
+            insertText: this.insertTextWithStructuredPhrases
         };
         structuredFieldTypes.forEach((type) => {
             const typeName = type.name;
@@ -335,7 +335,7 @@ class FluxNotesEditor extends React.Component {
           focusOffset: data.focusOffset
         }).delete()
 
-        this.handleSummaryUpdate(data.newText, nextState)
+        this.insertTextWithStructuredPhrases(data.newText, nextState)
     }
     
     isBlock1BeforeBlock2(key1, offset1, key2, offset2, state) {
@@ -363,7 +363,7 @@ class FluxNotesEditor extends React.Component {
     // This gets called when the before the component receives new properties
     componentWillReceiveProps = (nextProps) => {
         if (this.props.itemToBeInserted !== nextProps.itemToBeInserted && nextProps.itemToBeInserted.length > 0) {
-            this.handleSummaryUpdate(nextProps.itemToBeInserted);
+            this.insertTextWithStructuredPhrases(nextProps.itemToBeInserted);
             this.props.itemInserted();
         }
     }
@@ -386,22 +386,23 @@ class FluxNotesEditor extends React.Component {
     /*
      * Handle updates when we have a new
      */
-    handleSummaryUpdate = (itemToBeInserted, currentTransform=undefined) => {
+    insertTextWithStructuredPhrases = (textToBeInserted, currentTransform=undefined) => {
         let state;
         const currentState = this.state.state;
         
-        // console.log(itemToBeInserted);
+        console.log(textToBeInserted);
 
         let transform = (currentTransform) ? currentTransform : currentState.transform();
-        let remainder = itemToBeInserted;
-        let start, before, end, after;
+        let remainder = textToBeInserted;
+        let start, end;
+        let before = '', after = '';
         
-        //console.log(itemToBeInserted);
-        const triggers = this.noteParser.getListOfTriggersFromText(itemToBeInserted)[0];
+        //console.log(textToBeInserted);
+        const triggers = this.noteParser.getListOfTriggersFromText(textToBeInserted)[0];
         //console.log(triggers);
         if (!Lang.isNull(triggers)) {
             triggers.forEach((trigger) => {
-                //console.log(trigger);
+
                 start = remainder.indexOf(trigger.trigger);
                 if (start > 0) {
                     before = remainder.substring(0, start);
@@ -409,10 +410,18 @@ class FluxNotesEditor extends React.Component {
                     transform = this.insertPlainText(transform, before);
                 }
                 remainder = remainder.substring(start + trigger.trigger.length);
+
+                // FIXME: Temporary work around that adds spaces when needed to @-phrases inserted via mic
+                if (start !== 0 && trigger.trigger.startsWith('@') && !before.endsWith(' ')) { 
+                    transform = this.insertPlainText(transform, ' ');   
+                }
+                
+                // Deals with @condition phrases inserted via data summary panel buttons. 
                 if (remainder.startsWith("[[")) {
                     end = remainder.indexOf("]]");
                     after = remainder.substring(2, end);
                     remainder = remainder.substring(end + 2);
+                // FIXME: Temporary work around that can parse '@condition's inserted via mic with extraneous space
                 } else if (remainder.startsWith(" [[")) {
                     remainder = remainder.replace(/\s+(\[\[\S*\s*.*)/g, '$1');
                     end = remainder.indexOf("]]");
@@ -421,6 +430,7 @@ class FluxNotesEditor extends React.Component {
                 } else { 
                     after = "";
                 }
+                
                 transform = this.insertShortcut(trigger.definition, trigger.trigger, after, transform);
             });
         }

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -325,8 +325,6 @@ class FluxNotesEditor extends React.Component {
 
     onInput = (event, data) => {
         // Create an updated state with the text replaced.
-        console.log(data);
-        console.log(data.newText);
 
         var nextState = this.state.state.transform().select({
           anchorKey: data.anchorKey,
@@ -390,7 +388,7 @@ class FluxNotesEditor extends React.Component {
         let state;
         const currentState = this.state.state;
         
-        console.log(textToBeInserted);
+        // console.log(textToBeInserted);
 
         let transform = (currentTransform) ? currentTransform : currentState.transform();
         let remainder = textToBeInserted;

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -325,6 +325,9 @@ class FluxNotesEditor extends React.Component {
 
     onInput = (event, data) => {
         // Create an updated state with the text replaced.
+        console.log(data);
+        console.log(data.newText);
+
         var nextState = this.state.state.transform().select({
           anchorKey: data.anchorKey,
           anchorOffset: data.anchorOffset,
@@ -387,6 +390,8 @@ class FluxNotesEditor extends React.Component {
         let state;
         const currentState = this.state.state;
         
+        // console.log(itemToBeInserted);
+
         let transform = (currentTransform) ? currentTransform : currentState.transform();
         let remainder = itemToBeInserted;
         let start, before, end, after;
@@ -408,10 +413,14 @@ class FluxNotesEditor extends React.Component {
                     end = remainder.indexOf("]]");
                     after = remainder.substring(2, end);
                     remainder = remainder.substring(end + 2);
-                } else {
+                } else if (remainder.startsWith(" [[")) {
+                    remainder = remainder.replace(/\s+(\[\[\S*\s*.*)/g, '$1');
+                    end = remainder.indexOf("]]");
+                    after = remainder.charAt(2).toUpperCase() + remainder.substring(3, end);
+                    remainder = remainder.substring(end + 2);
+                } else { 
                     after = "";
                 }
-                //console.log(remainder);
                 transform = this.insertShortcut(trigger.definition, trigger.trigger, after, transform);
             });
         }

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -420,17 +420,19 @@ class FluxNotesEditor extends React.Component {
                 if (remainder.startsWith("[[")) {
                     end = remainder.indexOf("]]");
                     after = remainder.substring(2, end);
+                    // FIXME: 2 is a magic number based on [[ length, ditto for 2 below for ]]
                     remainder = remainder.substring(end + 2);
                 // FIXME: Temporary work around that can parse '@condition's inserted via mic with extraneous space
                 } else if (remainder.startsWith(" [[")) {
                     remainder = remainder.replace(/\s+(\[\[\S*\s*.*)/g, '$1');
                     end = remainder.indexOf("]]");
+                    // FIXME: 2 is a magic number based on ' [[' length, ditto for 2 below for ]]
                     after = remainder.charAt(2).toUpperCase() + remainder.substring(3, end);
                     remainder = remainder.substring(end + 2);
                 } else { 
                     after = "";
                 }
-                
+
                 transform = this.insertShortcut(trigger.definition, trigger.trigger, after, transform);
             });
         }


### PR DESCRIPTION
Added updates to our demo script that specify instructions for using dragon dictation to insert text ala current demo instructions. Also made minor changes to the application to provide interim solutions that improve mic usage, but do not provide long term solutions to the dragon dictation integration. Additionally, changed some function names to be more intuitive, added some fixmes, and removed a console log or two. 

In terms of future fixes, below I've broken down what we need for proper dragon dictation integration, what we have done so far, and what my concern is with this temporary fix. 

1. **At signs**:
- Problem: Dragon parses out spaces between words separated with '@' to approximate email formatting. 
- Temporary solution: I've modified our insertTextWithStructuredPhrases function to add a space if the text to be insert 
- Issues: I'm not sure this is our optimal solution, as it will change formatting for text pasted in if there aren't spaces inbetween "at-sign". We may want to change our symbol. 

2. **Hash signs**: Not so many problems here. I think we're doing alright with these. Open to suggestions though.

3. **Domain-specific terminology**:
- Problem: Some phrases like PATINA aren't easily recognized by Dragon
- Temporary solution: I've added the word "PATINA" my specific application
- Issues: This only works on my Dragon account, and wouldn't work across hospital machines. Dragon can take in documents and use them to source a vocabulary, so that might be a longterm solution.


_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- [x] **N/A** Cheat sheet is updated
- [x] Demo script is updated 
- [x] **N/A** Documentation on Wiki has been updated 
- [x] **N/A** Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [x] **N/A** Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] **N/A** Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- [x] **N/A** Added UI tests for slim mode 
- [x] **N/A** Added UI tests for full mode
- [x] **N/A** Added backend tests for fluxNotes code
- [x] **N/A** Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
