### PR TITLE
List visualizer

### DIFF
--- a/src/apps/FullApp.jsx
+++ b/src/apps/FullApp.jsx
@@ -122,9 +122,12 @@ class FullApp extends Component {
     }
 
     // Update the summaryitemtoinsert based on the item given
-    handleSummaryItemSelected = (item) =>{
+    handleSummaryItemSelected = (item, arrayIndex = -1) =>{
         if (item) {
-            if (item.shortcut) {
+            // calls to this method from the buttons on a ListType pass in 'item' as an array.
+            if(Lang.isArray(item) && arrayIndex >= 0){
+                this.setState({SummaryItemToInsert: item[arrayIndex]});
+            } else if (item.shortcut) {
                 this.setState({SummaryItemToInsert: `${item.shortcut}[[${item.value}]]`});
             } else if (item.value) {
                 this.setState({SummaryItemToInsert: item.value});

--- a/src/summary/NarrativeListVisualizer.css
+++ b/src/summary/NarrativeListVisualizer.css
@@ -1,0 +1,66 @@
+.tabular-subsections { 
+    margin-bottom: 20px;
+}
+
+table {
+    border-collapse: collapse;
+    width: 98%;
+    margin-top: 10px;
+}
+
+table, tr, td {
+    font-size: 0.8rem;
+
+}
+
+.subsection-header {
+    color: #333 !important;
+}
+
+/* Include the bottom border on the last row of the table */
+tr:last-child td {
+    border-bottom: 1px solid #ccc;
+}
+
+tr:last-child td:last-child {
+    border-bottom: 0;
+}
+
+/* Most table elements only have a top border */
+td {
+    border-top: 1px solid #ccc;
+    padding: 8px 10px;
+}
+
+td:first-child {
+    color: #999;
+}
+
+/* Omit the borders from the icon column in the table */
+td:last-child {
+    border-top: 0;
+    border-bottom: 0;
+    color: #fefefe;
+}
+
+tr.captured td.disabled:last-child {
+    color: #DDD;
+}
+tr.captured td:last-child {
+    color: #888;
+}
+
+td.missing {
+    color: #fff;
+    background-color: #fa9f8f;
+}
+
+td.captured {
+    color: #333;
+    background-color: #d9ebf9;
+}
+
+span.button-hover {
+    cursor: pointer;
+}
+

--- a/src/summary/NarrativeListVisualizer.jsx
+++ b/src/summary/NarrativeListVisualizer.jsx
@@ -1,0 +1,186 @@
+import React, {Component} from 'react';
+import {Row, Col} from 'react-flexbox-grid';
+import PropTypes from 'prop-types';
+import Lang from 'lodash';
+import './NarrativeListVisualizer.css';
+
+/*
+ A table view of one or more data summary items. Items could be pathology-related,
+ diagnosis-related, genetics-related, etc.
+ */
+class NarrativeListVisualizer extends Component {
+//  this all will have to change to accomodate lists.
+    getSubsections() {
+        const {patient, condition, conditionSection} = this.props;
+
+        if (patient == null || condition == null || conditionSection == null) {
+            return [];
+        }
+
+        let subsections = [];
+        conditionSection.data.forEach((subsection) => {
+            subsections.push(subsection);
+        });
+
+        return subsections;
+    }
+
+    getList(subsection) {
+        const {patient, condition, conditionSection} = this.props;
+        if (patient == null || condition == null || conditionSection == null) {
+            return [];
+        }
+
+        const items = subsection.items;
+        const itemsFunction = subsection.itemsFunction;
+
+        let list = null;
+
+        if (Lang.isUndefined(items)) {
+            list = itemsFunction(patient, condition);
+        } else {
+            list = items.map((item, i) => {
+                if (Lang.isNull(item.value)) {
+                    return {name: item.name, value: null};
+                } else {
+                    return {name: item.name, value: item.value(patient, condition), shortcut: item.shortcut};
+                }
+            });
+        }
+
+        return list;
+    }
+
+    renderedSubsections(subsections) {
+        const isSingleColumn = !this.props.isWide;
+
+        if (isSingleColumn) {
+            return subsections.map((subsection, index) => {
+                return this.renderedSubsection(subsection, index);
+            });
+        }
+
+        // Grab the sections from subsections and create 2 arrays, one for the first half of the sections and another
+        // for the second half of sections
+        const numberOfFirstHalfSections = Math.ceil(subsections.length / 2);
+        let firstHalfSections = [];
+        let secondHalfSections = [];
+
+        // Create array containing the first half of the subsections
+        subsections.slice(0, numberOfFirstHalfSections).forEach((subsection) => {
+            firstHalfSections.push(subsection);
+        });
+
+        // Create array containing the second half of the subsections
+        subsections.slice(numberOfFirstHalfSections).forEach((subsection) => {
+            secondHalfSections.push(subsection);
+        });
+
+        let ind = 0;
+        const renderedFirstHalf = firstHalfSections.map((subsection) => {
+            return this.renderedSubsection(subsection, ind++);
+        });
+        const renderedSecondHalf = secondHalfSections.map((subsection) => {
+            return this.renderedSubsection(subsection, ind++);
+        });
+
+        // Display the data in 2 columns. The first column displays the first half
+        // of the sections in one table and the second column displays the second half of the sections in a second table
+        return (
+            <Row start="xs">
+                <Col sm={6}>
+                    {renderedFirstHalf}
+                </Col>
+                <Col sm={6}>
+                    {renderedSecondHalf}
+                </Col>
+            </Row>
+        );
+    }
+
+    renderedSubsection(subsection, index) {
+        const list = this.getList(subsection);
+
+        if (list.length <= 0) {
+            return <h2 key={index}>None</h2>;
+        }
+
+        return (
+            <table key={index}>
+                <tbody>
+                    <tr>
+                        <td className="subsection-header">
+                            {subsection.name}
+                        </td>
+                    </tr>
+                    {this.renderedListItems(list)}
+                </tbody>
+            </table>
+        );
+    }
+
+    renderedListItem(item, index, rowClass, itemClass, itemText, onClick, hoverClass) {
+        if (this.props.allowItemClick) {
+            return (
+                <tr key={index} className={rowClass}>
+                    <td width="40%">{item.name}</td>
+                    <td width="55%" className={itemClass} data-test-summary-item={item.name}>{itemText}</td>
+                    <td width="5%" onClick={onClick}>
+                        <span className={hoverClass}><i className="fa fa-plus-square fa-lg"></i></span>
+                    </td>
+                </tr>
+            );
+        }
+
+        return (
+            <tr key={index} className={rowClass}>
+                <td width="40%">{item.name}</td>
+                <td width="55%" className={itemClass}>{itemText}</td>
+                <td className="disabled" width="5%"><span><i className="fa fa-plus-square fa-lg"></i></span></td>
+            </tr>
+        );
+    }
+    
+    renderedListItems(list) {
+        let onClick, hoverClass, rowClass, itemClass, itemText = "";
+
+        return list.map((item, index) => {
+            if (!Lang.isEmpty(item.value)) {
+                rowClass = "captured";
+                itemClass = "captured";
+                itemText = item.value;
+                onClick = (e) => this.props.onItemClicked(item);
+                hoverClass = "button-hover";
+            } else {
+                itemClass = "missing";
+                itemText = `Missing ${item.name}`;
+                onClick = null;
+                hoverClass = null;
+            }
+
+            return this.renderedListItem(item, index, rowClass, itemClass, itemText, onClick, hoverClass);
+        });
+    }
+
+    // Gets called for each section in SummaryMetaData.jsx
+    render() {
+        const subsections = this.getSubsections();
+
+        return (
+            <div className="tabular-subsections">
+                {this.renderedSubsections(subsections)}
+            </div>
+        );
+    }
+}
+
+NarrativeListVisualizer.propTypes = {
+    patient: PropTypes.object,
+    condition: PropTypes.object,
+    conditionSection: PropTypes.object,
+    isWide: PropTypes.bool,
+    onItemClicked: PropTypes.func,
+    allowItemClick: PropTypes.bool
+};
+
+export default NarrativeListVisualizer;

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -197,7 +197,7 @@ class SummaryMetadata {
                     },
                     {
                         name: "Procedures",
-                        type: "NameValuePairs",
+                        type: "ListType",
                         data: [
                             {
                                 name: "",
@@ -377,7 +377,7 @@ class SummaryMetadata {
                     },
                     {
                         name: "Procedures",
-                        type: "NameValuePairs",
+                        type: "ListType",
                         data: [
                             {
                                 name: "",
@@ -420,9 +420,17 @@ class SummaryMetadata {
         const procedures = patient.getProceduresForConditionChronologicalOrder(currentConditionEntry);
         return procedures.map((p, i) => {
             if (typeof p.occurrenceTime !== 'string') {
-                return {name: p.specificType.value.coding[0].displayText.value, value: p.occurrenceTime.timePeriodStart + " to " + p.occurrenceTime.timePeriodEnd};
+                // old key-value in { }
+           //     return {name: p.specificType.value.coding[0].displayText.value, value: p.occurrenceTime.timePeriodStart + " to " + p.occurrenceTime.timePeriodEnd};
+        //   console.log("occurrenceTime is not a string: ");
+        //   console.log([ p.specificType.value.coding[0].displayText.value, p.occurrenceTime.timePeriodStart + " to " + p.occurrenceTime.timePeriodEnd  ]);
+                return [ p.specificType.value.coding[0].displayText.value, p.occurrenceTime.timePeriodStart + " to " + p.occurrenceTime.timePeriodEnd  ];
             } else {
-                return {name: p.specificType.value.coding[0].displayText.value, value: p.occurrenceTime };
+                // old key-value in { }
+           //     return {name: p.specificType.value.coding[0].displayText.value, value: p.occurrenceTime };
+       //    console.log("occurrenceTime is a string: ");
+       //    console.log([ p.specificType.value.coding[0].displayText.value, p.occurrenceTime ]);
+                return [ p.specificType.value.coding[0].displayText.value, p.occurrenceTime ]; //just switch to a json list, and to ListType above. What breaks? TNVPV ?
             }
 
 

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -420,17 +420,9 @@ class SummaryMetadata {
         const procedures = patient.getProceduresForConditionChronologicalOrder(currentConditionEntry);
         return procedures.map((p, i) => {
             if (typeof p.occurrenceTime !== 'string') {
-                // old key-value in { }
-           //     return {name: p.specificType.value.coding[0].displayText.value, value: p.occurrenceTime.timePeriodStart + " to " + p.occurrenceTime.timePeriodEnd};
-        //   console.log("occurrenceTime is not a string: ");
-        //   console.log([ p.specificType.value.coding[0].displayText.value, p.occurrenceTime.timePeriodStart + " to " + p.occurrenceTime.timePeriodEnd  ]);
-                return [ p.specificType.value.coding[0].displayText.value, p.occurrenceTime.timePeriodStart + " to " + p.occurrenceTime.timePeriodEnd  ];
+                return [ p.specificType.value.coding[0].displayText.value, p.occurrenceTime.timePeriodStart + " to " + p.occurrenceTime.timePeriodEnd ];
             } else {
-                // old key-value in { }
-           //     return {name: p.specificType.value.coding[0].displayText.value, value: p.occurrenceTime };
-       //    console.log("occurrenceTime is a string: ");
-       //    console.log([ p.specificType.value.coding[0].displayText.value, p.occurrenceTime ]);
-                return [ p.specificType.value.coding[0].displayText.value, p.occurrenceTime ]; //just switch to a json list, and to ListType above. What breaks? TNVPV ?
+                return [ p.specificType.value.coding[0].displayText.value, p.occurrenceTime]; 
             }
 
 

--- a/src/summary/TabularListVisualizer.css
+++ b/src/summary/TabularListVisualizer.css
@@ -6,6 +6,7 @@ table {
     border-collapse: collapse;
     width: 98%;
     margin-top: 10px;
+    /*table-layout: fixed;*/
 }
 
 table, tr, td {
@@ -30,6 +31,7 @@ tr:last-child td:last-child {
 td {
     border-top: 1px solid #ccc;
     padding: 8px 10px;
+    /*word-wrap: break-word;*/
 }
 
 td:first-child {
@@ -49,6 +51,9 @@ tr.captured td.disabled:last-child {
 tr.captured td:last-child {
     color: #888;
 }
+/*tr.captured { makes other tables lose alignment across rows
+    display:block;
+}*/
 
 td.missing {
     color: #fff;
@@ -58,12 +63,13 @@ td.missing {
 td.captured {
     color: #333;
     background-color: #d9ebf9;
+    
 }
 
 span.button-hover {
     cursor: pointer;
 }
-span.data {
+/*span.data {
     display:inline-block;
-}
+}*/
 

--- a/src/summary/TabularListVisualizer.css
+++ b/src/summary/TabularListVisualizer.css
@@ -1,0 +1,69 @@
+.tabular-subsections { 
+    margin-bottom: 20px;
+}
+
+table {
+    border-collapse: collapse;
+    width: 98%;
+    margin-top: 10px;
+}
+
+table, tr, td {
+    font-size: 0.8rem;
+
+}
+
+.subsection-header {
+    color: #333 !important;
+}
+
+/* Include the bottom border on the last row of the table */
+tr:last-child td {
+    border-bottom: 1px solid #ccc;
+}
+
+tr:last-child td:last-child {
+    border-bottom: 0;
+}
+
+/* Most table elements only have a top border */
+td {
+    border-top: 1px solid #ccc;
+    padding: 8px 10px;
+}
+
+td:first-child {
+    color: #999;
+}
+
+/* Omit the borders from the icon column in the table */
+td:last-child {
+    border-top: 0;
+    border-bottom: 0;
+    color: #fefefe;
+}
+
+tr.captured td.disabled:last-child {
+    color: #DDD;
+}
+tr.captured td:last-child {
+    color: #888;
+}
+
+td.missing {
+    color: #fff;
+    background-color: #fa9f8f;
+}
+
+td.captured {
+    color: #333;
+    background-color: #d9ebf9;
+}
+
+span.button-hover {
+    cursor: pointer;
+}
+span.data {
+    display:inline-block;
+}
+

--- a/src/summary/TabularListVisualizer.jsx
+++ b/src/summary/TabularListVisualizer.jsx
@@ -127,59 +127,78 @@ class TabularListVisualizer extends Component {
             </table>
         );
     }
- // not the same hieght within a row, why?
-    renderedListItem(item, index, rowClass, itemClass, itemText, onClick, hoverClass) {
-        if (this.props.allowItemClick) {
-            // Allows for 5% for each + button, and the remainder divided among the columns. There are item.length columns.
+
+    renderedListItem(item, index, rowClass, itemClass, onClick, hoverClass) {
+        
+            // Allows for 5% for each plus button, and the remainder divided among the columns. There are item.length columns.
             let columnPercentage = (100 - 5*item.length) / item.length;
-            let renderedColumns = item.map((element, arrayIndex) => {
+            var renderedColumns = [];
+            item.forEach((element, arrayIndex) => {
+                var plusButtonForColumnItem = null;
                 if(Lang.isEqual(arrayIndex, 0)){
                     // white background on the first column
-                    return (   
-                        <span className="data">   
-                            <td width={columnPercentage + "%"}>{element}</td>
-                            <td width="5%" onClick={onClick}>
+                    const columnItem = (
+                        <td width={columnPercentage + "%"} key={index + "-item-" + arrayIndex}>{element}</td>
+                    );
+                    if (this.props.allowItemClick) {
+                        plusButtonForColumnItem = (
+                            <td width="5%" onClick={onClick} key={index + "-plus-" + arrayIndex}>
                                 <span className={hoverClass}><i className="fa fa-plus-square fa-lg"></i></span>
                             </td>
-                        </span>
-                   );
+                        );
+                    } else{
+                        plusButtonForColumnItem = (
+                            <td className="disabled" width="5%"><span><i className="fa fa-plus-square fa-lg"></i></span></td>
+                        );
+                    }
+                    renderedColumns.push(columnItem);
+                    renderedColumns.push(plusButtonForColumnItem);
                 } else {
                     // red or blue background on the other columns
-                    return (
-                        <span className="data">
-                            <td width={columnPercentage + "%"} className={itemClass} data-test-summary-item={item[0]}>{element}</td>
-                            <td width="5%" onClick={onClick}>
-                                <span className={hoverClass}><i className="fa fa-plus-square fa-lg"></i></span>
-                            </td>
-                        </span>
+                    const columnItem = (
+                        <td width={columnPercentage + "%"} className={itemClass} data-test-summary-item={item[0]} key={index + "-item-" + arrayIndex}>{element}</td>
                     );
+                    if (this.props.allowItemClick) {
+                        plusButtonForColumnItem = (
+                                <td width="5%" onClick={onClick} key={index + "-plus-" + arrayIndex}>
+                                    <span className={hoverClass}><i className="fa fa-plus-square fa-lg"></i></span>
+                                </td>
+                        );
+                    } else {
+                        plusButtonForColumnItem = (
+                            <td className="disabled" width="5%"><span><i className="fa fa-plus-square fa-lg"></i></span></td>
+                        );
+                    }
+                    renderedColumns.push(columnItem);
+                    renderedColumns.push(plusButtonForColumnItem);
                 }
             });
+            
             return (
                 <tr key={index} className={rowClass}>
                     {renderedColumns}  
                 </tr>
             );
-        }
+        
 
-        // TODO also edit this return the same way, is the else of line 1
+        /* TODO also edit this return the same way, is the else of line 1
         return (
             <tr key={index} className={rowClass}>
                 <td width="40%">{item.name}</td>
-                <td width="55%" className={itemClass}>{itemText}</td>
+                <td width="55%" className={itemClass}>itemText</td>
                 <td className="disabled" width="5%"><span><i className="fa fa-plus-square fa-lg"></i></span></td>
             </tr>
-        );
+        );*/
     }
     
     renderedListItems(list) {
-        let onClick, hoverClass, rowClass, itemClass, itemText = "";
+        let onClick, hoverClass, rowClass, itemClass = "";
         // item is now an Array. so this should not be called by firstHalf and secondHalf, one call per row.
         return list.map((item, index) => {
-            console.log("in map in renderedListItems:: ");
+           /* console.log("in map in renderedListItems:: ");
             console.log(item[0]);
             console.log(item[1]);
-            console.log(index);
+            console.log(index);*/
             // Handles case where this method is passed a NameValuePair or other type accidentally, or null
             if(!Lang.isArray(item) || Lang.isEmpty(item)){
                 itemClass = "missing";

--- a/src/summary/TabularListVisualizer.jsx
+++ b/src/summary/TabularListVisualizer.jsx
@@ -127,18 +127,18 @@ class TabularListVisualizer extends Component {
             </table>
         );
     }
-
+ // not the same hieght within a row, why?
     renderedListItem(item, index, rowClass, itemClass, itemText, onClick, hoverClass) {
         if (this.props.allowItemClick) {
             // Allows for 5% for each + button, and the remainder divided among the columns. There are item.length columns.
-            let columnPercentage = (100 - 10*item.length) / item.length;
+            let columnPercentage = (100 - 5*item.length) / item.length;
             let renderedColumns = item.map((element, arrayIndex) => {
                 if(Lang.isEqual(arrayIndex, 0)){
                     // white background on the first column
                     return (   
                         <span className="data">   
                             <td width={columnPercentage + "%"}>{element}</td>
-                            <td width="10%" onClick={onClick}>
+                            <td width="5%" onClick={onClick}>
                                 <span className={hoverClass}><i className="fa fa-plus-square fa-lg"></i></span>
                             </td>
                         </span>

--- a/src/summary/TabularListVisualizer.jsx
+++ b/src/summary/TabularListVisualizer.jsx
@@ -142,10 +142,10 @@ class TabularListVisualizer extends Component {
                     );
                     if (this.props.allowItemClick) {
                         plusButtonForColumnItem = (
-                            <td width="5%" onClick={onClick} key={index + "-plus-" + arrayIndex}>
+                            <td width="5%" onClick={() => { this.props.onItemClicked(item, arrayIndex)}} key={index + "-plus-" + arrayIndex}>
                                 <span className={hoverClass}><i className="fa fa-plus-square fa-lg"></i></span>
                             </td>
-                        );
+                        ); 
                     } else{
                         plusButtonForColumnItem = (
                             <td className="disabled" width="5%"><span><i className="fa fa-plus-square fa-lg"></i></span></td>
@@ -160,7 +160,7 @@ class TabularListVisualizer extends Component {
                     );
                     if (this.props.allowItemClick) {
                         plusButtonForColumnItem = (
-                                <td width="5%" onClick={onClick} key={index + "-plus-" + arrayIndex}>
+                                <td width="5%" onClick={() => { this.props.onItemClicked(item, arrayIndex)}} key={index + "-plus-" + arrayIndex} className={itemClass}>
                                     <span className={hoverClass}><i className="fa fa-plus-square fa-lg"></i></span>
                                 </td>
                         );
@@ -179,26 +179,11 @@ class TabularListVisualizer extends Component {
                     {renderedColumns}  
                 </tr>
             );
-        
-
-        /* TODO also edit this return the same way, is the else of line 1
-        return (
-            <tr key={index} className={rowClass}>
-                <td width="40%">{item.name}</td>
-                <td width="55%" className={itemClass}>itemText</td>
-                <td className="disabled" width="5%"><span><i className="fa fa-plus-square fa-lg"></i></span></td>
-            </tr>
-        );*/
     }
     
     renderedListItems(list) {
         let onClick, hoverClass, rowClass, itemClass = "";
-        // item is now an Array. so this should not be called by firstHalf and secondHalf, one call per row.
         return list.map((item, index) => {
-           /* console.log("in map in renderedListItems:: ");
-            console.log(item[0]);
-            console.log(item[1]);
-            console.log(index);*/
             // Handles case where this method is passed a NameValuePair or other type accidentally, or null
             if(!Lang.isArray(item) || Lang.isEmpty(item)){
                 itemClass = "missing";
@@ -208,15 +193,12 @@ class TabularListVisualizer extends Component {
             } else {
                 rowClass = "captured";
                 itemClass = "captured";
-               // itemText = item.value; //value part of key-value
-                onClick = (e) => this.props.onItemClicked(item);
                 hoverClass = "button-hover";
             }
             return this.renderedListItem(item, index, rowClass, itemClass, onClick, hoverClass);
         });
     }
 
-    // Gets called for each section in SummaryMetaData.jsx
     render() {
         const subsections = this.getSubsections();
 

--- a/src/summary/TabularListVisualizer.jsx
+++ b/src/summary/TabularListVisualizer.jsx
@@ -1,0 +1,221 @@
+import React, {Component} from 'react';
+import {Row, Col} from 'react-flexbox-grid';
+import PropTypes from 'prop-types';
+import Lang from 'lodash';
+import './TabularListVisualizer.css';
+
+/*
+ A table view of one or more data summary items. Items could be pathology-related,
+ diagnosis-related, genetics-related, etc.
+ */
+class TabularListVisualizer extends Component {
+//  this all will have to change to accomodate lists.
+    // this has one subsection, the Procedures ListType from SummaryMetadata with the itemsFunction
+    getSubsections() {
+        const {patient, condition, conditionSection} = this.props;
+
+        if (patient == null || condition == null || conditionSection == null) {
+            return [];
+        }
+
+        let subsections = [];
+        conditionSection.data.forEach((subsection) => {
+            subsections.push(subsection);
+        });
+        
+        return subsections;
+    }
+
+    getList(subsection) {
+        const {patient, condition, conditionSection} = this.props;
+        if (patient == null || condition == null || conditionSection == null) {
+            return [];
+        }
+
+        const items = subsection.items;
+        const itemsFunction = subsection.itemsFunction;
+
+        let list = null;
+
+        if (Lang.isUndefined(items)) {
+           // console.log("in TabularListViz.getList() old method:: "); it's all there
+           // console.log(patient);
+           // console.log(condition);
+            list = itemsFunction(patient, condition);
+        } else {
+            list = items.map((item, i) => {
+                if (Lang.isNull(item.value)) {
+                    return {name: item.name, value: null};
+                } else {
+                    return {name: item.name, value: item.value(patient, condition), shortcut: item.shortcut};
+                }
+            });
+        }
+       // console.log('...and List is correct, 5 procedures');
+      //  console.log(list);
+        return list;
+    }
+
+    renderedSubsections(subsections) {
+        const isSingleColumn = !this.props.isWide;
+
+        if (isSingleColumn) {
+            return subsections.map((subsection, index) => {
+                return this.renderedSubsection(subsection, index);
+            });
+        }
+
+        // Grab the sections from subsections and create 2 arrays, one for the first half of the sections and another
+        // for the second half of sections
+       /* const numberOfFirstHalfSections = Math.ceil(subsections.length / 2);
+        let firstHalfSections = [];
+        let secondHalfSections = [];
+
+        // Create array containing the first half of the subsections
+        subsections.slice(0, numberOfFirstHalfSections).forEach((subsection) => {
+            firstHalfSections.push(subsection);
+        });
+
+        // Create array containing the second half of the subsections
+        subsections.slice(numberOfFirstHalfSections).forEach((subsection) => {
+            secondHalfSections.push(subsection);
+        });
+
+        let ind = 0;
+        const renderedFirstHalf = firstHalfSections.map((subsection) => {
+            return this.renderedSubsection(subsection, ind++);
+        });
+        const renderedSecondHalf = secondHalfSections.map((subsection) => {
+            return this.renderedSubsection(subsection, ind++);
+        });*/
+        
+        // just use subsections
+        let ind = 0;
+        const renderedAllSections = subsections.map((subsection) => {
+            return this.renderedSubsection(subsection, ind++);
+        });
+
+        // Display the data in 2 columns. The first column displays the first half
+        // of the sections in one table and the second column displays the second half of the sections in a second table
+        // may need better Cols inserted for each column.
+        return (
+            <Row start="xs">
+                <Col sm={6}>
+                    {renderedAllSections}
+                </Col>
+            </Row>
+        );
+    }
+
+    renderedSubsection(subsection, index) {
+        const list = this.getList(subsection);
+
+        if (list.length <= 0) {
+            return <h2 key={index}>None</h2>;
+        }
+
+        return (
+            <table key={index}>
+                <tbody>
+                    <tr>
+                        <td className="subsection-header">
+                            {subsection.name}
+                        </td>
+                    </tr>
+                    {this.renderedListItems(list)}
+                </tbody>
+            </table>
+        );
+    }
+
+    renderedListItem(item, index, rowClass, itemClass, itemText, onClick, hoverClass) {
+        if (this.props.allowItemClick) {
+            // Allows for 5% for each + button, and the remainder divided among the columns. There are item.length columns.
+            let columnPercentage = (100 - 10*item.length) / item.length;
+            let renderedColumns = item.map((element, arrayIndex) => {
+                if(Lang.isEqual(arrayIndex, 0)){
+                    // white background on the first column
+                    return (   
+                        <span className="data">   
+                            <td width={columnPercentage + "%"}>{element}</td>
+                            <td width="10%" onClick={onClick}>
+                                <span className={hoverClass}><i className="fa fa-plus-square fa-lg"></i></span>
+                            </td>
+                        </span>
+                   );
+                } else {
+                    // red or blue background on the other columns
+                    return (
+                        <span className="data">
+                            <td width={columnPercentage + "%"} className={itemClass} data-test-summary-item={item[0]}>{element}</td>
+                            <td width="5%" onClick={onClick}>
+                                <span className={hoverClass}><i className="fa fa-plus-square fa-lg"></i></span>
+                            </td>
+                        </span>
+                    );
+                }
+            });
+            return (
+                <tr key={index} className={rowClass}>
+                    {renderedColumns}  
+                </tr>
+            );
+        }
+
+        // TODO also edit this return the same way, is the else of line 1
+        return (
+            <tr key={index} className={rowClass}>
+                <td width="40%">{item.name}</td>
+                <td width="55%" className={itemClass}>{itemText}</td>
+                <td className="disabled" width="5%"><span><i className="fa fa-plus-square fa-lg"></i></span></td>
+            </tr>
+        );
+    }
+    
+    renderedListItems(list) {
+        let onClick, hoverClass, rowClass, itemClass, itemText = "";
+        // item is now an Array. so this should not be called by firstHalf and secondHalf, one call per row.
+        return list.map((item, index) => {
+            console.log("in map in renderedListItems:: ");
+            console.log(item[0]);
+            console.log(item[1]);
+            console.log(index);
+            // Handles case where this method is passed a NameValuePair or other type accidentally, or null
+            if(!Lang.isArray(item) || Lang.isEmpty(item)){
+                itemClass = "missing";
+                item = [ "Missing data" ];
+                onClick = null;
+                hoverClass = null;
+            } else {
+                rowClass = "captured";
+                itemClass = "captured";
+               // itemText = item.value; //value part of key-value
+                onClick = (e) => this.props.onItemClicked(item);
+                hoverClass = "button-hover";
+            }
+            return this.renderedListItem(item, index, rowClass, itemClass, onClick, hoverClass);
+        });
+    }
+
+    // Gets called for each section in SummaryMetaData.jsx
+    render() {
+        const subsections = this.getSubsections();
+
+        return (
+            <div className="tabular-subsections">
+                {this.renderedSubsections(subsections)}
+            </div>
+        );
+    }
+}
+
+TabularListVisualizer.propTypes = {
+    patient: PropTypes.object,
+    condition: PropTypes.object,
+    conditionSection: PropTypes.object,
+    isWide: PropTypes.bool,
+    onItemClicked: PropTypes.func,
+    allowItemClick: PropTypes.bool
+};
+
+export default TabularListVisualizer;

--- a/src/summary/TargetedDataSection.jsx
+++ b/src/summary/TargetedDataSection.jsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import Button from '../elements/Button';
 import TabularNameValuePairsVisualizer from './TabularNameValuePairsVisualizer';
 import NarrativeNameValuePairsVisualizer from './NarrativeNameValuePairsVisualizer';
+import NarrativeListVisualizer from './NarrativeListVisualizer';
+import TabularListVisualizer from './TabularListVisualizer';
 import TimelineEventsVisualizer from '../timeline/TimelineEventsVisualizer';
 import './TargetedDataSection.css';
 
@@ -149,10 +151,39 @@ class TargetedDataSection extends Component {
     // TODO: Add a List type and a tabular renderer for it for Procedures section. case where left column is data
     //       and not just a label
     renderSection = (section) => {
+       // console.log("renderSection got: ");
+        //console.log(section);
         const {patient, condition, onItemClicked, allowItemClick, isWide, type} = this.props;
         const visualization = this.checkVisualization();
 
         switch (type) {
+            case "ListType": { // needs NarrativeListVisualizer and TabularListVisualizer to be created
+                if (visualization === 'tabular') {
+                    return (
+                        <TabularListVisualizer
+                            patient={patient}
+                            condition={condition}
+                            conditionSection={section}
+                            onItemClicked={onItemClicked}
+                            allowItemClick={allowItemClick}
+                            isWide={isWide}
+                        />
+                    );
+                } else if (visualization === 'narrative') {
+                    return (
+                        <NarrativeListVisualizer
+                            patient={patient}
+                            condition={condition}
+                            conditionSection={section}
+                            onItemClicked={onItemClicked}
+                            allowItemClick={allowItemClick}
+                            isWide={isWide}
+                        />
+                    ); 
+                } else {
+                    return null;
+                }
+            }
             case 'NameValuePairs': {
                 if (visualization === 'tabular') {
                     return (


### PR DESCRIPTION
In progress, looking at the button coloring before review is requested...

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [ ] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [ ] This pull request describes why these changes were made
- [ ] Recognizes any potential shortcomings/bugs in the description 
- [ ] Cheat sheet is updated
- [ ] Demo script is updated 
- [ ] Documentation on Wiki has been updated 
- [ ] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [ ] Note parser has been updated if structured phrases change

**Code Quality**

- [ ] 4-space indents - convert any tabs to spaces
- [ ] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [ ] Code is commented

**Tests**

- [ ] Existing tests passed
- [ ] Added UI tests for slim mode 
- [ ] Added UI tests for full mode
- [ ] Added backend tests for fluxNotes code
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
