### PR TITLE
Note preview styling

### DIFF
--- a/src/notes/NoteAssistant.css
+++ b/src/notes/NoteAssistant.css
@@ -16,9 +16,11 @@ span.button-hover {
 .note-new {
     padding-top: 10px;
     padding-bottom: 10px;
-    margin-left: 5px;
     margin-bottom: 10px;
     text-align: center;
+    height: auto !important;
+    width: 8vw !important;
+    min-width: 180px !important;
 }
 
 .note-new-text {
@@ -27,11 +29,11 @@ span.button-hover {
 
 .resume-note-btn {
     background-color: white !important;
-    height: 80px;
-    width: 95%;
     padding: 10px !important;
-    margin-left: 5px;
     margin-bottom: 20px;
+    height: auto !important;
+    width: 8vw !important;
+    min-width: 180px !important;
 }
 
 .resume-note-btn:hover {
@@ -68,6 +70,9 @@ span.button-hover {
 }
 .note {
     padding-top: 0px !important;
+    height: auto !important;
+    width: 8vw !important;
+    min-width: 180px !important;
 }
 
 .note:hover {
@@ -94,13 +99,11 @@ span.button-hover {
 
 .more-notes-btn {
     background-color: white !important;
-    font-size: 0.7rem !important;
-    height: 60px;
-    width: 95%;
     padding: 10px !important;
-    margin-left: 5px;
     margin-top: 10px;
-    text-transform: none !important;
+    height: auto !important;
+    width: 8vw !important;
+    min-width: 180px !important;
 }
 
 .more-notes-btn:hover {

--- a/src/notes/NoteAssistant.css
+++ b/src/notes/NoteAssistant.css
@@ -19,7 +19,7 @@ span.button-hover {
     margin-bottom: 10px;
     text-align: center;
     height: auto !important;
-    width: 15vw !important;
+    width: 9vw !important;
     min-width: 180px !important;
 }
 
@@ -32,7 +32,7 @@ span.button-hover {
     padding: 10px !important;
     margin-bottom: 20px;
     height: auto !important;
-    width: 15vw !important;
+    width: 9vw !important;
     min-width: 180px !important;
 }
 
@@ -71,7 +71,7 @@ span.button-hover {
 .note {
     padding-top: 0px !important;
     height: auto !important;
-    width: 15vw !important;
+    width: 9vw !important;
     min-width: 180px !important;
 }
 
@@ -102,7 +102,7 @@ span.button-hover {
     padding: 10px !important;
     margin-top: 10px;
     height: auto !important;
-    width: 15vw !important;
+    width: 9vw !important;
     min-width: 180px !important;
 }
 

--- a/src/notes/NoteAssistant.css
+++ b/src/notes/NoteAssistant.css
@@ -5,25 +5,49 @@ span.button-hover {
 
 .clinical-notes-panel {
     margin: auto;
-    width: 150px;
+    width: 160px;
     height: 100px;
+}
+
+.note-new {
+    padding-bottom: 20px;
+    margin-bottom: 20px;
+    text-align: center;
 }
 
 .resume-note-btn {
     background-color: white !important;
     height: 120px;
     width: 100%;
+    margin-bottom: 20px;
 }
 
 .resume-note-btn:hover {
     background: #e6e6e6 !important;
 }
 
+.svg {
+    z-index: 999;
+}
+
+.note-new:hover {
+    cursor:pointer;
+    background: #e6e6e6;
+}
+
+.note {
+    padding-top: 0px !important;
+}
+
+
 .note:hover {
     cursor:pointer;
     background: #e6e6e6;
 }
 
+.notes-table {
+    margin-top: 0px !important;
+}
 /*Playing around with button click animation*/
 /*.note:active {*/
     /*vertical-align: top;*/

--- a/src/notes/NoteAssistant.css
+++ b/src/notes/NoteAssistant.css
@@ -2,7 +2,6 @@ span.button-hover {
     cursor: pointer;
 }
 
-
 .clinical-notes-panel {
     margin: auto;
     width: 160px;
@@ -10,9 +9,15 @@ span.button-hover {
 }
 
 .note-new {
-    padding-bottom: 20px;
+    padding-top: 10px;
+    padding-bottom: 10px;
     margin-bottom: 20px;
     text-align: center;
+}
+
+.note-new:hover {
+    cursor:pointer;
+    background: #e6e6e6;
 }
 
 .resume-note-btn {
@@ -26,19 +31,38 @@ span.button-hover {
     background: #e6e6e6 !important;
 }
 
-.svg {
-    z-index: 999;
+
+.previous-notes-label {
+    font-weight: bold;
+    font-size: 0.8em;
+    margin-left: 10px;
 }
 
-.note-new:hover {
-    cursor:pointer;
-    background: #e6e6e6;
+.sort-label {
+    margin-left: 10px;
+    font-size: 0.8em;
 }
 
+.sort-selection {
+
+    margin-bottom: 20px;
+}
+
+.sort-select {
+    width: 50%;
+    margin-left: 10px;
+}
+.sort-selection .sort-select {
+    font-size: 0.8em;
+}
+
+.sort-item:hover {
+    background-color: #1384b5;
+    color: #fff;
+}
 .note {
     padding-top: 0px !important;
 }
-
 
 .note:hover {
     cursor:pointer;
@@ -48,6 +72,39 @@ span.button-hover {
 .notes-table {
     margin-top: 0px !important;
 }
+
+
+td.existing-note-date {
+    color: #333333 !important;
+    font-weight: bold;
+}
+
+td.existing-note-subject {
+    font-size: 0.8rem;
+    color: #999 !important;
+}
+
+td.existing-note-metadata {
+    color: #999 !important;
+}
+
+.view-more-notes-label {
+    margin-left: 10px;
+    font-size: 0.8em;
+}
+
+.more-notes-btn {
+    background-color: white !important;
+    height: 80px;
+    width: 100%;
+    margin-bottom: 20px;
+    text-transform: none !important;
+}
+
+.more-notes-btn:hover {
+    background: #e6e6e6 !important;
+}
+
 /*Playing around with button click animation*/
 /*.note:active {*/
     /*vertical-align: top;*/

--- a/src/notes/NoteAssistant.css
+++ b/src/notes/NoteAssistant.css
@@ -16,10 +16,14 @@ span.button-hover {
 .note-new {
     padding-top: 10px;
     padding-bottom: 10px;
+    margin-left: 5px;
     margin-bottom: 10px;
     text-align: center;
 }
 
+.note-new-text {
+    font-size: 0.9rem;
+}
 
 .resume-note-btn {
     background-color: white !important;
@@ -33,7 +37,6 @@ span.button-hover {
 .resume-note-btn:hover {
     background: #e6e6e6 !important;
 }
-
 
 .previous-notes-label {
     font-weight: bold;
@@ -65,18 +68,12 @@ span.button-hover {
 }
 .note {
     padding-top: 0px !important;
-
 }
 
 .note:hover {
     cursor:pointer;
     background: #e6e6e6;
 }
-
-.notes-table {
-    margin-top: 0px !important;
-}
-
 
 .existing-note-date {
     font-size: 0.7rem;
@@ -109,10 +106,4 @@ span.button-hover {
 .more-notes-btn:hover {
     background: #e6e6e6 !important;
 }
-
-/*Playing around with button click animation*/
-/*.note:active {*/
-    /*vertical-align: top;*/
-    /*padding: 8px 13px 6px;*/
-/*}*/
 

--- a/src/notes/NoteAssistant.css
+++ b/src/notes/NoteAssistant.css
@@ -19,7 +19,7 @@ span.button-hover {
     margin-bottom: 10px;
     text-align: center;
     height: auto !important;
-    width: 8vw !important;
+    width: 15vw !important;
     min-width: 180px !important;
 }
 
@@ -32,7 +32,7 @@ span.button-hover {
     padding: 10px !important;
     margin-bottom: 20px;
     height: auto !important;
-    width: 8vw !important;
+    width: 15vw !important;
     min-width: 180px !important;
 }
 
@@ -71,7 +71,7 @@ span.button-hover {
 .note {
     padding-top: 0px !important;
     height: auto !important;
-    width: 8vw !important;
+    width: 15vw !important;
     min-width: 180px !important;
 }
 
@@ -102,7 +102,7 @@ span.button-hover {
     padding: 10px !important;
     margin-top: 10px;
     height: auto !important;
-    width: 8vw !important;
+    width: 15vw !important;
     min-width: 180px !important;
 }
 

--- a/src/notes/NoteAssistant.css
+++ b/src/notes/NoteAssistant.css
@@ -2,8 +2,31 @@ span.button-hover {
     cursor: pointer;
 }
 
-.resume-note-btn {
-    width: 100%;
-    height: 60px;
-    background-color: white !important;
+
+.clinical-notes-panel {
+    margin: auto;
+    width: 150px;
+    height: 100px;
 }
+
+.resume-note-btn {
+    background-color: white !important;
+    height: 120px;
+    width: 100%;
+}
+
+.resume-note-btn:hover {
+    background: #e6e6e6 !important;
+}
+
+.note:hover {
+    cursor:pointer;
+    background: #e6e6e6;
+}
+
+/*Playing around with button click animation*/
+/*.note:active {*/
+    /*vertical-align: top;*/
+    /*padding: 8px 13px 6px;*/
+/*}*/
+

--- a/src/notes/NoteAssistant.css
+++ b/src/notes/NoteAssistant.css
@@ -5,14 +5,7 @@ span.button-hover {
 .clinical-notes-panel {
     margin: auto;
     width: 160px;
-    height: 100px;
-}
-
-.note-new {
-    padding-top: 10px;
-    padding-bottom: 10px;
-    margin-bottom: 20px;
-    text-align: center;
+    /*height: 100px;*/
 }
 
 .note-new:hover {
@@ -20,10 +13,20 @@ span.button-hover {
     background: #e6e6e6;
 }
 
+.note-new {
+    padding-top: 10px;
+    padding-bottom: 10px;
+    margin-bottom: 10px;
+    text-align: center;
+}
+
+
 .resume-note-btn {
     background-color: white !important;
-    height: 120px;
-    width: 100%;
+    height: 80px;
+    width: 95%;
+    padding: 10px !important;
+    margin-left: 5px;
     margin-bottom: 20px;
 }
 
@@ -62,6 +65,7 @@ span.button-hover {
 }
 .note {
     padding-top: 0px !important;
+
 }
 
 .note:hover {
@@ -74,30 +78,31 @@ span.button-hover {
 }
 
 
-td.existing-note-date {
+.existing-note-date {
+    font-size: 0.7rem;
     color: #333333 !important;
     font-weight: bold;
 }
 
-td.existing-note-subject {
-    font-size: 0.8rem;
+.existing-note-subject {
+    font-size: 0.7rem;
     color: #999 !important;
 }
 
-td.existing-note-metadata {
+.existing-note-metadata {
+    font-size: 0.7rem;
     color: #999 !important;
-}
-
-.view-more-notes-label {
-    margin-left: 10px;
-    font-size: 0.8em;
+    margin-bottom: 5px;
 }
 
 .more-notes-btn {
     background-color: white !important;
-    height: 80px;
-    width: 100%;
-    margin-bottom: 20px;
+    font-size: 0.7rem !important;
+    height: 60px;
+    width: 95%;
+    padding: 10px !important;
+    margin-left: 5px;
+    margin-top: 10px;
     text-transform: none !important;
 }
 

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -109,7 +109,7 @@ class NoteAssistant extends Component {
     // Render the new note button
     renderNewNoteSVG() {
         return (
-            <svg className="note-new" onClick={() => {this.test()}}width="150px" height="33px" viewBox="0 0 150 33" version="1.1"
+            <svg className="note-new" onClick={() => {this.test()}} viewBox="0 0 150 33" version="1.1"
                  xmlns="http://www.w3.org/2000/svg">
                 <defs>
                     <path
@@ -170,7 +170,7 @@ class NoteAssistant extends Component {
     renderClinicalNoteSVG(item, i) {
 
         return (
-            <svg key={i} className="note" width="160px" height="102px" viewBox="0 0 149 102" version="1.1"
+            <svg key={i} className="note" viewBox="0 0 149 102" version="1.1"
                  xmlns="http://www.w3.org/2000/svg">
                 <defs>
                     <path

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -1,4 +1,6 @@
 import React, {Component} from 'react';
+import Divider from 'material-ui/Divider';
+import Paper from 'material-ui/Paper';
 import ContextTray from '../context/ContextTray';
 import Button from '../elements/Button';
 
@@ -23,6 +25,10 @@ class NoteAssistant extends Component {
         );
     }
 
+    test() {
+        console.log("clicked on paper");
+    }
+
     renderNoteAssistantContent(noteAssistantMode) {
 
         switch (noteAssistantMode) {
@@ -42,15 +48,11 @@ class NoteAssistant extends Component {
                 );
             case "clinical-notes":
                 return (
-                    <div>
+                    <div className="clinical-notes-panel">
                         <Button raised
                                 className="resume-note-btn"
                         >Resume in-progress note</Button>
-                        <table>
-                            <tbody>
-                            {this.renderedNotes()}
-                            </tbody>
-                        </table>
+                        {this.renderedNotes()}
                     </div>
                 );
 
@@ -62,21 +64,30 @@ class NoteAssistant extends Component {
 
     renderedNotes() {
         return this.props.patient.getNotes().map((item, i) =>
-
-            <tr className="existing-note-entry" key={i}>
-                <td className="existing-note-date" width="15%">{item.date}</td>
-                <td className="existing-note-metadata" width="55%">
-                    <span id="existing-note-subject">{item.subject}</span> <br/>
-                    <span>{item.hospital}</span> <br/>
-                    <span>{item.clinician}</span>
-                </td>
-                <td className="existing-note-button" width="30%">
-                    <Button raised
-                            className="existing-note-btn"
-                            key={i}
-                    >View Note</Button>
-                </td>
-            </tr>
+            <Paper key={i} className="note" onClick={() => {
+                this.test()
+            }}>
+                <table >
+                    <tbody>
+                    <tr>
+                        <td className="existing-note-date" width="15%">{item.date}</td>
+                    </tr>
+                    <tr>
+                        <td className="existing-note-date" id="existing-note-subject">{item.subject}</td>
+                        </tr>
+                    <Divider />
+                    <tr>
+                        <td className="existing-note-metadata" width="55%">
+                            <span>{item.hospital}</span> <br/>
+                            {/*<span>{item.clinician}</span>*/}
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+                {/*<svg width="100" height="100">*/}
+                    {/*<circle cx="50" cy="50" r="40" stroke="green"  fill="yellow" />*/}
+                {/*</svg>*/}
+            </Paper>
         );
     }
 

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -3,9 +3,10 @@ import Divider from 'material-ui/Divider';
 import Paper from 'material-ui/Paper';
 import ContextTray from '../context/ContextTray';
 import Button from '../elements/Button';
+import Select from 'material-ui/Select';
+import MenuItem from 'material-ui/Menu/MenuItem';
 
 import './NoteAssistant.css';
-
 
 class NoteAssistant extends Component {
 
@@ -13,26 +14,54 @@ class NoteAssistant extends Component {
         super(props);
 
         this.state = {
-            noteAssistantMode: "context-tray"
+            noteAssistantMode: "context-tray",
+            sortIndex: null,
+            maxNotesToDisplay: 4,
+            notesNotDisplayed: null,
+            notesToDisplay: []
         };
     }
 
+    componentWillMount() {
+
+        // Set default value for sort selection
+        this.selectSort(0);
+
+        // Generate notesToDisplay array which will be used to render the notes in clinical notes view
+        let allNotes = this.props.patient.getNotes();
+        for (let i = 0; i < this.state.maxNotesToDisplay; i++) {
+            this.state.notesToDisplay.push(allNotes[i]);
+        }
+
+        // Set the number of notes that are not being displayed
+        let missingNotes = allNotes.length - this.state.maxNotesToDisplay;
+
+        this.setState({ notesNotDisplayed: missingNotes });
+    }
+
+    // Switch view. Currently only switching from context tray to clinical notes is available
+    // Cannot currently switch from clinical notes view back to current note view
     toggleView() {
-        this.setState(
-            {
-                noteAssistantMode: "clinical-notes"
-            }
-        );
+        this.setState({ noteAssistantMode: "clinical-notes" });
+    }
+
+    selectSort(sortIndex) {
+        this.setState({ sortIndex: sortIndex });
     }
 
     test() {
-        console.log("clicked on paper");
+        console.log("clicked on new note");
     }
 
+    // Render the content for the Note Assistant panel
     renderNoteAssistantContent(noteAssistantMode) {
+
+        const numberOfPreviousNotes = this.props.patient.getNotes().length;
 
         switch (noteAssistantMode) {
             case "context-tray":
+
+                // Render the context tray
                 return (
                     <div>
                         <span className="button-hover clinical-notes-btn" onClick={() => {
@@ -46,21 +75,32 @@ class NoteAssistant extends Component {
                         />
                     </div>
                 );
+
+            // Render the clinical notes view which includes new note button, resume note button,
+            // number of previous notes label, sort selection, and preview of previous notes
             case "clinical-notes":
                 return (
                     <div className="clinical-notes-panel">
                         <Paper className="note-new" onClick={() => {
                             this.test()
                         }}>
-                            {this.renderNoteSVG()}
-                            <span><i className="fa fa-plus" aria-hidden="true"></i>New note</span>
+                            <span><i className="fa fa-plus" aria-hidden="true"></i> New note</span>
+                            {/*{this.renderNewNoteSVG()}*/}
                         </Paper>
-
                         <Button raised
                                 className="resume-note-btn"
                         >Resume in-progress note</Button>
 
-                        {this.renderedNotes()}
+                        <span className="previous-notes-label">{numberOfPreviousNotes} previous notes</span>
+
+                        {this.renderSortSelection()}
+
+                        {this.renderNotes()}
+
+                        {this.renderMoreNotesButton()}
+
+                        {/*<span*/}
+                            {/*className="view-more-notes-label">Notes not displayed: {this.state.notesNotDisplayed}</span>*/}
 
                     </div>
                 );
@@ -71,13 +111,29 @@ class NoteAssistant extends Component {
         }
     }
 
-    renderedNotes() {
-        return this.props.patient.getNotes().map((item, i) =>
-            <Paper key={i} className="note" onClick={() => {
-                this.test()
-            }}>
+    renderSortSelection() {
+        return (
+            <div className="sort-selection">
+                <span className="sort-label">Sort by </span>
+                <Select
+                    className="sort-select"
+                    value={this.state.sortIndex}
+                    onChange={(event) => this.selectSort(event.target.value)}
+                >
+                    <MenuItem className="sort-item" value={0}>Date</MenuItem>
+                    <MenuItem className="sort-item" value={1}>Subject</MenuItem>
+                    <MenuItem className="sort-item" value={2}>Hospital</MenuItem>
+                </Select>
+            </div>
+        );
+    }
 
-                {this.renderNoteSVG()}
+    renderNotes() {
+
+        return this.state.notesToDisplay.map((item, i) =>
+            <Paper key={i} className="note">
+
+                {/*{this.renderClinicalNoteSVG()}*/}
 
                 <table className="notes-table">
                     <tbody>
@@ -85,7 +141,7 @@ class NoteAssistant extends Component {
                         <td className="existing-note-date" width="15%">{item.date}</td>
                     </tr>
                     <tr>
-                        <td className="existing-note-date" id="existing-note-subject">{item.subject}</td>
+                        <td className="existing-note-subject" id="existing-note-subject">{item.subject}</td>
                     </tr>
                     <Divider />
                     <tr>
@@ -100,30 +156,61 @@ class NoteAssistant extends Component {
         );
     }
 
-    renderNoteSVG() {
+    renderMoreNotesButton() {
+        if (this.state.notesNotDisplayed > 0) {
+            return (
+                <Button raised
+                        className="more-notes-btn"
+
+                >View {this.state.notesNotDisplayed} more clinical note(s)</Button>
+            );
+        }
+
+    }
+
+    renderClinicalNoteSVG() {
         return (
-            <svg width="160" height="17">
-                <defs>
-                    <filter id="f1" x="0" y="0" width="200%" height="200%">
-                        <feOffset result="offOut" in="SourceGraphic" dx="20" dy="20"/>
-                        <feBlend in="SourceGraphic" in2="offOut" mode="normal"/>
-                    </filter>
-                </defs>
-                <rect x="144" y="0" rx="2" ry="2" width="17" height="17"
-                      fill="white" stroke="#999" strokeWidth="1" opacity="0.5" filter="url(#f1)"/>
-                <line x1="145" y1="0" x2="200" y2="52" stroke="#999" strokeWidth="1" filter="url(#f1)"/>
+            <svg width="160" height="160">
+
+                <rect x="143" y="0" rx="2" ry="2" width="17" height="17"
+                      fill="white" stroke="#999" strokeWidth="1" opacity="0.5"/>
+                <line x1="143" y1="0" x2="200" y2="52" stroke="#999" strokeWidth="1"/>
+
+                <text x="20" y="20" fontFamily="sans-serif" fontSize="20px" fill="red">Date</text>
+                <text x="20" y="40" fontFamily="sans-serif" fontSize="20px" fill="red">note subject</text>
+
+                <line x1="10" y1="50" x2="150" y2="50" stroke="#999" strokeWidth="1"/>
+                <text x="20" y="60" fontFamily="sans-serif" fontSize="20px" fill="red">hospital</text>
+            </svg>
+        );
+    }
+
+    renderNewNoteSVG() {
+        return (
+            <svg width="11px" height="11px" viewBox="0 0 11 11" version="1.1" xmlns="http://www.w3.org/2000/svg">
+                <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd" strokeLinecap="square">
+                    <g id="Group-Copy-3" transform="translate(0.660429, 0.452719)" stroke="#16253E"
+                       strokeWidth="1.5552">
+                        <path d="M0.465836188,4.96173944 L8.70583619,4.96173944" id="Line"></path>
+                        <path d="M4.59517238,1.04666266 L4.59517238,9.28624923" id="Line-Copy"></path>
+                    </g>
+                </g>
+                <text x="0" y="0" fontFamily="sans-serif" fontSize="20px" fill="red">New note</text>
             </svg>
         );
     }
 
     render() {
 
+        // If the note viewer is editable then we want to be able to edit notes and view the context tray
         if (this.props.isNoteViewerEditable) {
             return (
                 <div>
                     {this.renderNoteAssistantContent(this.state.noteAssistantMode)}
                 </div>
             );
+
+            // If the note viewer is read only the we want to be able to view the clinical notes
         } else {
             return (
                 <div>

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -43,10 +43,13 @@ class NoteAssistant extends Component {
         this.setState({noteAssistantMode: "clinical-notes"});
     }
 
+    // Update the selected index for the sort drop down
     selectSort(sortIndex) {
         this.setState({sortIndex: sortIndex});
     }
 
+    // Test method when user clicks on the new note button
+    // TODO: Implement creation of a new note. Rename method
     test() {
         console.log("clicked on new note");
     }
@@ -103,6 +106,41 @@ class NoteAssistant extends Component {
         }
     }
 
+    // Render the new note button
+    renderNewNoteSVG() {
+        return (
+            <svg className="note-new" width="150px" height="33px" viewBox="0 0 150 33" version="1.1"
+                 xmlns="http://www.w3.org/2000/svg">
+                <defs>
+                    <path
+                        d="M136.737204,0.069612193 L3.70678711,0.069612193 L3.70678711,0.069612193 C2.04993286,0.069612193 0.706787109,1.41275794 0.706787109,3.06961219 L0.706787109,3.06961219 L0.706787109,30 C0.706787109,31.6568542 2.04993286,33 3.70678711,33 L3.70678711,33 L146.214569,33 C147.871423,33 149.214569,31.6568542 149.214569,30 L149.214569,30 L149.214569,12.5469764 L136.737204,0.069612193 Z"
+                        id="path-1"></path>
+                </defs>
+                <svg x="25" y="12" width="11px" height="11px" viewBox="0 0 11 11" version="1.1" xmlns="http://www.w3.org/2000/svg">
+                    <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd" strokeLinecap="square">
+                        <g id="Group-Copy-3" transform="translate(0.660429, 0.452719)" stroke="#16253E" strokeWidth="1.5552">
+                            <path d="M0.465836188,4.96173944 L8.70583619,4.96173944" id="Line"></path>
+                            <path d="M4.59517238,1.04666266 L4.59517238,9.28624923" id="Line-Copy"></path>
+                        </g>
+                    </g>
+                </svg>
+                <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
+                    <g id="Group-24">
+                        <g id="Combined-Shape">
+                            <use fill="#FFFFFF" fillRule="evenodd" ></use>
+                            <path stroke="#B3B3B3" strokeWidth="0.5"
+                                  d="M136.633651,0.319612193 L3.70678711,0.319612193 C2.18800405,0.319612193 0.956787109,1.55082913 0.956787109,3.06961219 L0.956787109,30 C0.956787109,31.5187831 2.18800405,32.75 3.70678711,32.75 L146.214569,32.75 C147.733352,32.75 148.964569,31.5187831 148.964569,30 L148.964569,12.6505298 L136.633651,0.319612193 Z"></path>
+                        </g>
+                        <polyline id="Path-14" stroke="#B3B3B3" strokeWidth="0.5" fill="#FFFFFF"
+                                  points="136.300181 0.370008208 136.300181 13.0028388 148.974379 13.0028388"></polyline>
+                    </g>
+                </g>
+                <text className="note-new-text" x="40" y="22">New note</text>
+            </svg>
+        );
+    }
+
+    // Render the sort drop down
     renderSortSelection() {
         return (
             <div className="sort-selection">
@@ -120,6 +158,7 @@ class NoteAssistant extends Component {
         );
     }
 
+    // Render the list of clinical notes
     renderNotes() {
 
         return this.state.notesToDisplay.map((item, i) =>
@@ -127,16 +166,7 @@ class NoteAssistant extends Component {
         );
     }
 
-    renderMoreNotesButton() {
-        if (this.state.notesNotDisplayed > 0) {
-            return (
-                <Button raised
-                        className="more-notes-btn"
-                >View {this.state.notesNotDisplayed} more clinical note(s)</Button>
-            );
-        }
-    }
-
+    // For each clinical note, render the note image with the text
     renderClinicalNoteSVG(item, i) {
 
         return (
@@ -169,6 +199,7 @@ class NoteAssistant extends Component {
         );
     }
 
+    // Render the meta data section of the note (currently this data is just the hospital name)
     renderMetaDataText(item) {
 
         // Split hospital name into 2 lines for svg (svg doesn't handle text wrap. Do this manually using tspan tag)
@@ -185,23 +216,23 @@ class NoteAssistant extends Component {
 
         // If the hospital name contains more than 3 words, split it into 2 lines to be displayed in the note
         if (hospitalWordsArray.length > 3) {
-            let numberInFirstHalf = Math.ceil(hospitalWordsArray.length/2);
+            let numberInFirstHalf = Math.ceil(hospitalWordsArray.length / 2);
 
-            for (let i=0; i < Math.ceil(hospitalWordsArray.length/2); i++) {
+            for (let i = 0; i < Math.ceil(hospitalWordsArray.length / 2); i++) {
                 hospitalFirstArray.push(hospitalWordsArray[i]);
                 hospitalFirstArray.push(" ");
             }
 
-            for (let j=numberInFirstHalf; j < hospitalWordsArray.length; j++) {
+            for (let j = numberInFirstHalf; j < hospitalWordsArray.length; j++) {
                 hospitalSecondArray.push(hospitalWordsArray[j]);
                 hospitalSecondArray.push(" ");
             }
 
-            for (let i=0; i < hospitalFirstArray.length; i++) {
+            for (let i = 0; i < hospitalFirstArray.length; i++) {
                 hospitalFirstString = hospitalFirstString.concat(hospitalFirstArray[i]);
             }
 
-            for (let j=0; j < hospitalSecondArray.length; j++) {
+            for (let j = 0; j < hospitalSecondArray.length; j++) {
                 hospitalSecondString = hospitalSecondString.concat(hospitalSecondArray[j]);
             }
 
@@ -223,43 +254,18 @@ class NoteAssistant extends Component {
         }
     }
 
-    renderNewNoteSVG() {
-        return (
-            <svg className="note-new" width="160px" height="102px" viewBox="0 0 149 102" version="1.1"
-                 xmlns="http://www.w3.org/2000/svg">
-                <defs>
-                    <path
-                        d="M136.405173,0.069612193 L3.37475586,0.069612193 L3.37475586,0.069612193 C1.71790161,0.069612193 0.374755859,1.41275794 0.374755859,3.06961219 L0.374755859,3.06961219 L0.374755859,98.5117187 C0.374755859,100.168573 1.71790161,101.511719 3.37475586,101.511719 L3.37475586,101.511719 L145.882537,101.511719 C147.539392,101.511719 148.882537,100.168573 148.882537,98.5117187 L148.882537,98.5117187 L148.882537,12.5469764 L136.405173,0.069612193 Z"
-                        id="path-1"></path>
-                </defs>
-                <svg x="25" y="15" width="11px" height="11px" viewBox="0 0 11 11" version="1.1"
-                     xmlns="http://www.w3.org/2000/svg">
-                    <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd" strokeLinecap="square">
-                        <g id="Group-Copy-3" transform="translate(0.660429, 0.452719)" stroke="#16253E"
-                           strokeWidth="1.5552">
-                            <path d="M0.465836188,4.96173944 L8.70583619,4.96173944" id="Line"></path>
-                            <path d="M4.59517238,1.04666266 L4.59517238,9.28624923" id="Line-Copy"></path>
-                        </g>
-                    </g>
-                </svg>
-
-                <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
-                    <g id="Group-23">
-                        <g id="Combined-Shape">
-                            <use fill="#FFFFFF" fillRule="evenodd"></use>
-                            <path stroke="#B3B3B3" strokeWidth="0.5"
-                                  d="M136.30162,0.319612193 L3.37475586,0.319612193 C1.8559728,0.319612193 0.624755859,1.55082913 0.624755859,3.06961219 L0.624755859,98.5117187 C0.624755859,100.030502 1.8559728,101.261719 3.37475586,101.261719 L145.882537,101.261719 C147.401321,101.261719 148.632537,100.030502 148.632537,98.5117187 L148.632537,12.6505298 L136.30162,0.319612193 Z"></path>
-                        </g>
-                        <polyline id="Path-14" stroke="#B3B3B3" strokeWidth="0.5" fill="#FFFFFF"
-                                  points="135.968149 0.370008208 135.968149 13.0028388 148.642348 13.0028388"></polyline>
-                    </g>
-                </g>
-                <text x="40" y="25">New note</text>
-
-            </svg>
-        );
+    // Render the button to display more notes that are not currently displayed
+    renderMoreNotesButton() {
+        if (this.state.notesNotDisplayed > 0) {
+            return (
+                <Button raised
+                        className="more-notes-btn"
+                >View {this.state.notesNotDisplayed} more clinical note(s)</Button>
+            );
+        }
     }
 
+    // Main render method
     render() {
 
         // If the note viewer is editable then we want to be able to edit notes and view the context tray

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -1,6 +1,4 @@
 import React, {Component} from 'react';
-import Divider from 'material-ui/Divider';
-import Paper from 'material-ui/Paper';
 import ContextTray from '../context/ContextTray';
 import Button from '../elements/Button';
 import Select from 'material-ui/Select';
@@ -16,7 +14,7 @@ class NoteAssistant extends Component {
         this.state = {
             noteAssistantMode: "context-tray",
             sortIndex: null,
-            maxNotesToDisplay: 4,
+            maxNotesToDisplay: 3,
             notesNotDisplayed: null,
             notesToDisplay: []
         };
@@ -36,17 +34,17 @@ class NoteAssistant extends Component {
         // Set the number of notes that are not being displayed
         let missingNotes = allNotes.length - this.state.maxNotesToDisplay;
 
-        this.setState({ notesNotDisplayed: missingNotes });
+        this.setState({notesNotDisplayed: missingNotes});
     }
 
     // Switch view. Currently only switching from context tray to clinical notes is available
     // Cannot currently switch from clinical notes view back to current note view
     toggleView() {
-        this.setState({ noteAssistantMode: "clinical-notes" });
+        this.setState({noteAssistantMode: "clinical-notes"});
     }
 
     selectSort(sortIndex) {
-        this.setState({ sortIndex: sortIndex });
+        this.setState({sortIndex: sortIndex});
     }
 
     test() {
@@ -81,12 +79,9 @@ class NoteAssistant extends Component {
             case "clinical-notes":
                 return (
                     <div className="clinical-notes-panel">
-                        <Paper className="note-new" onClick={() => {
-                            this.test()
-                        }}>
-                            <span><i className="fa fa-plus" aria-hidden="true"></i> New note</span>
-                            {/*{this.renderNewNoteSVG()}*/}
-                        </Paper>
+
+                        {this.renderNewNoteSVG()}
+
                         <Button raised
                                 className="resume-note-btn"
                         >Resume in-progress note</Button>
@@ -98,9 +93,6 @@ class NoteAssistant extends Component {
                         {this.renderNotes()}
 
                         {this.renderMoreNotesButton()}
-
-                        {/*<span*/}
-                            {/*className="view-more-notes-label">Notes not displayed: {this.state.notesNotDisplayed}</span>*/}
 
                     </div>
                 );
@@ -131,28 +123,7 @@ class NoteAssistant extends Component {
     renderNotes() {
 
         return this.state.notesToDisplay.map((item, i) =>
-            <Paper key={i} className="note">
-
-                {/*{this.renderClinicalNoteSVG()}*/}
-
-                <table className="notes-table">
-                    <tbody>
-                    <tr>
-                        <td className="existing-note-date" width="15%">{item.date}</td>
-                    </tr>
-                    <tr>
-                        <td className="existing-note-subject" id="existing-note-subject">{item.subject}</td>
-                    </tr>
-                    <Divider />
-                    <tr>
-                        <td className="existing-note-metadata" width="55%">
-                            <span>{item.hospital}</span> <br/>
-                            {/*<span>{item.clinician}</span>*/}
-                        </td>
-                    </tr>
-                    </tbody>
-                </table>
-            </Paper>
+            this.renderClinicalNoteSVG(item, i)
         );
     }
 
@@ -161,41 +132,130 @@ class NoteAssistant extends Component {
             return (
                 <Button raised
                         className="more-notes-btn"
-
                 >View {this.state.notesNotDisplayed} more clinical note(s)</Button>
             );
         }
-
     }
 
-    renderClinicalNoteSVG() {
+    renderClinicalNoteSVG(item, i) {
+
         return (
-            <svg width="160" height="160">
+            <svg key={i} className="note" width="160px" height="102px" viewBox="0 0 149 102" version="1.1"
+                 xmlns="http://www.w3.org/2000/svg">
+                <defs>
+                    <path
+                        d="M136.405173,0.069612193 L3.37475586,0.069612193 L3.37475586,0.069612193 C1.71790161,0.069612193 0.374755859,1.41275794 0.374755859,3.06961219 L0.374755859,3.06961219 L0.374755859,98.5117187 C0.374755859,100.168573 1.71790161,101.511719 3.37475586,101.511719 L3.37475586,101.511719 L145.882537,101.511719 C147.539392,101.511719 148.882537,100.168573 148.882537,98.5117187 L148.882537,98.5117187 L148.882537,12.5469764 L136.405173,0.069612193 Z"
+                        id="path-1"></path>
+                </defs>
+                <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
+                    <g id="Group-23">
+                        <g id="Combined-Shape">
+                            <use fill="#FFFFFF" fillRule="evenodd"></use>
+                            <path stroke="#B3B3B3" strokeWidth="0.5"
+                                  d="M136.30162,0.319612193 L3.37475586,0.319612193 C1.8559728,0.319612193 0.624755859,1.55082913 0.624755859,3.06961219 L0.624755859,98.5117187 C0.624755859,100.030502 1.8559728,101.261719 3.37475586,101.261719 L145.882537,101.261719 C147.401321,101.261719 148.632537,100.030502 148.632537,98.5117187 L148.632537,12.6505298 L136.30162,0.319612193 Z"></path>
+                        </g>
+                        <polyline id="Path-14" stroke="#B3B3B3" strokeWidth="0.5" fill="#FFFFFF"
+                                  points="135.968149 0.370008208 135.968149 13.0028388 148.642348 13.0028388"></polyline>
+                    </g>
+                </g>
+                <text className="existing-note-date" x="20" y="20">{item.date}</text>
+                <text x="20" y="40" className="existing-note-subject">{item.subject}</text>
 
-                <rect x="143" y="0" rx="2" ry="2" width="17" height="17"
-                      fill="white" stroke="#999" strokeWidth="1" opacity="0.5"/>
-                <line x1="143" y1="0" x2="200" y2="52" stroke="#999" strokeWidth="1"/>
+                <line x1="10" y1="50" x2="140" y2="50" stroke="#999" strokeWidth="1"/>
 
-                <text x="20" y="20" fontFamily="sans-serif" fontSize="20px" fill="red">Date</text>
-                <text x="20" y="40" fontFamily="sans-serif" fontSize="20px" fill="red">note subject</text>
+                {this.renderMetaDataText(item)}
 
-                <line x1="10" y1="50" x2="150" y2="50" stroke="#999" strokeWidth="1"/>
-                <text x="20" y="60" fontFamily="sans-serif" fontSize="20px" fill="red">hospital</text>
             </svg>
         );
     }
 
+    renderMetaDataText(item) {
+
+        // Split hospital name into 2 lines for svg (svg doesn't handle text wrap. Do this manually using tspan tag)
+        // Only split the name if it is more than three words long
+        let hospitalWordsArray = item.hospital.split(" ");
+
+        // Arrays hold the words in the hospital name
+        let hospitalFirstArray = [];
+        let hospitalSecondArray = [];
+
+        // Strings hold the string to be displayed in the note
+        let hospitalFirstString = "";
+        let hospitalSecondString = "";
+
+        // If the hospital name contains more than 3 words, split it into 2 lines to be displayed in the note
+        if (hospitalWordsArray.length > 3) {
+            let numberInFirstHalf = Math.ceil(hospitalWordsArray.length/2);
+
+            for (let i=0; i < Math.ceil(hospitalWordsArray.length/2); i++) {
+                hospitalFirstArray.push(hospitalWordsArray[i]);
+                hospitalFirstArray.push(" ");
+            }
+
+            for (let j=numberInFirstHalf; j < hospitalWordsArray.length; j++) {
+                hospitalSecondArray.push(hospitalWordsArray[j]);
+                hospitalSecondArray.push(" ");
+            }
+
+            for (let i=0; i < hospitalFirstArray.length; i++) {
+                hospitalFirstString = hospitalFirstString.concat(hospitalFirstArray[i]);
+            }
+
+            for (let j=0; j < hospitalSecondArray.length; j++) {
+                hospitalSecondString = hospitalSecondString.concat(hospitalSecondArray[j]);
+            }
+
+            return (
+                <text x="20" y="70" className="existing-note-metadata">
+                    <tspan x="20" y="70">{hospitalFirstString}</tspan>
+                    <tspan x="20" y="85">{hospitalSecondString}</tspan>
+                </text>
+            );
+
+        } else {
+            hospitalFirstString = item.hospital;
+
+            return (
+                <text x="20" y="70" className="existing-note-metadata">
+                    <tspan x="20" y="70">{hospitalFirstString}</tspan>
+                </text>
+            );
+        }
+    }
+
     renderNewNoteSVG() {
         return (
-            <svg width="11px" height="11px" viewBox="0 0 11 11" version="1.1" xmlns="http://www.w3.org/2000/svg">
-                <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd" strokeLinecap="square">
-                    <g id="Group-Copy-3" transform="translate(0.660429, 0.452719)" stroke="#16253E"
-                       strokeWidth="1.5552">
-                        <path d="M0.465836188,4.96173944 L8.70583619,4.96173944" id="Line"></path>
-                        <path d="M4.59517238,1.04666266 L4.59517238,9.28624923" id="Line-Copy"></path>
+            <svg className="note-new" width="160px" height="102px" viewBox="0 0 149 102" version="1.1"
+                 xmlns="http://www.w3.org/2000/svg">
+                <defs>
+                    <path
+                        d="M136.405173,0.069612193 L3.37475586,0.069612193 L3.37475586,0.069612193 C1.71790161,0.069612193 0.374755859,1.41275794 0.374755859,3.06961219 L0.374755859,3.06961219 L0.374755859,98.5117187 C0.374755859,100.168573 1.71790161,101.511719 3.37475586,101.511719 L3.37475586,101.511719 L145.882537,101.511719 C147.539392,101.511719 148.882537,100.168573 148.882537,98.5117187 L148.882537,98.5117187 L148.882537,12.5469764 L136.405173,0.069612193 Z"
+                        id="path-1"></path>
+                </defs>
+                <svg x="25" y="15" width="11px" height="11px" viewBox="0 0 11 11" version="1.1"
+                     xmlns="http://www.w3.org/2000/svg">
+                    <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd" strokeLinecap="square">
+                        <g id="Group-Copy-3" transform="translate(0.660429, 0.452719)" stroke="#16253E"
+                           strokeWidth="1.5552">
+                            <path d="M0.465836188,4.96173944 L8.70583619,4.96173944" id="Line"></path>
+                            <path d="M4.59517238,1.04666266 L4.59517238,9.28624923" id="Line-Copy"></path>
+                        </g>
+                    </g>
+                </svg>
+
+                <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
+                    <g id="Group-23">
+                        <g id="Combined-Shape">
+                            <use fill="#FFFFFF" fillRule="evenodd"></use>
+                            <path stroke="#B3B3B3" strokeWidth="0.5"
+                                  d="M136.30162,0.319612193 L3.37475586,0.319612193 C1.8559728,0.319612193 0.624755859,1.55082913 0.624755859,3.06961219 L0.624755859,98.5117187 C0.624755859,100.030502 1.8559728,101.261719 3.37475586,101.261719 L145.882537,101.261719 C147.401321,101.261719 148.632537,100.030502 148.632537,98.5117187 L148.632537,12.6505298 L136.30162,0.319612193 Z"></path>
+                        </g>
+                        <polyline id="Path-14" stroke="#B3B3B3" strokeWidth="0.5" fill="#FFFFFF"
+                                  points="135.968149 0.370008208 135.968149 13.0028388 148.642348 13.0028388"></polyline>
                     </g>
                 </g>
-                <text x="0" y="0" fontFamily="sans-serif" fontSize="20px" fill="red">New note</text>
+                <text x="40" y="25">New note</text>
+
             </svg>
         );
     }

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -109,7 +109,7 @@ class NoteAssistant extends Component {
     // Render the new note button
     renderNewNoteSVG() {
         return (
-            <svg className="note-new" width="150px" height="33px" viewBox="0 0 150 33" version="1.1"
+            <svg className="note-new" onClick={() => {this.test()}}width="150px" height="33px" viewBox="0 0 150 33" version="1.1"
                  xmlns="http://www.w3.org/2000/svg">
                 <defs>
                     <path

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -49,10 +49,19 @@ class NoteAssistant extends Component {
             case "clinical-notes":
                 return (
                     <div className="clinical-notes-panel">
+                        <Paper className="note-new" onClick={() => {
+                            this.test()
+                        }}>
+                            {this.renderNoteSVG()}
+                            <span><i className="fa fa-plus" aria-hidden="true"></i>New note</span>
+                        </Paper>
+
                         <Button raised
                                 className="resume-note-btn"
                         >Resume in-progress note</Button>
+
                         {this.renderedNotes()}
+
                     </div>
                 );
 
@@ -67,14 +76,17 @@ class NoteAssistant extends Component {
             <Paper key={i} className="note" onClick={() => {
                 this.test()
             }}>
-                <table >
+
+                {this.renderNoteSVG()}
+
+                <table className="notes-table">
                     <tbody>
                     <tr>
                         <td className="existing-note-date" width="15%">{item.date}</td>
                     </tr>
                     <tr>
                         <td className="existing-note-date" id="existing-note-subject">{item.subject}</td>
-                        </tr>
+                    </tr>
                     <Divider />
                     <tr>
                         <td className="existing-note-metadata" width="55%">
@@ -84,10 +96,23 @@ class NoteAssistant extends Component {
                     </tr>
                     </tbody>
                 </table>
-                {/*<svg width="100" height="100">*/}
-                    {/*<circle cx="50" cy="50" r="40" stroke="green"  fill="yellow" />*/}
-                {/*</svg>*/}
             </Paper>
+        );
+    }
+
+    renderNoteSVG() {
+        return (
+            <svg width="160" height="17">
+                <defs>
+                    <filter id="f1" x="0" y="0" width="200%" height="200%">
+                        <feOffset result="offOut" in="SourceGraphic" dx="20" dy="20"/>
+                        <feBlend in="SourceGraphic" in2="offOut" mode="normal"/>
+                    </filter>
+                </defs>
+                <rect x="144" y="0" rx="2" ry="2" width="17" height="17"
+                      fill="white" stroke="#999" strokeWidth="1" opacity="0.5" filter="url(#f1)"/>
+                <line x1="145" y1="0" x2="200" y2="52" stroke="#999" strokeWidth="1" filter="url(#f1)"/>
+            </svg>
         );
     }
 

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -26,7 +26,7 @@ class NotesPanel extends Component {
         } else {
             return (
                 <Row center="xs">
-                    <Col sm={8}>
+                    <Col sm={12}>
                         {this.renderNoteAssistant()}
                     </Col>
                 </Row>

--- a/src/summary/DataSummaryPanel.css
+++ b/src/summary/DataSummaryPanel.css
@@ -14,22 +14,22 @@
     margin-top: 20px;
 }
 
-table.existing-notes td {
-    padding: 20px 10px;
-}
+/*table.existing-notes td {*/
+    /*padding: 20px 10px;*/
+/*}*/
 
-td.existing-note-metadata {
-    color: #333333;
-}
+/*td.existing-note-metadata {*/
+    /*color: #333333;*/
+/*}*/
 
-td.existing-note-date {
-    color: #999;
-}
+/*td.existing-note-date {*/
+    /*color: #999;*/
+/*}*/
 
-td span#existing-note-subject {
-    font-weight: bold;
-    font-size: 1rem;
-}
+/*td span#existing-note-subject {*/
+    /*font-weight: bold;*/
+    /*font-size: 1rem;*/
+/*}*/
 
 /*Explicitly add in top and bottom border for last cell in row because it is removed in the Data Summary Table css*/
 tr.existing-note-entry td:last-child {


### PR DESCRIPTION
Updated clinical notes view in NoteAssistant to follow Involution's design mockups. 

To view, click on clinical notes in the right most panel. The context tray toggles to the clinical notes view

- New Note and Resume in-progress note buttons don't currently work. Functionality is addressed in a separate jira issue
- label shows how many previous notes are available (adding or removing notes in the hard coded patient json updates this number)
- Selector to choose how to sort notes doesn't currently work. Sorting is address in a separate jira issue
- Implemented new note and clinical note svgs from Involution so notes match mockup design
- Added button to view additional notes (this button doesn't currently work. This is part of a different jira task). Developers can set the number of notes to view in NoteAssistant via the maxNotesToDisplay state variable. The label of the view additional notes updates to the correct number of notes not currently being shown
- Notes and buttons scale with screen size 


_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- N/A Cheat sheet is updated
- N/A Demo script is updated 
- N/A Documentation on Wiki has been updated 
- N/A Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- N/A Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- N/A Added UI tests for slim mode 
- N/A Added UI tests for full mode
- N/A Added backend tests for fluxNotes code
- N/A Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
