### PR TITLE
Implement data view buttons

### DIFF
--- a/src/summary/NarrativeNameValuePairsVisualizer.jsx
+++ b/src/summary/NarrativeNameValuePairsVisualizer.jsx
@@ -93,6 +93,9 @@ class NarrativeNameValuePairsVisualizer extends Component {
     */
     buildNarrativeSnippetList(template, subsections) {
         let result = [];
+        if (template === undefined) {
+            return result;
+        }
         const len = template.length;
         let index, start = 0;
         let pos = template.indexOf("${"), endpos;

--- a/src/summary/NarrativeNameValuePairsVisualizer.jsx
+++ b/src/summary/NarrativeNameValuePairsVisualizer.jsx
@@ -160,6 +160,9 @@ class NarrativeNameValuePairsVisualizer extends Component {
         let subsections = this.getSubsections();
 
         let narrativeTemplate = "";
+        if (conditionSection.narrative === undefined) {
+            return [];
+        }
         conditionSection.narrative.forEach((sentenceObject) => {
             const template = this.getTemplate(subsections, sentenceObject);
             narrativeTemplate = narrativeTemplate.concat(template).concat(". ");

--- a/src/summary/SummaryHeader.css
+++ b/src/summary/SummaryHeader.css
@@ -39,5 +39,6 @@ h2, h3 {
 
 .small-btn {
     min-width: 0 !important;
+    min-height: 0 !important;
     margin-left: 1px;
 }

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -175,6 +175,7 @@ class SummaryMetadata {
                     {
                         name: "Key Dates",
                         type: "NameValuePairs",
+                        defaultVisualizer: "tabular",
                         data: [
                             {
                                 name: "",
@@ -198,6 +199,7 @@ class SummaryMetadata {
                     {
                         name: "Procedures",
                         type: "NameValuePairs",
+                        defaultVisualizer: "tabular",
                         data: [
                             {
                                 name: "",
@@ -317,6 +319,7 @@ class SummaryMetadata {
                     {
                         name: "Timeline",
                         type: "Events",
+                        defaultVisualizer: "graphic",
                         data: [
                             {
                                 name: "Medications",
@@ -343,6 +346,7 @@ class SummaryMetadata {
                     {
                         name: "Current Diagnosis",
                         type: "NameValuePairs",
+                        defaultVisualizer: "tabular",
                         data: [
                             {
                                 name: "",
@@ -361,6 +365,7 @@ class SummaryMetadata {
                     {
                         name: "Key Dates",
                         type: "NameValuePairs",
+                        defaultVisualizer: "tabular",
                         data: [
                             {
                                 name: "",
@@ -378,6 +383,7 @@ class SummaryMetadata {
                     {
                         name: "Procedures",
                         type: "NameValuePairs",
+                        defaultVisualizer: "tabular",
                         data: [
                             {
                                 name: "",
@@ -388,6 +394,7 @@ class SummaryMetadata {
                     {
                         name: "Timeline",
                         type: "Events",
+                        defaultVisualizer: "graphic",
                         data: [
                             {
                                 name: "Medications",

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -175,7 +175,6 @@ class SummaryMetadata {
                     {
                         name: "Key Dates",
                         type: "NameValuePairs",
-                        defaultVisualizer: "tabular",
                         data: [
                             {
                                 name: "",
@@ -199,7 +198,6 @@ class SummaryMetadata {
                     {
                         name: "Procedures",
                         type: "NameValuePairs",
-                        defaultVisualizer: "tabular",
                         data: [
                             {
                                 name: "",
@@ -319,7 +317,6 @@ class SummaryMetadata {
                     {
                         name: "Timeline",
                         type: "Events",
-                        defaultVisualizer: "graphic",
                         data: [
                             {
                                 name: "Medications",
@@ -346,7 +343,6 @@ class SummaryMetadata {
                     {
                         name: "Current Diagnosis",
                         type: "NameValuePairs",
-                        defaultVisualizer: "tabular",
                         data: [
                             {
                                 name: "",
@@ -365,7 +361,6 @@ class SummaryMetadata {
                     {
                         name: "Key Dates",
                         type: "NameValuePairs",
-                        defaultVisualizer: "tabular",
                         data: [
                             {
                                 name: "",
@@ -383,7 +378,6 @@ class SummaryMetadata {
                     {
                         name: "Procedures",
                         type: "NameValuePairs",
-                        defaultVisualizer: "tabular",
                         data: [
                             {
                                 name: "",
@@ -394,7 +388,6 @@ class SummaryMetadata {
                     {
                         name: "Timeline",
                         type: "Events",
-                        defaultVisualizer: "graphic",
                         data: [
                             {
                                 name: "Medications",

--- a/src/summary/TargetedDataSection.css
+++ b/src/summary/TargetedDataSection.css
@@ -1,0 +1,13 @@
+#targeted-data-section h2.section-header{
+    font-weight: bold;
+    color: #333;
+}
+
+.small-btn {
+    min-width: 0 !important;
+    min-height: 0 !important;
+}
+
+.right-icons {
+    float: right;
+}

--- a/src/summary/TargetedDataSection.jsx
+++ b/src/summary/TargetedDataSection.jsx
@@ -132,20 +132,14 @@ class TargetedDataSection extends Component {
     }
 
     renderVisualizationOptions = (options) => {
-        // TODO: Does one data view option provide value?
-        // if (options.length > 1) {
-            return (
-                <span className="right-icons">
-                    {this.getVisualizationsIcons(options)}
-                </span>
-            );
-        // }
-        // return null;
+        return (
+            <span className="right-icons">
+                {this.getVisualizationsIcons(options)}
+            </span>
+        );
     }
 
-    // renderedSection checks the type of data that is being passed and chooses the correct component to render the data
-    // TODO: Render other types of data. also change how it decides which visualization component to use when
-    //       multiple (e.g., NameValuePairs)
+    // renderSection checks the type of data that is being passed and chooses the correct component to render the data
     // TODO: Add a List type and a tabular renderer for it for Procedures section. case where left column is data
     //       and not just a label
     renderSection = (section) => {

--- a/src/summary/TargetedDataSection.jsx
+++ b/src/summary/TargetedDataSection.jsx
@@ -1,0 +1,191 @@
+import React, { Component } from 'react';
+import Button from '../elements/Button';
+import TabularNameValuePairsVisualizer from './TabularNameValuePairsVisualizer';
+import NarrativeNameValuePairsVisualizer from './NarrativeNameValuePairsVisualizer';
+import TimelineEventsVisualizer from '../timeline/TimelineEventsVisualizer';
+
+class TargetedDataSection extends Component {
+    constructor(props) {
+        super(props);
+
+        // TODO: Better way to get default based on type
+        this.state = { dataViewMode: 'tabular' };
+    }
+    
+    // componentDidMount(){
+    //     console.log("UPDATE")
+    //     console.log(this.props.section)
+    //     if (this.state.dataViewMode === null) {
+    //         if (this.props.type === 'NameValuePairs') {
+    //             this.setState({ dataViewMode: 'tabular' });
+    //         } else if (this.props.type === 'Events') {
+    //             this.setState({ dataViewMode: 'graphic' });
+    //         } else {
+    //             this.setState({ dataViewMode: null });
+    //         }
+    //     }
+    // }
+
+    handleViewChange = (dataViewMode) => {
+        this.setState({ dataViewMode });
+    }
+
+    tabularView = () => {
+        const strokeColor = this.state.dataViewMode === "tabular" ? "#3F3F3F" : "#CCCCCC";
+        return (
+            <svg width="17px" height="17px" viewBox="0 0 17 17" version="1.1" xmlns="http://www.w3.org/2000/svg">
+                <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd" opacity="0.8">
+                    <g id="Group-4-Copy" transform="translate(0.884726, 0.440969)" stroke={strokeColor} strokeWidth="1.62" fill="#FFFFFF">
+                        <rect id="Rectangle-9-Copy-7" x="0.445109978" y="0.73198638" width="7.21076743" height="7.21833702"></rect>
+                        <rect id="Rectangle-9-Copy-8" x="0.445109978" y="8.26516734" width="7.21076743" height="7.21833702"></rect>
+                        <rect id="Rectangle-9-Copy-9" x="7.81454794" y="0.73198638" width="7.21076743" height="7.21833702"></rect>
+                        <rect id="Rectangle-9-Copy-10" x="7.81454794" y="8.26516734" width="7.21076743" height="7.21833702"></rect>
+                    </g>
+                </g>
+            </svg>
+        );
+    }
+
+    narrativeView = () => {
+        const strokeColor = this.state.dataViewMode === "narrative" ? "#3F3F3F" : "#CCCCCC";
+        return (
+            <svg width="17px" height="15px" viewBox="0 0 17 15" version="1.1" xmlns="http://www.w3.org/2000/svg">
+                <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd" strokeLinecap="square" opacity="0.8">
+                    <g id="Group-3-Copy" transform="translate(0.567421, 0.048197)" stroke={strokeColor} strokeWidth="2">
+                        <path d="M1.03162221,1 L7.83111001,1" id="Line-4"></path>
+                        <path d="M1.03162221,7 L15.1251513,7" id="Line-4-Copy"></path>
+                        <path d="M1.03162221,13 L15.1251513,13" id="Line-4-Copy-2"></path>
+                    </g>
+                </g>
+            </svg>
+        );
+    }
+
+    graphicView = () => {
+        // TODO: This needs to use the new graphic icon
+        const strokeColor = this.state.dataViewMode === "graphic" ? "#3F3F3F" : "#CCCCCC";
+        return (
+            <svg width="17px" height="15px" viewBox="0 0 17 15" version="1.1" xmlns="http://www.w3.org/2000/svg">
+                <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd" strokeLinecap="square" opacity="0.8">
+                    <g id="Group-3-Copy" transform="translate(0.567421, 0.048197)" stroke={strokeColor} strokeWidth="2">
+                        <path d="M1.03162221,1 L7.83111001,1" id="Line-4"></path>
+                        <path d="M1.03162221,7 L15.1251513,7" id="Line-4-Copy"></path>
+                    </g>
+                </g>
+            </svg>
+        );
+    }
+
+    renderIcon = (type, i) => {
+        let icon = null;
+        if (type === 'tabular') {
+            icon = this.tabularView();
+        } else if (type === 'narrative') {
+            icon = this.narrativeView();
+        } else if (type === 'graphic') {
+            icon = this.graphicView();
+        }
+        
+        if (icon !== null) {
+            return (
+                <Button
+                    key={i}
+                    className="small-btn"
+                    onClick={() => this.handleViewChange(type)}>
+                    {icon}
+                </Button>
+            );
+        }
+        return null;
+    }
+
+    getVisualizationsIcons = (options) => {
+        let visualizationButtons = options.map((type, i) => this.renderIcon(type, i));
+        return visualizationButtons;
+    }
+
+    getOptions = (section) => {
+        let options = [];
+        if (section.type === "NameValuePairs") {
+            options.push('tabular');
+            if (section.narrative) {
+                options.push('narrative');
+            }
+        } else if (section.type === "Events") {
+            options.push('graphic');
+            // options.push('tabular'); // TODO: In order to not add buttons that don't work, tabular Events is not supported or rendered
+        }
+        return options;
+    }
+
+    renderVisualizationOptions = (options) => {
+        // TODO: Does one data view option provide value?
+        // if (options.length > 1) {
+            return (
+                <div style={{float: "right"}}>
+                    {this.getVisualizationsIcons(options)}
+                </div>
+            );
+        // }
+        // return null;
+    }
+
+    // renderedSection checks the type of data that is being passed and chooses the correct component to render the data
+    // TODO: Render other types of data. also change how it decides which visualization component to use when
+    //       multiple (e.g., NameValuePairs)
+    // TODO: Add a List type and a tabular renderer for it for Procedures section. case where left column is data
+    //       and not just a label
+    renderSection(section) {
+        const {patient, condition, onItemClicked, allowItemClick, isWide} = this.props;
+
+        if (section.type === 'NameValuePairs' && this.state.dataViewMode === 'tabular') {
+            return (
+                <TabularNameValuePairsVisualizer
+                    patient={patient}
+                    condition={condition}
+                    conditionSection={section}
+                    onItemClicked={onItemClicked}
+                    allowItemClick={allowItemClick}
+                    isWide={isWide}
+                />
+            );
+        } else if (section.type === 'NameValuePairs' && this.state.dataViewMode === 'narrative') {
+            return (
+                <NarrativeNameValuePairsVisualizer
+                    patient={patient}
+                    condition={condition}
+                    conditionSection={section}
+                    onItemClicked={onItemClicked}
+                    allowItemClick={allowItemClick}
+                    isWide={isWide}
+                />
+            );
+        } else if (section.type === 'Events' /*&& this.state.dataViewMode === 'graphic'*/) {
+            return (
+                <TimelineEventsVisualizer
+                    patient={patient}
+                    condition={condition}
+                    section={section}
+                    isWide={isWide}
+                />
+            );
+        }
+    }
+
+    render() {
+        const visualizationOptions = this.getOptions(this.props.section);
+        return (
+            <div>
+                <h2 className="section-header">
+                    {this.props.section.name}
+                    {this.renderVisualizationOptions(visualizationOptions)}
+                </h2>
+                {this.renderSection(this.props.section)}
+            </div>
+        );
+    }
+}
+
+export default TargetedDataSection;
+
+// TODO PropTypes

--- a/src/summary/TargetedDataSection.jsx
+++ b/src/summary/TargetedDataSection.jsx
@@ -104,6 +104,7 @@ class TargetedDataSection extends Component {
                 <Button
                     key={i}
                     className="small-btn"
+                    id={type}
                     onClick={() => this.handleViewChange(type)}>
                     {icon}
                 </Button>

--- a/src/summary/TargetedDataSection.jsx
+++ b/src/summary/TargetedDataSection.jsx
@@ -10,9 +10,10 @@ class TargetedDataSection extends Component {
     constructor(props) {
         super(props);
 
-        const defaultOrTabular = props.defaultVisualizer ? props.defaultVisualizer : 'tabular';
+        const optionsForSection = this.getOptions(props.section);
+        const defaultOrTabular = optionsForSection.length > 0 ? optionsForSection[0] : 'tabular';
 
-        // this.state.defaultVisualizer comes from the summary metadata, this.state.chosenVisualizer changes when icons are clicked
+        // this.state.defaultVisualizer is the first possible visualization, this.state.chosenVisualizer changes when icons are clicked
         this.state = {
             defaultVisualizer: defaultOrTabular,
             chosenVisualizer: null
@@ -20,8 +21,8 @@ class TargetedDataSection extends Component {
     }
     
     componentDidUpdate() {
-        // If no default is set in summary metadata, the default will be tabular
-        const defaultOrTabular = this.props.defaultVisualizer ? this.props.defaultVisualizer : 'tabular';
+        const optionsForSection = this.getOptions(this.props.section);
+        const defaultOrTabular = optionsForSection.length > 0 ? optionsForSection[0] : 'tabular';
         if (this.state.defaultVisualizer !== defaultOrTabular) {
             this.setState({defaultVisualizer: defaultOrTabular });
         }

--- a/src/summary/TargetedDataSection.jsx
+++ b/src/summary/TargetedDataSection.jsx
@@ -23,8 +23,9 @@ class TargetedDataSection extends Component {
     componentDidUpdate() {
         const optionsForSection = this.getOptions(this.props.section);
         const defaultOrTabular = optionsForSection.length > 0 ? optionsForSection[0] : 'tabular';
-        if (this.state.defaultVisualizer !== defaultOrTabular) {
-            this.setState({defaultVisualizer: defaultOrTabular });
+        if (this.state.defaultVisualizer !== defaultOrTabular ||
+            (this.state.chosenVisualizer !== null && !optionsForSection.includes(this.state.chosenVisualizer))) {
+            this.setState({defaultVisualizer: defaultOrTabular, chosenVisualizer: null });
         }
     }
 

--- a/src/summary/TargetedDataSection.jsx
+++ b/src/summary/TargetedDataSection.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Button from '../elements/Button';
 import TabularNameValuePairsVisualizer from './TabularNameValuePairsVisualizer';
 import NarrativeNameValuePairsVisualizer from './NarrativeNameValuePairsVisualizer';
@@ -62,14 +63,13 @@ class TargetedDataSection extends Component {
     }
 
     graphicView = () => {
-        // TODO: This needs to use the new graphic icon
         const strokeColor = this.state.dataViewMode === "graphic" ? "#3F3F3F" : "#CCCCCC";
         return (
-            <svg width="17px" height="15px" viewBox="0 0 17 15" version="1.1" xmlns="http://www.w3.org/2000/svg">
-                <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd" strokeLinecap="square" opacity="0.8">
-                    <g id="Group-3-Copy" transform="translate(0.567421, 0.048197)" stroke={strokeColor} strokeWidth="2">
-                        <path d="M1.03162221,1 L7.83111001,1" id="Line-4"></path>
-                        <path d="M1.03162221,7 L15.1251513,7" id="Line-4-Copy"></path>
+            <svg width="17px" height="17px" viewBox="0 0 17 17" version="1.1" xmlns="http://www.w3.org/2000/svg">
+                <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
+                    <g id="Group-39" stroke={strokeColor} strokeWidth="1.62">
+                        <path d="M0.936953125,0.9428125 L0.936953125,15.8228125 L15.8169531,15.8228125 L15.8169531,0.9428125 L0.936953125,0.9428125 Z" id="Rectangle-3"></path>
+                        <polyline id="Path-3" strokeLinejoin="round" points="0.71875 11.0977783 5.125 6.69152832 9.5 11.2852783 12.34375 7.97277832 15.625 11.3477783"></polyline>
                     </g>
                 </g>
             </svg>
@@ -188,4 +188,12 @@ class TargetedDataSection extends Component {
 
 export default TargetedDataSection;
 
-// TODO PropTypes
+TargetedDataSection.propTypes = {
+    type: PropTypes.string,
+    section: PropTypes.object,
+    patient: PropTypes.object,
+    condition: PropTypes.object,
+    onItemClicked: PropTypes.func,
+    allowItemClick: PropTypes.bool,
+    isWide: PropTypes.bool.isRequired,
+}

--- a/src/summary/TargetedDataSubpanel.css
+++ b/src/summary/TargetedDataSubpanel.css
@@ -42,5 +42,9 @@ tr.existing-note-entry td:last-child {
     color: #333;
 }
 
+.icons {
+    float: right;
+    padding: 10px;
+}
 
 

--- a/src/summary/TargetedDataSubpanel.jsx
+++ b/src/summary/TargetedDataSubpanel.jsx
@@ -1,5 +1,8 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
+import Divider from 'material-ui/Divider';
+import Button from '../elements/Button';
+import TargetedDataSection from './TargetedDataSection';
 import TabularNameValuePairsVisualizer from './TabularNameValuePairsVisualizer';
 import NarrativeNameValuePairsVisualizer from './NarrativeNameValuePairsVisualizer';
 import TimelineEventsVisualizer from '../timeline/TimelineEventsVisualizer';
@@ -25,59 +28,27 @@ class TargetedDataSubpanel extends Component {
         return conditionMetadata;
     }
 
-    // renderedSection checks the type of data that is being passed and chooses the correct component to render the data
-    // TODO: Render other types of data. also change how it decides which visualization component to use when
-    //       multiple (e.g., NameValuePairs)
-    // TODO: Add a List type and a tabular renderer for it for Procedures section. case where left column is data
-    //       and not just a label
-    renderSection(section) {
-        const {patient, condition, onItemClicked, allowItemClick, isWide} = this.props;
-
-        if (section.type === 'NameValuePairs' && !section.narrative) {
-            return (
-                <TabularNameValuePairsVisualizer
-                    patient={patient}
-                    condition={condition}
-                    conditionSection={section}
-                    onItemClicked={onItemClicked}
-                    allowItemClick={allowItemClick}
-                    isWide={isWide}
-                />
-            );
-        } else if (section.type === 'NameValuePairs' && section.narrative) {
-            return (
-                <NarrativeNameValuePairsVisualizer
-                    patient={patient}
-                    condition={condition}
-                    conditionSection={section}
-                    onItemClicked={onItemClicked}
-                    allowItemClick={allowItemClick}
-                    isWide={isWide}
-                />
-            );
-        } else if (section.type === 'Events') {
-            return (
-                <TimelineEventsVisualizer
-                    patient={patient}
-                    condition={condition}
-                    section={section}
-                    isWide={isWide}
-                />
-            );
-        }
-    }
-
     renderSections() {
         const conditionMetadata = this.getConditionMetadata();
         if (conditionMetadata == null) {
             return null;
         }
+        const {patient, condition, onItemClicked, allowItemClick, isWide} = this.props;
 
         return conditionMetadata.sections.map((section, i) => {
             return (
                 <div key={i} data-test-summary-section={section.name}>
-                    <h2 className="section-header">{section.name}</h2>
-                    {this.renderSection(section)}
+                    <TargetedDataSection
+                        type={section.type}
+                        section={section}
+                        patient={patient}
+                        condition={condition}
+                        onItemClicked={onItemClicked}
+                        allowItemClick={allowItemClick}
+                        isWide={isWide}
+                        defaultView={section.defaultView}
+                    />
+                    { i < conditionMetadata.sections.length - 1 ? <Divider className="divider"/> : null }
                 </div>
             );
         });

--- a/src/summary/TargetedDataSubpanel.jsx
+++ b/src/summary/TargetedDataSubpanel.jsx
@@ -1,11 +1,7 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import Divider from 'material-ui/Divider';
-import Button from '../elements/Button';
 import TargetedDataSection from './TargetedDataSection';
-import TabularNameValuePairsVisualizer from './TabularNameValuePairsVisualizer';
-import NarrativeNameValuePairsVisualizer from './NarrativeNameValuePairsVisualizer';
-import TimelineEventsVisualizer from '../timeline/TimelineEventsVisualizer';
 import 'font-awesome/css/font-awesome.min.css';
 import './TargetedDataSubpanel.css';
 
@@ -46,7 +42,6 @@ class TargetedDataSubpanel extends Component {
                         onItemClicked={onItemClicked}
                         allowItemClick={allowItemClick}
                         isWide={isWide}
-                        defaultView={section.defaultView}
                     />
                     { i < conditionMetadata.sections.length - 1 ? <Divider className="divider"/> : null }
                 </div>

--- a/src/summary/TargetedDataSubpanel.jsx
+++ b/src/summary/TargetedDataSubpanel.jsx
@@ -36,6 +36,7 @@ class TargetedDataSubpanel extends Component {
                 <div key={i} data-test-summary-section={section.name}>
                     <TargetedDataSection
                         type={section.type}
+                        defaultVisualizer={section.defaultVisualizer}
                         section={section}
                         patient={patient}
                         condition={condition}

--- a/test/backend/views/FullApp.test.js
+++ b/test/backend/views/FullApp.test.js
@@ -5,8 +5,10 @@ import { expect } from 'chai'
 
 import FullApp from '../../../src/apps/FullApp';
 import SummaryHeader from '../../../src/summary/SummaryHeader';
-// import TargetedDataControl from '../../../src/summary/TargetedDataControl';
+import TargetedDataSection from '../../../src/summary/TargetedDataSection';
 import Button from '../../../src/elements/Button';
+import SummaryMetadata from '../../../src/summary/SummaryMetadata';
+import TabularNameValuePairsVisualizer from '../../../src/summary/NarrativeNameValuePairsVisualizer';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -51,18 +53,25 @@ describe('SummaryHeader', function() {
           .to.eq('left');
     });
 });
-// describe('TargetedDataControl', function() {
-//     it('noteDisplayMode buttons update state', function() {
-//         const wrapper = shallow(<TargetedDataControl />);
-//
-//         // Initial state
-//         expect(wrapper.state('noteDisplayMode'))
-//             .to.eq('narrative');
-//
-//         // Clicking the non-default note display button changes the state
-//         const leftView = wrapper.find(Button).find('#tabular-button');
-//         leftView.simulate('click');
-//         expect(wrapper.state('noteDisplayMode'))
-//           .to.eq('tabular');
-//     });
-// });
+
+describe('TargetedDataControl', function() {
+    it('noteDisplayMode buttons update state', function() {
+        const summaryMetadata = new SummaryMetadata();
+        const section = summaryMetadata.hardCodedMetadata["http://snomed.info/sct/408643008"].sections[0];
+        const defaultOrTabular = section.defaultVisualizer ? section.defaultVisualizer : 'tabular';
+        
+        const wrapper = shallow(<TargetedDataSection section={section} type={section.type} />);
+
+        // Initial state
+        expect(wrapper.state('defaultVisualizer'))
+            .to.eq(defaultOrTabular);
+        expect(wrapper.state('chosenVisualizer'))
+            .to.be.null;
+
+        // Clicking the non-default note display button changes the state
+        const narrativeIcon = wrapper.find('.right-icons').find(Button).find('#narrative');
+        narrativeIcon.simulate('click');
+        expect(wrapper.state('chosenVisualizer'))
+            .to.eq('narrative');
+    });
+});

--- a/test/backend/views/FullApp.test.js
+++ b/test/backend/views/FullApp.test.js
@@ -58,7 +58,16 @@ describe('TargetedDataControl', function() {
     it('noteDisplayMode buttons update state', function() {
         const summaryMetadata = new SummaryMetadata();
         const section = summaryMetadata.hardCodedMetadata["http://snomed.info/sct/408643008"].sections[0];
-        const defaultOrTabular = section.defaultVisualizer ? section.defaultVisualizer : 'tabular';
+        let options = [];
+        if (section.type === "NameValuePairs") {
+            options.push('tabular');
+            if (section.narrative) {
+                options.push('narrative');
+            }
+        } else if (section.type === "Events") {
+            options.push('graphic');
+        }
+        const defaultOrTabular = options.length > 0 ? options[0] : 'tabular';
         
         const wrapper = shallow(<TargetedDataSection section={section} type={section.type} />);
 

--- a/test/ui/FullApp.js
+++ b/test/ui/FullApp.js
@@ -314,7 +314,7 @@ test('Clicking to insert a captured data element results in that text pasted int
     }
 });
 
-test.only('Clicking the data visualization buttons changes the visualizer used', async t => {
+test('Clicking the data visualization buttons changes the visualizer used', async t => {
     const sections = Selector('#targeted-data-section')
     const sectionData = Selector('div#targeted-data-section');
     const numSections = await sections.count;
@@ -329,10 +329,19 @@ test.only('Clicking the data visualization buttons changes the visualizer used',
             // console.log(await sectionData.nth(i).classNames)
             if (iconType === 'tabular') {
                 // Check that class name of section = tabular-subsections
+               await t
+                    .expect(sections.nth(i).find('.tabular-subsections').exists)
+                    .ok();
             } else if (iconType === 'narrative'){
                 // check classname = 'narrative-subsections'
+                await t
+                    .expect(sections.nth(i).find('.narrative-subsections').exists)
+                    .ok();
             } else if (iconType === 'graphic') {
-                //check classname = 'timeline'
+                //check id = 'timeline'
+                await t
+                    .expect(sections.nth(i).find('#timeline').exists)
+                    .ok();
             }
         }
     }

--- a/test/ui/FullApp.js
+++ b/test/ui/FullApp.js
@@ -314,6 +314,30 @@ test('Clicking to insert a captured data element results in that text pasted int
     }
 });
 
+test.only('Clicking the data visualization buttons changes the visualizer used', async t => {
+    const sections = Selector('#targeted-data-section')
+    const sectionData = Selector('div#targeted-data-section');
+    const numSections = await sections.count;
+    for (let i = 0; i < numSections; i++) {
+        let icons = sections.nth(i).find('.right-icons button');
+        let numIcons = await icons.count;
+        for (let j = 0; j < numIcons; j++) {
+            const iconType = await icons.nth(j).id;
+            await t
+                .click(icons.nth(j));
+            // TODO: Try to get the class name off of the non-header part of the targeted-data-section
+            // console.log(await sectionData.nth(i).classNames)
+            if (iconType === 'tabular') {
+                // Check that class name of section = tabular-subsections
+            } else if (iconType === 'narrative'){
+                // check classname = 'narrative-subsections'
+            } else if (iconType === 'graphic') {
+                //check classname = 'timeline'
+            }
+        }
+    }
+});
+
 fixture('Patient Mode - Timeline')
     .page(startPage);
 

--- a/test/ui/FullApp.js
+++ b/test/ui/FullApp.js
@@ -325,20 +325,18 @@ test('Clicking the data visualization buttons changes the visualizer used', asyn
             const iconType = await icons.nth(j).id;
             await t
                 .click(icons.nth(j));
-            // TODO: Try to get the class name off of the non-header part of the targeted-data-section
-            // console.log(await sectionData.nth(i).classNames)
             if (iconType === 'tabular') {
                 // Check that class name of section = tabular-subsections
                await t
                     .expect(sections.nth(i).find('.tabular-subsections').exists)
                     .ok();
             } else if (iconType === 'narrative'){
-                // check classname = 'narrative-subsections'
+                // Check class name = 'narrative-subsections'
                 await t
                     .expect(sections.nth(i).find('.narrative-subsections').exists)
                     .ok();
             } else if (iconType === 'graphic') {
-                //check id = 'timeline'
+                // Check id = 'timeline'
                 await t
                     .expect(sections.nth(i).find('#timeline').exists)
                     .ok();


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

This moves the visualization options for the Targeted Data Subpanel onto each individual section and gives the icons functionality. 

Right now, the default option is specified on SummaryMetadata, although this can be moved. I left it there for now because I thought maybe individual sections would prefer a default of one visualization or another, rather than all sections of a certain type having the same default. This can be changed though if it's not the desired approach. Also, I have it so that even sections with only one visualization option give an icon showing what option is displayed. I thought that it provided a little more context at what visualization was provided, but I'm open to change this if others feel differently.

This also fixes the backend test to check that the state updates when the icons are clicked. I added a UI test to check the right visualization is actually rendered (with lots of help from lots of people! Thanks!).

## Submitter:

**Running the Application**

- [X] Manually tested in Chrome
- [X] Manually tested in IE

**Documentation**

- [X] This pull request describes why these changes were made
- [X] Recognizes any potential shortcomings/bugs in the description 
- [] **N/A** Cheat sheet is updated
- [] **N/A** Demo script is updated 
- [] **N/A** Documentation on Wiki has been updated 
- [] **N/A** Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [] **N/A** Note parser has been updated if structured phrases change

**Code Quality**

- [X] 4-space indents - convert any tabs to spaces
- [X] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [X] Code is commented

**Tests**

- [X] Existing tests passed
- [] **N/A** Added UI tests for slim mode 
- [X] Added UI tests for full mode
- [X] Added backend tests for fluxNotes code
- [] **N/A** Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
