### PR TITLE
Update style data buttons

### DIFF
--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -17,11 +17,11 @@ class SummaryMetadata {
                                 defaultTemplate: "Patient has ${Current Diagnosis.Name} stage ${Current Diagnosis.Stage}"
                             },
                             {
-                                defaultTemplate: "As of ${Current Diagnosis.As Of Date}, disease is ${Current Diagnosis.Progression} based on ${Current Diagnosis.Rationale}",
+                                defaultTemplate: "As of ${Current Diagnosis.As Of Date}, disease is ${Current Diagnosis.Disease Status} based on ${Current Diagnosis.Rationale}",
                                 dataMissingTemplate: "No recent ${disease status}",
                                 useDataMissingTemplateCriteria: [
                                     "Current Diagnosis.As Of Date",
-                                    "Current Diagnosis.Progression",
+                                    "Current Diagnosis.Disease Status",
                                     "Current Diagnosis.Rationale"
                                 ]
                             },
@@ -57,7 +57,7 @@ class SummaryMetadata {
                                         shortcut: "@stage"
                                     },
                                     {
-                                        name: "Progression",
+                                        name: "Disease Status",
                                         value: (patient, currentConditionEntry) => {
                                             let p = patient.getMostRecentProgressionForCondition(currentConditionEntry, moment().subtract(6, 'months'));
                                             if (Lang.isNull(p) || !p.status) {

--- a/src/summary/TargetedDataSection.css
+++ b/src/summary/TargetedDataSection.css
@@ -10,4 +10,5 @@
 
 .right-icons {
     float: right;
+    padding-right: 10px;
 }

--- a/src/summary/TargetedDataSection.jsx
+++ b/src/summary/TargetedDataSection.jsx
@@ -134,11 +134,15 @@ class TargetedDataSection extends Component {
     }
 
     renderVisualizationOptions = (options) => {
-        return (
-            <span className="right-icons">
-                {this.getVisualizationsIcons(options)}
-            </span>
-        );
+        if (options.length > 1) {
+            return (
+                <span className="right-icons">
+                    {this.getVisualizationsIcons(options)}
+                </span>
+            );
+        } else {
+            return null;
+        }
     }
 
     // renderSection checks the type of data that is being passed and chooses the correct component to render the data


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

This is a small pull request. It removes the icon for data visualization options if there is only one option and adds a padding to the icons. It also changes the names on the tabular visualization from "Progression" to "Disease Status".

## Submitter:

**Running the Application**

- [ ] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [ ] This pull request describes why these changes were made
- [ ] Recognizes any potential shortcomings/bugs in the description 
- [ ] Cheat sheet is updated
- [ ] Demo script is updated 
- [ ] Documentation on Wiki has been updated 
- [ ] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [ ] Note parser has been updated if structured phrases change

**Code Quality**

- [ ] 4-space indents - convert any tabs to spaces
- [ ] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [ ] Code is commented

**Tests**

- [ ] Existing tests passed
- [ ] Added UI tests for slim mode 
- [ ] Added UI tests for full mode
- [ ] Added backend tests for fluxNotes code
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
