### PR TITLE
Narrative component handling missing data

### DIFF
--- a/src/summary/NarrativeNameValuePairsVisualizer.jsx
+++ b/src/summary/NarrativeNameValuePairsVisualizer.jsx
@@ -40,7 +40,7 @@ class NarrativeNameValuePairsVisualizer extends Component {
             return (Lang.isUndefined(item) || Lang.isNull(item.value));
         });
 
-        return allNull ? sentenceObject.dataMissingTemplate: sentenceObject.defaultTemplate;
+        return allNull ? '${' + sentenceObject.dataMissingTemplate + '}': sentenceObject.defaultTemplate;
     }
 
     // create a map of subsection name to its metadata 
@@ -110,13 +110,18 @@ class NarrativeNameValuePairsVisualizer extends Component {
             index = valueSpec.indexOf(".");
             if (index === -1) {
                 subsectionName = valueSpec;
-                list = this.getList(subsections[subsectionName]);
-                if (Lang.isEmpty(list) || Lang.isNull(list)) {
-                    value = "missing";
+                if(Lang.isUndefined(subsections[subsectionName])) {
+                    value = valueSpec;
                     type = "missing";
                 } else {
-                    value = list.map(_addLabResultToNarrative).join(", ");
-                    type = "structured-data";
+                    list = this.getList(subsections[subsectionName]);
+                    if (Lang.isEmpty(list) || Lang.isNull(list)) {
+                        value = "missing";
+                        type = "missing";
+                    } else {
+                        value = list.map(_addLabResultToNarrative).join(", ");
+                        type = "structured-data";
+                    }
                 }
             } else {
                 subsectionName = valueSpec.substring(0, index);

--- a/src/summary/NarrativeNameValuePairsVisualizer.jsx
+++ b/src/summary/NarrativeNameValuePairsVisualizer.jsx
@@ -40,7 +40,7 @@ class NarrativeNameValuePairsVisualizer extends Component {
             return (Lang.isUndefined(item) || Lang.isNull(item.value));
         });
 
-        return allNull ? '${' + sentenceObject.dataMissingTemplate + '}': sentenceObject.defaultTemplate;
+        return allNull ? sentenceObject.dataMissingTemplate : sentenceObject.defaultTemplate;
     }
 
     // create a map of subsection name to its metadata 

--- a/src/summary/NarrativeNameValuePairsVisualizer.jsx
+++ b/src/summary/NarrativeNameValuePairsVisualizer.jsx
@@ -34,7 +34,7 @@ class NarrativeNameValuePairsVisualizer extends Component {
                 return it.name === valueName;
             });
 
-            if (!Lang.isNull(item.value)) allNull = false;
+            if (!Lang.isUndefined(item) && !Lang.isNull(item.value)) allNull = false;
         });
 
         return allNull ? conditionSection.missingNarrative.template : conditionSection.narrative;

--- a/src/summary/NarrativeNameValuePairsVisualizer.jsx
+++ b/src/summary/NarrativeNameValuePairsVisualizer.jsx
@@ -9,8 +9,35 @@ import './NarrativeNameValuePairsVisualizer.css';
 class NarrativeNameValuePairsVisualizer extends Component {
 
     // get the narrative template from the metadata
-    getNarrativeTemplate() {
-        return this.props.conditionSection.narrative;
+    getNarrativeTemplate(subsections) {
+        const {conditionSection} = this.props;
+
+        if (Lang.isNull(conditionSection.missingNarrative) || Lang.isUndefined(conditionSection.missingNarrative)) {
+            return conditionSection.narrative;
+        }
+
+        let allNull = true;
+        conditionSection.missingNarrative.missingData.forEach((data) => {
+            const index = data.indexOf(".");
+            let subsectionName, valueName;
+
+            if (index === -1) {
+                subsectionName = "";
+                valueName = data;
+            } else {
+                subsectionName = data.substring(0, index);
+                valueName = data.substring(index + 1);
+            }
+
+            const list = this.getList(subsections[subsectionName]);
+            const item = list.find((it) => {
+                return it.name === valueName;
+            });
+
+            if (!Lang.isNull(item.value)) allNull = false;
+        });
+
+        return allNull ? conditionSection.missingNarrative.template : conditionSection.narrative;
     }
 
     // create a map of subsection name to its metadata 
@@ -115,8 +142,8 @@ class NarrativeNameValuePairsVisualizer extends Component {
 
     // Gets called for each section in SummaryMetaData.jsx that will be rendered by this component
     render() {
-        let template = this.getNarrativeTemplate();
         let subsections = this.getSubsections();
+        let template = this.getNarrativeTemplate(subsections);
 
         // build list of snippets that are part of narrative to support typing each snippet so each
         // can be given correct formatting and interactions

--- a/src/summary/NarrativeNameValuePairsVisualizer.jsx
+++ b/src/summary/NarrativeNameValuePairsVisualizer.jsx
@@ -18,8 +18,8 @@ class NarrativeNameValuePairsVisualizer extends Component {
             return sentenceObject.defaultTemplate;
         }
 
-        let allNull = true;
-        sentenceObject.useDataMissingTemplateCriteria.forEach((data) => {
+        // Check if every object in useDataMissingTemplateCriteria is null, empty, or undefined
+        const allNull = sentenceObject.useDataMissingTemplateCriteria.every((data) => {
             const index = data.indexOf(".");
             let subsectionName, list;
 
@@ -27,20 +27,20 @@ class NarrativeNameValuePairsVisualizer extends Component {
                 subsectionName = data;
                 list = this.getList(subsections[subsectionName]);
 
-                if (!Lang.isNull(list) && !Lang.isEmpty(list)) allNull = false;
-            } else {
-                const valueName = data.substring(index + 1);
-                subsectionName = data.substring(0, index);
-                list = this.getList(subsections[subsectionName]);
-                const item = list.find((it) => {
-                    return it.name === valueName;
-                });
+                return (Lang.isNull(list) || Lang.isEmpty(list));
+            } 
+            
+            const valueName = data.substring(index + 1);
+            subsectionName = data.substring(0, index);
+            list = this.getList(subsections[subsectionName]);
+            const item = list.find((it) => {
+                return it.name === valueName;
+            });
 
-                if (!Lang.isUndefined(item) && !Lang.isNull(item.value)) allNull = false;
-            }
+            return (Lang.isUndefined(item) || Lang.isNull(item.value));
         });
 
-        return allNull ? sentenceObject.dataMissingTemplate : sentenceObject.defaultTemplate;
+        return allNull ? sentenceObject.dataMissingTemplate: sentenceObject.defaultTemplate;
     }
 
     // create a map of subsection name to its metadata 

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -556,8 +556,8 @@ class SummaryMetadata {
             const assignedGroup = this.assignItemToGroup(items, prog.clinicallyRelevantTime, groupStartIndex);
 
             let classes = 'progression-item';
-            // Do not include progression on timeline if asOfDate is null
-            if (prog.asOfDate == null) return;
+            // Do not include progression on timeline if status not set
+            if (!prog.status) return;
             let startDate = new moment(prog.asOfDate, "D MMM YYYY");
             let hoverText = `${startDate.format('MM/DD/YYYY')}`;
             let endDate = startDate.clone().add(1, 'day');

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -11,17 +11,28 @@ class SummaryMetadata {
                     {
                         name: "Summary",
                         type: "NameValuePairs",
-                        narrative: 
     /*eslint no-template-curly-in-string: "off"*/
-                        "Patient has ${Current Diagnosis.Name} stage ${Current Diagnosis.Stage}. As of ${Current Diagnosis.As Of Date}, disease is ${Current Diagnosis.Progression} based on ${Current Diagnosis.Rationale}. Recent lab results include ${Recent Lab Results}.",
-                        missingNarrative: {
-                            missingData: [
-                                "Current Diagnosis.As Of Date",
-                                "Current Diagnosis.Progression",
-                                "Current Diagnosis.Rationale"
-                            ],
-                            template: "Patient has ${Current Diagnosis.Name} stage ${Current Diagnosis.Stage}.  No recent progression status.  Recent lab results include ${Recent Lab Results}."
-                        },
+                        narrative: [
+                            {
+                                defaultTemplate: "Patient has ${Current Diagnosis.Name} stage ${Current Diagnosis.Stage}"
+                            },
+                            {
+                                defaultTemplate: "As of ${Current Diagnosis.As Of Date}, disease is ${Current Diagnosis.Progression} based on ${Current Diagnosis.Rationale}",
+                                dataMissingTemplate: "No recent progression status",
+                                useDataMissingTemplateCriteria: [
+                                    "Current Diagnosis.As Of Date",
+                                    "Current Diagnosis.Progression",
+                                    "Current Diagnosis.Rationale"
+                                ]
+                            },
+                            {
+                                defaultTemplate: "Recent lab results include ${Recent Lab Results}" ,
+                                dataMissingTemplate: "No recent lab results",
+                                useDataMissingTemplateCriteria: [
+                                    "Recent Lab Results"
+                                ]                            
+                            }
+                        ],
                         data: [
                             {
                                 name: "Current Diagnosis",
@@ -197,9 +208,18 @@ class SummaryMetadata {
                     {
                         name: "Pathology Results",
                         type: "NameValuePairs",
-                        narrative: 
     /*eslint no-template-curly-in-string: "off"*/
-                        "Primary tumor color is ${.Color}, weight is ${.Weight}, and size is ${.Size}. Tumor margins are ${.Tumor Margins}. Histological grade is ${.Histological Grade}. ER-${.Receptor Status ER} PR-${.Receptor Status PR} HER2-${.Receptor Status HER2}",
+                        narrative: [
+                            {
+                                defaultTemplate: "Primary tumor color is ${.Color}, weight is ${.Weight}, and size is ${.Size}"
+                            },
+                            {
+                                defaultTemplate: "Tumor margins are ${.Tumor Margins}. Histological grade is ${.Histological Grade}"       
+                            },
+                            {
+                                defaultTemplate: "ER-${.Receptor Status ER} PR-${.Receptor Status PR} HER2-${.Receptor Status HER2}"
+                            }
+                        ],
                         data: [
                             {
                                 name: "",
@@ -269,9 +289,15 @@ class SummaryMetadata {
                     {
                         name: "Genetics",
                         type: "NameValuePairs",
-                        narrative: 
     /*eslint no-template-curly-in-string: "off"*/
-                        "Oncotype DX Recurrence Score is ${.Oncotype DX Recurrence Score}. Genetic Testing is ${.Genetic Testing}.",
+                        narrative: [
+                            {
+                                defaultTemplate: "Oncotype DX Recurrence Score is ${.Oncotype DX Recurrence Score}"
+                            },
+                            {
+                                defaultTemplate: "Genetic Testing is ${.Genetic Testing}"       
+                            }
+                        ],
                         data: [
                             {
                                 name: "",

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -14,6 +14,14 @@ class SummaryMetadata {
                         narrative: 
     /*eslint no-template-curly-in-string: "off"*/
                         "Patient has ${Current Diagnosis.Name} stage ${Current Diagnosis.Stage}. As of ${Current Diagnosis.As Of Date}, disease is ${Current Diagnosis.Progression} based on ${Current Diagnosis.Rationale}. Recent lab results include ${Recent Lab Results}.",
+                        missingNarrative: {
+                            missingData: [
+                                "Current Diagnosis.As Of Date",
+                                "Current Diagnosis.Progression",
+                                "Current Diagnosis.Rationale"
+                            ],
+                            template: "Patient has ${Current Diagnosis.Name} stage ${Current Diagnosis.Stage}.  No recent progression status.  Recent lab results include ${Recent Lab Results}."
+                        },
                         data: [
                             {
                                 name: "Current Diagnosis",

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -18,7 +18,7 @@ class SummaryMetadata {
                             },
                             {
                                 defaultTemplate: "As of ${Current Diagnosis.As Of Date}, disease is ${Current Diagnosis.Progression} based on ${Current Diagnosis.Rationale}",
-                                dataMissingTemplate: "No recent progression status",
+                                dataMissingTemplate: "No recent disease status",
                                 useDataMissingTemplateCriteria: [
                                     "Current Diagnosis.As Of Date",
                                     "Current Diagnosis.Progression",

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -18,7 +18,7 @@ class SummaryMetadata {
                             },
                             {
                                 defaultTemplate: "As of ${Current Diagnosis.As Of Date}, disease is ${Current Diagnosis.Progression} based on ${Current Diagnosis.Rationale}",
-                                dataMissingTemplate: "No recent disease status",
+                                dataMissingTemplate: "No recent ${disease status}",
                                 useDataMissingTemplateCriteria: [
                                     "Current Diagnosis.As Of Date",
                                     "Current Diagnosis.Progression",
@@ -27,7 +27,7 @@ class SummaryMetadata {
                             },
                             {
                                 defaultTemplate: "Recent lab results include ${Recent Lab Results}" ,
-                                dataMissingTemplate: "No recent lab results",
+                                dataMissingTemplate: "No recent ${lab results}",
                                 useDataMissingTemplateCriteria: [
                                     "Recent Lab Results"
                                 ]                            


### PR DESCRIPTION
- Changed narrative property in SummaryMetadata to be an array of sentence objects.
    - Each sentence object can have these properties:
             - defaultTemplate(required):  Default template to use
             - dataMissingTemplate(optional): Template to use if all data in useDataMissingTemplateCriteria is null.
             - useDataMissingTemplateCriteria(optional): Data that should be checked to determine if dataMissingTemplate should be used.

- NarrativeNameValuePairsVisualizer now parses through each sentence object and determines which template to use.
- Progression items do not show up on timeline unless status is set.

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- Cheat sheet is updated
- Demo script is updated 
- Documentation on Wiki has been updated 
- Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

-  Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- Added UI tests for slim mode 
- Added UI tests for full mode
- Added backend tests for fluxNotes code
- Added note parser examples to test new functionality


## Reviewer 1: Nicole

- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
