### PR TITLE
Implement add note button

### DIFF
--- a/src/containers/FullApp.jsx
+++ b/src/containers/FullApp.jsx
@@ -50,6 +50,8 @@ class FullApp extends Component {
             contextManager: this.contextManager,
             errors: [],
             layout: "",
+            isNoteViewerVisible: false,
+            isNoteViewerEditable: false,
             patient: patient,
             selectedText: null,
             superRole: 'Clinician',

--- a/src/context/ContextManager.jsx
+++ b/src/context/ContextManager.jsx
@@ -132,6 +132,12 @@ class ContextManager {
             return this.patientContext;
         }
     }
+
+    clearContexts() {
+        this.contexts = [];
+        this.activeContexts = [];
+        this.onContextUpdate();
+    }
 }
 
 export default ContextManager;

--- a/src/dashboard/ClinicianDashboard.jsx
+++ b/src/dashboard/ClinicianDashboard.jsx
@@ -162,7 +162,7 @@ class ClinicianDashboard extends Component {
         };
 
         const isTargetedDataSubpanelVisible = this.isTargetedDataSubpanelVisible(currentLayout);
-        const istargetedDataPanelWide = (parseFloat(this.state.targetedDataPanelSize) > 60);
+        const isTargetedDataPanelWide = (parseFloat(this.state.targetedDataPanelSize) > 60);
 
         return (
             <div id="clinician-dashboard-content" style={{display: "flex"}}>

--- a/src/dashboard/ClinicianDashboard.jsx
+++ b/src/dashboard/ClinicianDashboard.jsx
@@ -9,30 +9,35 @@ class ClinicianDashboard extends Component {
     constructor() { 
         super();
 
-        this.state = { 
+        this.state = {
             targetedDataPanelSize: "default",
             notesPanelSize: "default"
         };
     }
 
-    // Performs any initialization that needs to happen when the component mounts, specifcally: 
+    // Performs any initialization that needs to happen when the component mounts, specifically:
     // - Set layout to the task's default if there's a task and no layout to start.
-    componentWillMount = () => { 
+    componentWillMount = () => {
         const currentClinicalEvent = this.props.appState.clinicalEvent;
-        const currentLayout = this.props.appState.layout; 
+        const currentLayout = this.props.appState.layout;
 
-        if (!currentLayout && currentClinicalEvent) {  
+        if (!currentLayout && currentClinicalEvent) {
             this.changeLayoutBasedOnClinicalEvent(currentClinicalEvent);
-        } else if (currentLayout && currentClinicalEvent) { 
+            this.noteViewerBasedOnClinicalEvent(currentClinicalEvent);
+            this.noteEditableBasedOnClinicalEvent(currentClinicalEvent);
+        } else if (currentLayout && currentClinicalEvent) {
             this.initializePanelSizesBasedOnLayout(currentLayout);
         }
     }
 
-    // Performs anyupdates based on changes to the state, specifically: 
+    // Performs any updates based on changes to the state, specifically:
     // - Updates the layout when the task changes.
     componentWillReceiveProps = (nextProps) => { 
         if (nextProps.appState.clinicalEvent !== this.props.appState.clinicalEvent) { 
             this.changeLayoutBasedOnClinicalEvent(nextProps.appState.clinicalEvent);
+            //TODO: add iniitalization of editable and visiblie
+            this.noteViewerBasedOnClinicalEvent(nextProps.appState.clinicalEvent);
+            this.noteEditableBasedOnClinicalEvent(nextProps.appState.clinicalEvent);
         }
         if (nextProps.appState.layout !== this.props.appState.layout) {
             this.initializePanelSizesBasedOnLayout(nextProps.appState.layout)
@@ -40,116 +45,130 @@ class ClinicianDashboard extends Component {
     }
 
     // Updates the layout value based on the current clinical event
-    changeLayoutBasedOnClinicalEvent = (clinicalEvent) => { 
-        switch(clinicalEvent) { 
-            case "pre-encounter": 
-                this.props.setFullAppState('layout', "right-collapsed");
+    changeLayoutBasedOnClinicalEvent = (clinicalEvent) => {
+        switch (clinicalEvent) {
+            case "pre-encounter":
+                this.props.setFullAppState('layout', "right-collapsed"); // originally "right-collapsed"
                 break;
             case "encounter":
                 this.props.setFullAppState('layout', "left-collapsed");
                 break;
-            case "post-encounter": 
+            case "post-encounter":
                 this.props.setFullAppState('layout', "split");
                 break;
-            default: 
+            default:
                 this.props.setFullAppState('layout', '');
         } 
     }
 
     // Based on a currentLayout, set a default panel size
-    initializePanelSizesBasedOnLayout = (currentLayout) => { 
+    initializePanelSizesBasedOnLayout = (currentLayout) => {
         let newTargetedDataPanelSize = "";
         let newNotesPanelSize = "";
-        switch(currentLayout) { 
+        switch (currentLayout) {
             case "left-collapsed":
-                    newTargetedDataPanelSize = "25%";
-                    newNotesPanelSize = "75%";
-                    break;
+                newTargetedDataPanelSize = "25%";
+                newNotesPanelSize = "75%";
+                break;
             case "right-collapsed":
-                    newTargetedDataPanelSize = "75%";
-                    newNotesPanelSize = "25%";
-                    break;
+                newTargetedDataPanelSize = "75%";
+                newNotesPanelSize = "25%";
+                break;
             case "split":
-                    newTargetedDataPanelSize = "40%";
-                    newNotesPanelSize = "60%";
-                    break;
-            default: 
+                newTargetedDataPanelSize = "40%";
+                newNotesPanelSize = "60%";
+                break;
+            default:
                 // console.warn(`The layout provided, ${currentLayout}, does not have defined panelDimensions.`);
                 newTargetedDataPanelSize = "40%";
                 newNotesPanelSize = "60%";
-        }   
+        }
 
         this.setState({
-            "targetedDataPanelSize" : newTargetedDataPanelSize,
-            "notesPanelSize" : newNotesPanelSize,
+            "targetedDataPanelSize": newTargetedDataPanelSize,
+            "notesPanelSize": newNotesPanelSize,
         });
     }
 
     // Based on currentClinicalEvent, determines if a note should be viewed 
-    noteViewerBasedOnClinicalEvent = (currentClinicalEvent) => { 
-        switch(currentClinicalEvent) { 
+    noteViewerBasedOnClinicalEvent = (currentClinicalEvent) => {
+        switch (currentClinicalEvent) {
             case "pre-encounter":
-                return false;
+                this.props.setFullAppState('isNoteViewerVisible', false);
+                break;
             case "encounter":
-                return true;
+                this.props.setFullAppState('isNoteViewerVisible', true);
+                break;
             case "post-encounter":
-                return true;
-            default: 
+                this.props.setFullAppState('isNoteViewerVisible', true);
+                break;
+            default:
                 console.warn(`The task provided, ${currentClinicalEvent}, does not have a defined noteViewerBasedOnClinicalEvent value.`);
-                return true;
-        } 
+                //TODO: define the default case
+                return;
+        }
     }
 
     // Based on currentClinicalEvent, determines if a note should be editable
-    noteEditableBasedOnClinicalEvent = (currentClinicalEvent) => { 
-        switch(currentClinicalEvent) { 
+    noteEditableBasedOnClinicalEvent = (currentClinicalEvent) => {
+        switch (currentClinicalEvent) {
             case "pre-encounter":
-                return false;
+                this.props.setFullAppState('isNoteViewerEditable', "false");
+                break;
             case "encounter":
-                return true;
+                this.props.setFullAppState('isNoteViewerEditable', "true");
+                break;
             case "post-encounter":
-                return true;
-            default: 
+                this.props.setFullAppState('isNoteViewerEditable', "true");
+                break;
+            default:
                 console.warn(`The task provided, ${currentClinicalEvent}, does not have a defined noteEditableBasedOnClinicalEvent value.`);
-                return true;
-        } 
+                //TODO: define the default case
+                return;
+        }
     }
 
     // Based on currentLayout, determines if the targetedDataSubpanel should be visible.
-    isTargetedDataSubpanelVisible = (currentLayout) => { 
-        switch(currentLayout) { 
+    isTargetedDataSubpanelVisible = (currentLayout) => {
+        switch (currentLayout) {
             case "left-collapsed":
                 return false;
             case "right-collapsed":
                 return true;
             case "split":
                 return true;
-            default: 
+            default:
                 // console.warn(`The layout provided, ${currentLayout}, does not have a defined isTargetedDataSubpanelVisibile value.`);
                 return true;
         }
     }
 
 
-    render () { 
-        const currentClinicalEvent = this.props.appState.clinicalEvent;
-        const currentLayout = this.props.appState.layout; 
+    render() {
+        // const currentClinicalEvent = this.props.appState.clinicalEvent;
+        const currentLayout = this.props.appState.layout;
+        const isNoteViewerVisible = this.props.appState.isNoteViewerVisible;
+        const isNoteViewerEditable = this.props.appState.isNoteViewerEditable;
 
-        const targetedDataPanelStyles = { 
+        const targetedDataPanelStyles = {
             "width": this.state.targetedDataPanelSize,
             "WebkitTransition": "width .5s", /* Safari */
             "transition": "width .5s",
         };
-        const notesPanelStyles = { 
+        const notesPanelStyles = {
             "width": this.state.notesPanelSize,
             "WebkitTransition": "width .5s", /* Safari */
             "transition": "width .5s",
         };
 
-        const isNoteViewerVisible            = this.noteViewerBasedOnClinicalEvent(currentClinicalEvent);
-        const isNoteViewerEditable           = this.noteEditableBasedOnClinicalEvent(currentClinicalEvent);
-        const isTargetedDataSubpanelVisible  = this.isTargetedDataSubpanelVisible(currentLayout);
-        const isTargetedDataPanelWide        = (parseFloat(this.state.targetedDataPanelSize) > 60); 
+
+        //TODO: Take these 2 and make them have same architecture as layout
+        // const isNoteViewerVisible            = this.noteViewerBasedOnClinicalEvent(currentClinicalEvent);
+        // const isNoteViewerEditable           = this.noteEditableBasedOnClinicalEvent(currentClinicalEvent);
+
+
+        const isTargetedDataSubpanelVisible = this.isTargetedDataSubpanelVisible(currentLayout);
+        const istargetedDataPanelWide = (parseFloat(this.state.targetedDataPanelSize) > 60);
 
         return (
             <div id="clinician-dashboard-content" style={{display: "flex"}}>
@@ -175,6 +194,11 @@ class ClinicianDashboard extends Component {
                         shortcutManager={this.props.shortcutManager}
                         summaryItemToBeInserted={this.props.appState.SummaryItemToInsert}
                         updateErrors={this.props.updateErrors}
+                        updateLayoutOnNewNoteClicked={this.updateLayoutOnNewNoteClicked}
+                        handleNewNote={this.handleNewNote}
+                        currentViewMode={this.props.appState.clinicalEvent}
+
+                        setFullAppState={this.props.setFullAppState}
                     />
                 </div>
             </div>
@@ -199,6 +223,9 @@ ClinicianDashboard.proptypes = {
     setFullAppState: PropTypes.func.isRequired,
     shortcutManager: PropTypes.object.isRequired,
     summaryMetadata: PropTypes.object.isRequired,
+    updateLayoutOnNewNoteClicked: PropTypes.func.isRequired,
+    handleNewNote: PropTypes.func.isRequired,
+    currentViewMode: PropTypes.object.isRequired,
 };
 
 export default ClinicianDashboard;

--- a/src/dashboard/ClinicianDashboard.jsx
+++ b/src/dashboard/ClinicianDashboard.jsx
@@ -5,8 +5,8 @@ import TargetedDataPanel from '../panels/TargetedDataPanel';
 import NotesPanel from '../panels/NotesPanel';
 import './ClinicianDashboard.css';
 
-class ClinicianDashboard extends Component { 
-    constructor() { 
+class ClinicianDashboard extends Component {
+    constructor() {
         super();
 
         this.state = {
@@ -32,10 +32,12 @@ class ClinicianDashboard extends Component {
 
     // Performs any updates based on changes to the state, specifically:
     // - Updates the layout when the task changes.
-    componentWillReceiveProps = (nextProps) => { 
-        if (nextProps.appState.clinicalEvent !== this.props.appState.clinicalEvent) { 
+    componentWillReceiveProps = (nextProps) => {
+
+        // If the clinical event has changed, update the layout and if the note editor should be viewable and editable
+        // based on the clinical event
+        if (nextProps.appState.clinicalEvent !== this.props.appState.clinicalEvent) {
             this.changeLayoutBasedOnClinicalEvent(nextProps.appState.clinicalEvent);
-            //TODO: add iniitalization of editable and visiblie
             this.noteViewerBasedOnClinicalEvent(nextProps.appState.clinicalEvent);
             this.noteEditableBasedOnClinicalEvent(nextProps.appState.clinicalEvent);
         }
@@ -48,7 +50,7 @@ class ClinicianDashboard extends Component {
     changeLayoutBasedOnClinicalEvent = (clinicalEvent) => {
         switch (clinicalEvent) {
             case "pre-encounter":
-                this.props.setFullAppState('layout', "right-collapsed"); // originally "right-collapsed"
+                this.props.setFullAppState('layout', "right-collapsed");
                 break;
             case "encounter":
                 this.props.setFullAppState('layout', "left-collapsed");
@@ -58,7 +60,7 @@ class ClinicianDashboard extends Component {
                 break;
             default:
                 this.props.setFullAppState('layout', '');
-        } 
+        }
     }
 
     // Based on a currentLayout, set a default panel size
@@ -104,7 +106,7 @@ class ClinicianDashboard extends Component {
                 break;
             default:
                 console.warn(`The task provided, ${currentClinicalEvent}, does not have a defined noteViewerBasedOnClinicalEvent value.`);
-                //TODO: define the default case
+                this.props.setFullAppState('isNoteViewerVisible', false);
                 return;
         }
     }
@@ -113,17 +115,17 @@ class ClinicianDashboard extends Component {
     noteEditableBasedOnClinicalEvent = (currentClinicalEvent) => {
         switch (currentClinicalEvent) {
             case "pre-encounter":
-                this.props.setFullAppState('isNoteViewerEditable', "false");
+                this.props.setFullAppState('isNoteViewerEditable', false);
                 break;
             case "encounter":
-                this.props.setFullAppState('isNoteViewerEditable', "true");
+                this.props.setFullAppState('isNoteViewerEditable', true);
                 break;
             case "post-encounter":
-                this.props.setFullAppState('isNoteViewerEditable', "true");
+                this.props.setFullAppState('isNoteViewerEditable', true);
                 break;
             default:
                 console.warn(`The task provided, ${currentClinicalEvent}, does not have a defined noteEditableBasedOnClinicalEvent value.`);
-                //TODO: define the default case
+                this.props.setFullAppState('isNoteViewerEditable', false);
                 return;
         }
     }
@@ -143,9 +145,7 @@ class ClinicianDashboard extends Component {
         }
     }
 
-
     render() {
-        // const currentClinicalEvent = this.props.appState.clinicalEvent;
         const currentLayout = this.props.appState.layout;
         const isNoteViewerVisible = this.props.appState.isNoteViewerVisible;
         const isNoteViewerEditable = this.props.appState.isNoteViewerEditable;
@@ -160,12 +160,6 @@ class ClinicianDashboard extends Component {
             "WebkitTransition": "width .5s", /* Safari */
             "transition": "width .5s",
         };
-
-
-        //TODO: Take these 2 and make them have same architecture as layout
-        // const isNoteViewerVisible            = this.noteViewerBasedOnClinicalEvent(currentClinicalEvent);
-        // const isNoteViewerEditable           = this.noteEditableBasedOnClinicalEvent(currentClinicalEvent);
-
 
         const isTargetedDataSubpanelVisible = this.isTargetedDataSubpanelVisible(currentLayout);
         const istargetedDataPanelWide = (parseFloat(this.state.targetedDataPanelSize) > 60);
@@ -195,9 +189,7 @@ class ClinicianDashboard extends Component {
                         summaryItemToBeInserted={this.props.appState.SummaryItemToInsert}
                         updateErrors={this.props.updateErrors}
                         updateLayoutOnNewNoteClicked={this.updateLayoutOnNewNoteClicked}
-                        handleNewNote={this.handleNewNote}
                         currentViewMode={this.props.appState.clinicalEvent}
-
                         setFullAppState={this.props.setFullAppState}
                     />
                 </div>
@@ -224,7 +216,6 @@ ClinicianDashboard.proptypes = {
     shortcutManager: PropTypes.object.isRequired,
     summaryMetadata: PropTypes.object.isRequired,
     updateLayoutOnNewNoteClicked: PropTypes.func.isRequired,
-    handleNewNote: PropTypes.func.isRequired,
     currentViewMode: PropTypes.object.isRequired,
 };
 

--- a/src/dataaccess/HardCodedPatient.json
+++ b/src/dataaccess/HardCodedPatient.json
@@ -53,7 +53,8 @@
 			"clinician": "Dr. Smith",
 			"content": "@NAME:'Debra Hernandez672' is a @AGE:'51 year old' @GENDER:'female' presenting with @DIAGNOSIS[Lobular carcinoma of the breast]:'Lobular carcinoma of the breast'.\nDisease #disease status[Stable based on physical exam at 02.AUG.2015].",
 			"originalCreationDate": "02 AUG 2015",
-			"lastUpdateDate": "02 AUG 2015"
+			"lastUpdateDate": "02 AUG 2015",
+            "signed": true
 		},
 		{
 			"shrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
@@ -65,7 +66,8 @@
 			"hospital": "Dana Farber Cancer Institute",
 			"clinician": "Dr. Zheng",
 			"originalCreationDate": "12 JUL 2012",
-			"lastUpdateDate": "12 JUL 2012"
+			"lastUpdateDate": "12 JUL 2012",
+            "signed": true
 		},
 		{
 			"shrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
@@ -77,7 +79,8 @@
 			"hospital": "Brigham and Women's Hospital",
 			"clinician": "Dr. Smith",
 			"originalCreationDate": "20 JUN 2012",
-			"lastUpdateDate": "20 JUN 2012"
+			"lastUpdateDate": "20 JUN 2012",
+            "signed": true
 		},
 		{
 			"shrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
@@ -89,7 +92,8 @@
 			"hospital": "Dana Farber Cancer Institute",
 			"clinician": "Dr. Strauss",
 			"originalCreationDate": "16 MAY 2012",
-			"lastUpdateDate": "16 MAY 2012"
+			"lastUpdateDate": "16 MAY 2012",
+            "signed": true
 		},
 		{
 			"shrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",

--- a/src/model/shr/core/ClinicalNote.js
+++ b/src/model/shr/core/ClinicalNote.js
@@ -8,6 +8,7 @@ class ClinicalNote {
         if (json.hospital) this._hospital = json.hospital;
         if (json.clinician) this._clinician = json.clinician;
         if (json.content) this._content = json.content;
+        if (json.signed) this._signed = json.signed;
     }
     /**
      * Getter for entry information (shr.base.Entry)
@@ -61,6 +62,14 @@ class ClinicalNote {
 
     set content(val) {
         this._content = val;
+    }
+    
+    get signed() {
+        return this._signed;
+    }
+    
+    set signed(val) {
+        this._signed = val;
     }
 }
 

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -23,15 +23,15 @@ const schema = {
     nodes: {
         paragraph: props => <p {...props.attributes}>{props.children}</p>,
         heading: props => <h1 {...props.attributes}>{props.children}</h1>,
-        'bulleted-list-item':     props => <li {...props.attributes}>{props.children}</li>,
-        'numbered-list-item':     props => <li {...props.attributes}>{props.children}</li>,        
+        'bulleted-list-item': props => <li {...props.attributes}>{props.children}</li>,
+        'numbered-list-item': props => <li {...props.attributes}>{props.children}</li>,
         'bulleted-list': props => <ul {...props.attributes}>{props.children}</ul>,
         'numbered-list': props => <ol {...props.attributes}>{props.children}</ol>,
     },
     marks: {
         bold: (props) => <strong>{props.children}</strong>,
         italic: (props) => <em>{props.children}</em>,
-        underlined: (props) => <u>{props.children}</u>,      
+        underlined: (props) => <u>{props.children}</u>,
     }
 };
 
@@ -48,12 +48,12 @@ const structuredFieldTypes = [
 function getPos(domElement, node, state) {
     const offsetx = 0;
     const offsety = 0;
-    var pos = { left: 0, top: 0 };
-    
+    var pos = {left: 0, top: 0};
+
     const children = domElement.childNodes;
 
-    for(const child of children) { 
-        if (child.getBoundingClientRect && child.getAttribute("data-key")) { 
+    for (const child of children) {
+        if (child.getBoundingClientRect && child.getAttribute("data-key")) {
             const rect = child.getBoundingClientRect();
             pos.left = rect.left + rect.width + offsetx;
             pos.top = rect.top + offsety;
@@ -70,9 +70,9 @@ function position(state) {
 // Given  text and starting index, recursively traverse text to find index location of text
 function getIndexRangeForCurrentWord(text, index, initialIndex, initialChar) {
     if (index === initialIndex) {
-        return {    
-            start: getIndexRangeForCurrentWord(text, index - 1, initialIndex, initialChar), 
-            end: getIndexRangeForCurrentWord(text, index + 1, initialIndex, initialChar)    
+        return {
+            start: getIndexRangeForCurrentWord(text, index - 1, initialIndex, initialChar),
+            end: getIndexRangeForCurrentWord(text, index + 1, initialIndex, initialChar)
         }
     }
     if (text[index] === initialChar || text[index] === undefined) {
@@ -92,18 +92,18 @@ class FluxNotesEditor extends React.Component {
 
         this.contextManager = this.props.contextManager;
         this.updateErrors = this.props.updateErrors;
-        
+
         this.contextManager.setIsBlock1BeforeBlock2(this.isBlock1BeforeBlock2.bind(this));
-        
+
         this.didFocusChange = false;
-        
+
         this.selectingForShortcut = null;
         this.onChange = this.onChange.bind(this);
         this.onSelectionChange = this.onSelectionChange.bind(this);
 
 
         this.noteParser = new NoteParser(this.props.shortcutManager, this.props.contextManager);
-        
+
         // Set the initial state when the app is first constructed.
         this.resetEditorState();
 
@@ -134,17 +134,17 @@ class FluxNotesEditor extends React.Component {
             suggestions: this.suggestionFunction.bind(this, '@'),
             onEnter: this.choseSuggestedShortcut.bind(this)
         });
-        
+
         this.plugins = [
             this.suggestionsPluginCreators,
             this.suggestionsPluginInserters,
             this.structuredFieldPlugin
         ];
-        
+
         // The logic below that builds the regular expression could possibly be replaced by the regular
         // expression stored in NoteParser (this.noteParser is instance variable). Only difference is
         // global flag it looks like? TODO: evaluate
-        this.autoReplaceBeforeRegExp = undefined;        
+        this.autoReplaceBeforeRegExp = undefined;
         let autoReplaceAfters = [];
         let allShortcutDefinitions = this.props.shortcutManager.getAllShortcutDefinitions();
         allShortcutDefinitions.forEach((def) => {
@@ -153,14 +153,14 @@ class FluxNotesEditor extends React.Component {
             autoReplaceAfters = autoReplaceAfters.concat(shortcutNamesList);
         });
         this.autoReplaceBeforeRegExp = new RegExp("(" + autoReplaceAfters.join("|") + ")", 'i');
-        
+
         // now add an AutoReplace plugin instance for each shortcut we're supporting as well
         this.plugins.push(AutoReplace({
             "trigger": 'space',
             "before": this.autoReplaceBeforeRegExp,
             "transform": this.autoReplaceTransform.bind(this, null)
         }));
-        
+
         // let's see if we have any regular expression shortcuts
         let triggerRegExp;
         allShortcutDefinitions.forEach((def) => {
@@ -190,7 +190,7 @@ class FluxNotesEditor extends React.Component {
             top: 0
         }
     }
-        
+
     suggestionFunction(initialChar, text) {
         if (Lang.isUndefined(text)) return [];
         let shortcuts = this.contextManager.getCurrentlyValidShortcuts(this.props.shortcutManager);
@@ -212,11 +212,11 @@ class FluxNotesEditor extends React.Component {
         });
         return suggestionsShortcuts.slice(0, 10);
     }
-    
+
     choseSuggestedShortcut(suggestion) {
-        const { state } = this.state; 
+        const {state} = this.state;
         const shortcut = this.props.newCurrentShortcut(null, suggestion.value.name);
-        
+
         if (!Lang.isNull(shortcut) && shortcut.needToSelectValueFromMultipleOptions()) {
             return this.openPortalToSelectValueForShortcut(shortcut, true, state.transform()).apply();
         } else {
@@ -225,7 +225,7 @@ class FluxNotesEditor extends React.Component {
             return transformAfterInsert.apply();
         }
     }
-    
+
     insertShortcut(shortcutC, shortcutTrigger, text, transform = undefined) {
         if (Lang.isUndefined(transform)) {
             transform = this.state.state.transform();
@@ -251,16 +251,16 @@ class FluxNotesEditor extends React.Component {
             return this.insertStructuredFieldTransform(transform, shortcut).collapseToStartOfNextText().focus();
         }
     }
-    
+
     autoReplaceTransform(def, transform, e, data, matches) {
         // need to use Transform object provided to this method, which AutoReplace .apply()s after return.
         return this.insertShortcut(def, matches.before[0], "", transform).insertText(' ');
     }
-    
+
     openPortalToSelectValueForShortcut(shortcut, needToDelete, transform) {
         let portalOptions = shortcut.getValueSelectionOptions();
         let pos = position(this.state);
-        
+
         this.setState({
             isPortalOpen: true,
             portalOptions: portalOptions,
@@ -275,7 +275,7 @@ class FluxNotesEditor extends React.Component {
     // called from portal when an item is selected (context is not null) or if portal is closed without
     // selection (context is null)
     onPortalSelection = (state, context) => {
-        this.setState({ isPortalOpen: false });
+        this.setState({isPortalOpen: false});
         if (Lang.isNull(context)) return state;
         let shortcut = this.selectingForShortcut;
         this.selectingForShortcut = null;
@@ -296,34 +296,32 @@ class FluxNotesEditor extends React.Component {
 
     // consider reusing this method to replace code in choseSuggestedShortcut function
     suggestionDeleteExistingTransform(transform = null, prefixCharacter) {
-        const { state } = this.state;
+        const {state} = this.state;
         if (Lang.isNull(transform)) {
             transform = state.transform();
         }
-        const { anchorText, anchorOffset } = state
+        const {anchorText, anchorOffset} = state
         const text = anchorText.text
 
-        let index = { start: anchorOffset - 1, end: anchorOffset }
+        let index = {start: anchorOffset - 1, end: anchorOffset}
 
         if (text[anchorOffset - 1] !== prefixCharacter) {
             index = getIndexRangeForCurrentWord(text, anchorOffset - 1, anchorOffset - 1, prefixCharacter)
         }
-            
+
         const newText = `${text.substring(0, index.start)}`
         return transform
             .deleteBackward(anchorOffset)
-            .insertText(newText)    
+            .insertText(newText)
     }
-    
+
     insertStructuredFieldTransform(transform, shortcut) {
         //console.log(shortcut);
         if (Lang.isNull(shortcut)) return transform.focus();
         let result = this.structuredFieldPlugin.transforms.insertStructuredField(transform, shortcut); //2nd param needs to be Shortcut Object, how to create?
         //console.log(result[0]);
-        return result[0];   
+        return result[0];
     }
-
-
 
     onChange = (state) => {
         this.setState({
@@ -335,15 +333,15 @@ class FluxNotesEditor extends React.Component {
         // Create an updated state with the text replaced.
 
         var nextState = this.state.state.transform().select({
-          anchorKey: data.anchorKey,
-          anchorOffset: data.anchorOffset,
-          focusKey: data.focusKey,
-          focusOffset: data.focusOffset
+            anchorKey: data.anchorKey,
+            anchorOffset: data.anchorOffset,
+            focusKey: data.focusKey,
+            focusOffset: data.focusOffset
         }).delete()
 
         this.insertTextWithStructuredPhrases(data.newText, nextState)
     }
-    
+
     isBlock1BeforeBlock2(key1, offset1, key2, offset2, state) {
         if (Lang.isUndefined(state)) {
             state = this.state.state;
@@ -357,7 +355,7 @@ class FluxNotesEditor extends React.Component {
             return state.document.areDescendantsSorted(key1, key2);
         }
     }
-        
+
     onSelectionChange = (selection, state) => {
         this.contextManager.adjustActiveContexts((context) => {
             // return true if context should be active because it's before selection
@@ -368,44 +366,44 @@ class FluxNotesEditor extends React.Component {
 
     // This gets called before the component receives new properties
     componentWillReceiveProps = (nextProps) => {
+
+        // Check if the item to be inserted is updated
         if (this.props.itemToBeInserted !== nextProps.itemToBeInserted && nextProps.itemToBeInserted.length > 0) {
             this.insertTextWithStructuredPhrases(nextProps.itemToBeInserted);
             this.props.itemInserted();
         }
 
+        // Check if the updatedEditorNote property has been updated
         if (this.props.updatedEditorNote !== nextProps.updatedEditorNote && !Lang.isNull(nextProps.updatedEditorNote)) {
 
             // If the updated editor note is an empty string, then we are adding a new blank note. Call method to
             // re initialize editor state and reset updatedEditorNote state in parent to be null
             if (nextProps.updatedEditorNote === "") {
-
-                console.log("updatedEditor Note is updated. Clearing editor state");
                 this.resetEditorState();
+
+                // Calls parent function which resets updatedEditorNote to be null
                 this.props.handleUpdateEditorWithNote(null);
+
+                // This clears error messages from the editor
                 this.structuredFieldPlugin.clearStructuredFieldMap();
+
+                // This clears the contexts so that the tray starts back at the patient context
                 this.contextManager.clearContexts();
             }
         }
 
-        // When current view mode changes do this
+        // Check if the current view mode changes
         if (this.props.currentViewMode !== nextProps.currentViewMode && !Lang.isNull(nextProps.currentViewMode)) {
-
-            console.log("inside changing current mode");
-            // If the updated editor note is an empty string, then we are adding a new blank note. Call method to
-            // re initialize editor state and reset updatedEditorNote state in parent to be null
-            if (nextProps.updatedEditorNote === "") {
-                console.log("currentViewMode is updated. Clearing editor state");
-                this.resetEditorState();
-                this.props.handleUpdateEditorWithNote(null);
-                this.structuredFieldPlugin.clearStructuredFieldMap();
-                this.contextManager.clearContexts();
-            }
+            this.resetEditorState();
+            this.props.handleUpdateEditorWithNote(null);
+            this.structuredFieldPlugin.clearStructuredFieldMap();
+            this.contextManager.clearContexts();
         }
     }
-    
+
     insertNewLine = (transform) => {
         return transform
-          .splitBlock();
+            .splitBlock();
     }
 
     insertPlainText = (transform, text) => {
@@ -421,17 +419,17 @@ class FluxNotesEditor extends React.Component {
     /*
      * Handle updates when we have a new
      */
-    insertTextWithStructuredPhrases = (textToBeInserted, currentTransform=undefined) => {
+    insertTextWithStructuredPhrases = (textToBeInserted, currentTransform = undefined) => {
         let state;
         const currentState = this.state.state;
-        
+
         // console.log(textToBeInserted);
 
         let transform = (currentTransform) ? currentTransform : currentState.transform();
         let remainder = textToBeInserted;
         let start, end;
         let before = '', after = '';
-        
+
         //console.log(textToBeInserted);
         const triggers = this.noteParser.getListOfTriggersFromText(textToBeInserted)[0];
         //console.log(triggers);
@@ -447,24 +445,24 @@ class FluxNotesEditor extends React.Component {
                 remainder = remainder.substring(start + trigger.trigger.length);
 
                 // FIXME: Temporary work around that adds spaces when needed to @-phrases inserted via mic
-                if (start !== 0 && trigger.trigger.startsWith('@') && !before.endsWith(' ')) { 
-                    transform = this.insertPlainText(transform, ' ');   
+                if (start !== 0 && trigger.trigger.startsWith('@') && !before.endsWith(' ')) {
+                    transform = this.insertPlainText(transform, ' ');
                 }
-                
+
                 // Deals with @condition phrases inserted via data summary panel buttons. 
                 if (remainder.startsWith("[[")) {
                     end = remainder.indexOf("]]");
                     after = remainder.substring(2, end);
                     // FIXME: 2 is a magic number based on [[ length, ditto for 2 below for ]]
                     remainder = remainder.substring(end + 2);
-                // FIXME: Temporary work around that can parse '@condition's inserted via mic with extraneous space
+                    // FIXME: Temporary work around that can parse '@condition's inserted via mic with extraneous space
                 } else if (remainder.startsWith(" [[")) {
                     remainder = remainder.replace(/\s+(\[\[\S*\s*.*)/g, '$1');
                     end = remainder.indexOf("]]");
                     // FIXME: 2 is a magic number based on ' [[' length, ditto for 2 below for ]]
                     after = remainder.charAt(2).toUpperCase() + remainder.substring(3, end);
                     remainder = remainder.substring(end + 2);
-                } else { 
+                } else {
                     after = "";
                 }
 
@@ -494,59 +492,59 @@ class FluxNotesEditor extends React.Component {
      */
     handleBlockCheck = (type) => {
         const {state} = this.state;
-           return state.blocks.some((node) => {
-               return node.type === type;
+        return state.blocks.some((node) => {
+            return node.type === type;
 
-           }); 
-    }    
-    
-      /**
-       * Handle any changes to the current mark type.
-       */
-    handleMarkUpdate = (type) =>  {
-        let { state } = this.state
-        state = state
-         .transform()
-         .toggleMark(type)
-         .apply()
-       this.setState({ state });
+        });
     }
 
-      /**
-       * Handle any changes to the current block type.
-       */
-    handleBlockUpdate = (type) =>  {
-        let { state } = this.state;
+    /**
+     * Handle any changes to the current mark type.
+     */
+    handleMarkUpdate = (type) => {
+        let {state} = this.state
+        state = state
+            .transform()
+            .toggleMark(type)
+            .apply()
+        this.setState({state});
+    }
+
+    /**
+     * Handle any changes to the current block type.
+     */
+    handleBlockUpdate = (type) => {
+        let {state} = this.state;
         const transform = state.transform();
         const DEFAULT_NODE = "";
 
         // Handle list buttons.
         if (type === 'bulleted-list' || type === 'numbered-list') {
-          const isList = this.handleBlockCheck(type + '-item')
+            const isList = this.handleBlockCheck(type + '-item')
 
 
-          if (isList) {
-            transform
-              .setBlock(DEFAULT_NODE)
-              .unwrapBlock('bulleted-list')
-              .unwrapBlock('numbered-list')
-          } else if (isList) {
-            transform
-              .unwrapBlock(type === 'bulleted-list' ? 'numbered-list' : 'bulleted-list')
-              .wrapBlock(type)
-          } else {
-            transform
-              .setBlock(type + '-item')
-              .wrapBlock(type)
-          }
+            if (isList) {
+                transform
+                    .setBlock(DEFAULT_NODE)
+                    .unwrapBlock('bulleted-list')
+                    .unwrapBlock('numbered-list')
+            } else if (isList) {
+                transform
+                    .unwrapBlock(type === 'bulleted-list' ? 'numbered-list' : 'bulleted-list')
+                    .wrapBlock(type)
+            } else {
+                transform
+                    .setBlock(type + '-item')
+                    .wrapBlock(type)
+            }
         } else {
-          // We don't handle any other kinds of block style formatting right now, but if we did it would go here.
+            // We don't handle any other kinds of block style formatting right now, but if we did it would go here.
         }
 
         state = transform.apply()
-        this.setState({ state });
-    
-    }        
+        this.setState({state});
+
+    }
 
     render = () => {
         const CreatorsPortal = this.suggestionsPluginCreators.SuggestionPortal;
@@ -585,7 +583,7 @@ class FluxNotesEditor extends React.Component {
             errorDisplay = (
                 <div>
                     <Divider className="divider"/>
-                    <h1 style={{color:'red'}}>{this.props.errors.join()}</h1>
+                    <h1 style={{color: 'red'}}>{this.props.errors.join()}</h1>
                     <Divider className="divider"/>
                 </div>
             );
@@ -596,7 +594,9 @@ class FluxNotesEditor extends React.Component {
          * Render the editor, toolbar, dropdown and description for note
          */
         return (
-            <div id="clinical-notes" className="dashboard-panel" onClick={(event) => { editor.focus(); }}>
+            <div id="clinical-notes" className="dashboard-panel" onClick={(event) => {
+                editor.focus();
+            }}>
                 {noteDescriptionContent}
                 <div className="MyEditor-root">
                     <EditorToolbar
@@ -611,17 +611,19 @@ class FluxNotesEditor extends React.Component {
                         placeholder={'Enter your clinical note here or choose a template to start from...'}
                         plugins={this.plugins}
                         state={this.state.state}
-                        ref={function(c) { editor = c; }}
+                        ref={function (c) {
+                            editor = c;
+                        }}
                         onChange={this.onChange}
                         onInput={this.onInput}
                         onSelectionChange={this.onSelectionChange}
                         schema={schema}
                     />
                     {errorDisplay}
-                    <CreatorsPortal 
-                        state={this.state.state} />
+                    <CreatorsPortal
+                        state={this.state.state}/>
                     <InsertersPortal
-                        state={this.state.state} />
+                        state={this.state.state}/>
                     <ContextPortal
                         left={this.state.left}
                         top={this.state.top}
@@ -641,7 +643,7 @@ class FluxNotesEditor extends React.Component {
     }
 }
 
-FluxNotesEditor.proptypes = { 
+FluxNotesEditor.proptypes = {
     onSelectionChange: PropTypes.func.isRequired,
     newCurrentShortcut: PropTypes.func.isRequired,
     itemInserted: PropTypes.object,

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -101,16 +101,11 @@ class FluxNotesEditor extends React.Component {
         this.onChange = this.onChange.bind(this);
         this.onSelectionChange = this.onSelectionChange.bind(this);
 
+
         this.noteParser = new NoteParser(this.props.shortcutManager, this.props.contextManager);
         
         // Set the initial state when the app is first constructed.
-        this.state = {
-            state: initialState,
-            isPortalOpen: false,
-            portalOptions: null,
-            left: 0,
-            top: 0
-        }
+        this.resetEditorState();
 
         // setup structured field plugin
         const structuredFieldPluginOptions = {
@@ -183,6 +178,17 @@ class FluxNotesEditor extends React.Component {
                 }));
             }
         });
+    }
+
+    // Reset the editor to the initial state when the app is first constructed.
+    resetEditorState() {
+        this.state = {
+            state: initialState,
+            isPortalOpen: false,
+            portalOptions: null,
+            left: 0,
+            top: 0
+        }
     }
         
     suggestionFunction(initialChar, text) {
@@ -358,11 +364,21 @@ class FluxNotesEditor extends React.Component {
         this.contextManager.contextUpdated();
     }
 
-    // This gets called when the before the component receives new properties
+    // This gets called before the component receives new properties
     componentWillReceiveProps = (nextProps) => {
         if (this.props.itemToBeInserted !== nextProps.itemToBeInserted && nextProps.itemToBeInserted.length > 0) {
             this.insertTextWithStructuredPhrases(nextProps.itemToBeInserted);
             this.props.itemInserted();
+        }
+
+        if (this.props.updatedEditorNote !== nextProps.updatedEditorNote && !Lang.isNull(nextProps.updatedEditorNote)) {
+
+            // If the updated editor note is an empty string, then we are adding a new blank note. Call method to
+            // re initialize editor state and reset updatedEditorNote state in parent to be null
+            if (nextProps.updatedEditorNote === "") {
+                this.resetEditorState();
+                this.props.handleUpdateEditorWithNote(null);
+            }
         }
     }
     
@@ -614,6 +630,7 @@ FluxNotesEditor.proptypes = {
     contextManager: PropTypes.object.isRequired,
     updateErrors: PropTypes.func.isRequired,
     errors: PropTypes.array.isRequired,
+    resetEditorState: PropTypes.func.isRequired,
 }
 
 export default FluxNotesEditor;

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -323,6 +323,8 @@ class FluxNotesEditor extends React.Component {
         return result[0];   
     }
 
+
+
     onChange = (state) => {
         this.setState({
             state: state
@@ -376,8 +378,27 @@ class FluxNotesEditor extends React.Component {
             // If the updated editor note is an empty string, then we are adding a new blank note. Call method to
             // re initialize editor state and reset updatedEditorNote state in parent to be null
             if (nextProps.updatedEditorNote === "") {
+
+                console.log("updatedEditor Note is updated. Clearing editor state");
                 this.resetEditorState();
                 this.props.handleUpdateEditorWithNote(null);
+                this.structuredFieldPlugin.clearStructuredFieldMap();
+                this.contextManager.clearContexts();
+            }
+        }
+
+        // When current view mode changes do this
+        if (this.props.currentViewMode !== nextProps.currentViewMode && !Lang.isNull(nextProps.currentViewMode)) {
+
+            console.log("inside changing current mode");
+            // If the updated editor note is an empty string, then we are adding a new blank note. Call method to
+            // re initialize editor state and reset updatedEditorNote state in parent to be null
+            if (nextProps.updatedEditorNote === "") {
+                console.log("currentViewMode is updated. Clearing editor state");
+                this.resetEditorState();
+                this.props.handleUpdateEditorWithNote(null);
+                this.structuredFieldPlugin.clearStructuredFieldMap();
+                this.contextManager.clearContexts();
             }
         }
     }

--- a/src/notes/NoteAssistant.css
+++ b/src/notes/NoteAssistant.css
@@ -19,7 +19,7 @@ span.button-hover {
 
 .note-new {
     margin-top: 10px;
-    margin-bottom: 20px;
+    margin-bottom: 10px;
     text-align: center;
     height: auto !important;
     width: 9vw !important;

--- a/src/notes/NoteAssistant.css
+++ b/src/notes/NoteAssistant.css
@@ -90,6 +90,12 @@ li.sort-item:hover {
     font-weight: bold;
 }
 
+.in-progress-text {
+    font-size: 0.8rem;
+    color: #333333 !important;
+    font-weight: bold;
+}
+
 .existing-note-subject {
     font-size: 0.7rem;
     color: #999 !important;

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -37,10 +37,9 @@ class NoteAssistant extends Component {
         this.setState({notesNotDisplayed: missingNotes});
     }
 
-    // Switch view. Currently only switching from context tray to clinical notes is available
-    // Cannot currently switch from clinical notes view back to current note view
-    toggleView() {
-        this.setState({noteAssistantMode: "clinical-notes"});
+    // Switch view (i.e clinical notes view or context tray)
+    toggleView(mode) {
+        this.setState({noteAssistantMode: mode});
     }
 
     // Update the selected index for the sort drop down
@@ -48,10 +47,9 @@ class NoteAssistant extends Component {
         this.setState({sortIndex: sortIndex});
     }
 
-    // Test method when user clicks on the new note button
-    // TODO: Implement creation of a new note. Rename method
-    test() {
-        console.log("clicked on new note");
+    handleOnNewNoteButtonClick() {
+        this.toggleView("context-tray");
+        this.props.addNewNote("");
     }
 
     // Render the content for the Note Assistant panel
@@ -65,7 +63,7 @@ class NoteAssistant extends Component {
                 // Render the context tray
                 return (
                     <div>
-                        <span className="button-hover clinical-notes-btn" onClick={() => { this.toggleView()}}>
+                        <span className="button-hover clinical-notes-btn" onClick={() => { this.toggleView("clinical-notes")}}>
                             <i className="fa fa-arrow-left"></i>
                             Clinical Notes
                         </span>
@@ -110,7 +108,7 @@ class NoteAssistant extends Component {
     // Render the new note button
     renderNewNoteSVG() {
         return (
-            <svg className="note-new" onClick={() => this.props.addNewNote("")} viewBox="0 0 150 33" version="1.1"
+            <svg className="note-new" onClick={() => this.handleOnNewNoteButtonClick()} viewBox="0 0 150 33" version="1.1"
                  xmlns="http://www.w3.org/2000/svg">
                 <defs>
                     <path

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -159,7 +159,7 @@ class NoteAssistant extends Component {
     renderInProgressNoteSVG(note, i) {
         const selected = this.state.selectedNote === note;
         const strokeColor = selected ? "#9ecfef" : "#B3B3B3";
-        const strokeWidth = selected ? "1" : "0.5";
+        const strokeWidth = selected ? "2" : "0.5";
         return (
             <svg key={i} className="note" onClick={() => {this.openNote(note)}} viewBox="0 0 149 129" version="1.1"
                  xmlns="http://www.w3.org/2000/svg">
@@ -227,7 +227,7 @@ class NoteAssistant extends Component {
     renderClinicalNoteSVG(item, i) {
         const selected = this.state.selectedNote === item;
         const strokeColor = selected ? "#9ecfef" : "#B3B3B3";
-        const strokeWidth = selected ? "1" : "0.5";
+        const strokeWidth = selected ? "2" : "0.5";
 
         return (
             <svg key={i} className="note" onClick={() => {this.openNote(item)}} viewBox="0 0 149 102" version="1.1"

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -110,7 +110,7 @@ class NoteAssistant extends Component {
     // Render the new note button
     renderNewNoteSVG() {
         return (
-            <svg className="note-new" onClick={() => {this.test()}} viewBox="0 0 150 33" version="1.1"
+            <svg className="note-new" onClick={() => this.props.addNewNote("")} viewBox="0 0 150 33" version="1.1"
                  xmlns="http://www.w3.org/2000/svg">
                 <defs>
                     <path

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -330,6 +330,7 @@ class NoteAssistant extends Component {
 
         // If the note viewer is editable then we want to be able to edit notes and view the context tray
         if (this.props.isNoteViewerEditable) {
+
             return (
                 <div>
                     {this.renderNoteAssistantContent(this.state.noteAssistantMode)}
@@ -338,6 +339,7 @@ class NoteAssistant extends Component {
 
             // If the note viewer is read only the we want to be able to view the clinical notes
         } else {
+
             return (
                 <div>
                     {this.renderNoteAssistantContent("clinical-notes")}

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -41,6 +41,7 @@ class NoteAssistant extends Component {
         let signedNotes = Lang.filter(allNotes, o => o.signed);
         let unsignedNotes = Lang.filter(allNotes, o => !o.signed);
         const maxNotes = Math.min(this.state.maxNotesToDisplay, signedNotes.length);
+        this.notesToDisplay = [];
         for (let i = 0; i < maxNotes; i++) {
             this.notesToDisplay.push(signedNotes[i]);
         }
@@ -175,7 +176,7 @@ class NoteAssistant extends Component {
         const strokeColor = selected ? "#9ecfef" : "#B3B3B3";
         const strokeWidth = selected ? "2" : "0.5";
         return (
-            <svg key={i} className="note" onClick={() => {this.openNote(note)}} viewBox="0 0 149 129" version="1.1"
+            <svg key={i} className="note" id="in-progress-note" onClick={() => {this.openNote(note)}} viewBox="0 0 149 129" version="1.1"
                  xmlns="http://www.w3.org/2000/svg">
                 <defs>
                     <path

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -18,6 +18,11 @@ function StructuredFieldPlugin(opts) {
     let contextManager = opts.contextManager;
 	let updateErrors = opts.updateErrors;
     let insertText = opts.insertText;
+
+    function clearStructuredFieldMap() {
+        structuredFieldMap = new Map();
+        return structuredFieldMap;
+    }
         
     function onChange(state, editor) {
         var deletedKeys = [];
@@ -294,6 +299,7 @@ function StructuredFieldPlugin(opts) {
 		positioning needs to go up 1 line to overlap with that BR so user can click on placeholder message and get
 		a cursor. see style top value of -18px  */	    
 	return {
+	    clearStructuredFieldMap,
         onChange,
         onCut,
         onCopy,

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -17,22 +17,21 @@ class NotesPanel extends Component {
         this.handleUpdateEditorWithNote = this.handleUpdateEditorWithNote.bind(this);
     }
 
-
     // Handle when the editor needs to be updated with a note. The note can be a new blank note or a pre existing note
     handleUpdateEditorWithNote(note) {
 
-        // console.log("handling update in notes panel");
-
+        // Update the state so that updatedEditorNote has the note to update the editor with
         this.setState({updatedEditorNote: note});
 
-        // TODO: add setfullappstate to prop types. Add prop types to this file
-        if (this.props.currentViewMode === 'pre-encounter') {
+        // Check if the app is in pre-encounter and if the note editor should be visible
+        if (this.props.currentViewMode === 'pre-encounter' && !this.props.isNoteViewerVisible) {
+
+            // Change the layout so that the note editor is added to the view
             this.props.setFullAppState("layout", "split");
             this.props.setFullAppState("isNoteViewerVisible", true);
             this.props.setFullAppState("isNoteViewerEditable", true);
+            this.setState({updatedEditorNote: null});
         }
-
-
     }
 
     renderNotesPanelContent() {

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -20,16 +20,24 @@ class NotesPanel extends Component {
 
     // Handle when the editor needs to be updated with a note. The note can be a new blank note or a pre existing note
     handleUpdateEditorWithNote(note) {
+
+        // console.log("handling update in notes panel");
+
         this.setState({updatedEditorNote: note});
 
-        if (note === "") {
-            this.props.updateErrors([]);
+        // TODO: add setfullappstate to prop types. Add prop types to this file
+        if (this.props.currentViewMode === 'pre-encounter') {
+            this.props.setFullAppState("layout", "split");
+            this.props.setFullAppState("isNoteViewerVisible", true);
+            this.props.setFullAppState("isNoteViewerEditable", true);
         }
+
+
     }
 
     renderNotesPanelContent() {
 
-        // If isNoteViewerVisible is tru, render the flux notes editor and the note assistant
+        // If isNoteViewerVisible is true, render the flux notes editor and the note assistant
         if (this.props.isNoteViewerVisible) {
             return (
                 <Row center="xs">
@@ -71,6 +79,8 @@ class NotesPanel extends Component {
                     // Pass in note that the editor is to be updated with
                     updatedEditorNote={this.state.updatedEditorNote}
                     handleUpdateEditorWithNote={this.handleUpdateEditorWithNote}
+
+                    currentViewMode={this.props.currentViewMode}
                 />
             </div>
         );

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -7,6 +7,26 @@ import './NotesPanel.css';
 
 class NotesPanel extends Component {
 
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            updatedEditorNote: null
+        };
+
+        this.handleUpdateEditorWithNote = this.handleUpdateEditorWithNote.bind(this);
+    }
+
+
+    // Handle when the editor needs to be updated with a note. The note can be a new blank note or a pre existing note
+    handleUpdateEditorWithNote(note) {
+        this.setState({updatedEditorNote: note});
+
+        if (note === "") {
+            this.props.updateErrors([]);
+        }
+    }
+
     renderNotesPanelContent() {
 
         // If isNoteViewerVisible is tru, render the flux notes editor and the note assistant
@@ -47,6 +67,10 @@ class NotesPanel extends Component {
                     shortcutManager={this.props.shortcutManager}
                     updateErrors={this.props.updateErrors}
                     errors={this.props.errors}
+
+                    // Pass in note that the editor is to be updated with
+                    updatedEditorNote={this.state.updatedEditorNote}
+                    handleUpdateEditorWithNote={this.handleUpdateEditorWithNote}
                 />
             </div>
         );
@@ -61,6 +85,7 @@ class NotesPanel extends Component {
                     contextManager={this.props.contextManager}
                     shortcutManager={this.props.shortcutManager}
                     handleSummaryItemSelected={this.props.handleSummaryItemSelected}
+                    addNewNote={this.handleUpdateEditorWithNote}
                 />
             </div>
         );

--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -13,12 +13,14 @@ import moment from 'moment';
 import Guid from 'guid';
 
 class PatientRecord {
-	constructor(shrJson = null) {
+    constructor(shrJson = null) {
         if (!Lang.isNull(shrJson)) { // load existing from JSON
             this.entries = this._loadJSON(shrJson);
             this.personOfRecord = this.getPersonOfRecord();
             this.shrId = this.personOfRecord.entryInfo.shrId;
-            this.nextEntryId = Math.max.apply(Math, this.entries.map(function(o) { return o.entryId; })) + 1;
+            this.nextEntryId = Math.max.apply(Math, this.entries.map(function (o) {
+                    return o.entryId;
+                })) + 1;
         } else { // create a new patient
             this.entries = [];
             this.personOfRecord = null;
@@ -27,11 +29,11 @@ class PatientRecord {
             this.patientFocalSubject = null;
         }
     }
-    
+
     _loadJSON(shrJson) {
         return shrJson.map((entry) => {
-			return ShrObjectFactory.createInstance(entry.entryType[0], entry);
-            
+            return ShrObjectFactory.createInstance(entry.entryType[0], entry);
+
         });
     }
 
@@ -57,162 +59,193 @@ class PatientRecord {
     static isEntryOfType(entry, type) {
         return (entry.entryType[0] === type);
     }
-    
+
     static isEntryBasedOnType(entry, type) {
         return (entry.entryType.indexOf(type) >= 0);
     }
-    
+
     static createEntryReferenceTo(entry) {
-        return { "entryType": entry.entryType[0], "shrId": entry.shrId, "entryId": entry.entryId };
+        return {"entryType": entry.entryType[0], "shrId": entry.shrId, "entryId": entry.entryId};
     }
-	
-	getName() {
-		let personOfRecord = this.getPersonOfRecord();
-		if (Lang.isNull(personOfRecord)) return null;
-		return personOfRecord._humanName;
-	}
-	
-	getDateOfBirth() {
-		let personOfRecord = this.getPersonOfRecord();
-		if (Lang.isNull(personOfRecord)) return null;
+
+    getName() {
+        let personOfRecord = this.getPersonOfRecord();
+        if (Lang.isNull(personOfRecord)) return null;
+        return personOfRecord._humanName;
+    }
+
+    getDateOfBirth() {
+        let personOfRecord = this.getPersonOfRecord();
+        if (Lang.isNull(personOfRecord)) return null;
         return personOfRecord.dateOfBirth.value;
-	}
-	
-	getAge() {
-		let personOfRecord = this.getPersonOfRecord();
-		if (Lang.isNull(personOfRecord)) return null;
-		var today = new Date();
-		var birthDate = new Date(personOfRecord._dateOfBirth._value);
-		var age = today.getFullYear() - birthDate.getFullYear();
-		var m = today.getMonth() - birthDate.getMonth();
-		if (m < 0 || (m === 0 && today.getDate() < birthDate.getDate())) {
-			age--;
-		}
-		return age;
-	}
-	
-	getGender() {
-		let personOfRecord = this.getPersonOfRecord();
-		if (Lang.isNull(personOfRecord)) return null;
-		return personOfRecord.administrativeGender.value;
-	}
-	
-	getPersonOfRecord() {
+    }
+
+    getAge() {
+        let personOfRecord = this.getPersonOfRecord();
+        if (Lang.isNull(personOfRecord)) return null;
+        var today = new Date();
+        var birthDate = new Date(personOfRecord._dateOfBirth._value);
+        var age = today.getFullYear() - birthDate.getFullYear();
+        var m = today.getMonth() - birthDate.getMonth();
+        if (m < 0 || (m === 0 && today.getDate() < birthDate.getDate())) {
+            age--;
+        }
+        return age;
+    }
+
+    getGender() {
+        let personOfRecord = this.getPersonOfRecord();
+        if (Lang.isNull(personOfRecord)) return null;
+        return personOfRecord.administrativeGender.value;
+    }
+
+    getPersonOfRecord() {
         return this.getMostRecentEntryOfType(PersonOfRecord);
-	}
-	
-	getMRN() {
-		let list = this.entries.filter((item) => { return item instanceof PatientIdentifier && item.identifierType === "MRN" });
-		let identifierEntry = PatientRecord.getMostRecentEntryFromList(list);
-		if (Lang.isNull(identifierEntry)) return null;
-		return identifierEntry.value;
-	}
-	
-	getMostRecentPhoto() {
+    }
+
+    getMRN() {
+        let list = this.entries.filter((item) => {
+            return item instanceof PatientIdentifier && item.identifierType === "MRN"
+        });
+        let identifierEntry = PatientRecord.getMostRecentEntryFromList(list);
+        if (Lang.isNull(identifierEntry)) return null;
+        return identifierEntry.value;
+    }
+
+    getMostRecentPhoto() {
         let photoEntry = this.getMostRecentEntryOfType(Photograph);
-		if (Lang.isNull(photoEntry)) return null;
-		return photoEntry.filePath;
-	}
-	
-	getCurrentHomeAddress() {
-		let personOfRecord = this.getPersonOfRecord();
-		if (Lang.isNull(personOfRecord) || !personOfRecord.addressUsed) return null;
-		let addressUsed = personOfRecord.addressUsed.filter((item) => { return item.addressUse.some((au) => au.value.coding[0].value === "primary_residence") });
-		if (addressUsed.length === 0) return null;
-		return addressUsed[0].value;
-	}
-	
-	getConditions() {
+        if (Lang.isNull(photoEntry)) return null;
+        return photoEntry.filePath;
+    }
+
+    getCurrentHomeAddress() {
+        let personOfRecord = this.getPersonOfRecord();
+        if (Lang.isNull(personOfRecord) || !personOfRecord.addressUsed) return null;
+        let addressUsed = personOfRecord.addressUsed.filter((item) => {
+            return item.addressUse.some((au) => au.value.coding[0].value === "primary_residence")
+        });
+        if (addressUsed.length === 0) return null;
+        return addressUsed[0].value;
+    }
+
+    getConditions() {
         let result = this.getEntriesIncludingType(Condition);
-		return result;
-	}
-	
-	getLastBreastCancerCondition() {
-		let result = this.getEntriesOfType(BreastCancer);
-		return result[result.length - 1];
-	}
-	
-	getNotes() {
-		return this.getEntriesOfType(ClinicalNote);
-	}
-	
-	getKeyEventsChronologicalOrder() {
-		let conditions = this.getConditions();
-		let result = [];
-		conditions.forEach((c, i) => {
-			result.push({name: "diagnosis date - " + c.specificType.coding[0].displayText, start_time: c.whenClinicallyRecognized});
-		});
-		result.sort(this._eventTimeSorter);
-		return result;
-	}
+        return result;
+    }
+
+    getLastBreastCancerCondition() {
+        let result = this.getEntriesOfType(BreastCancer);
+        return result[result.length - 1];
+    }
+
+    // Add initial unsigned note to patient record
+    addClinicalNote(date, subject, hospital, clinician, signed) {
+
+        // Generate the clinical note json from passed in values
+        let clinicalNote = new ClinicalNote(
+            {
+                "date": date,
+                "subject": subject,
+                "hospital": hospital,
+                "clinician": clinician,
+                "signed": signed
+            }
+        );
+
+        this.addEntryToPatientWithPatientFocalSubject(clinicalNote);
+    }
+
+    getNotes() {
+        return this.getEntriesOfType(ClinicalNote);
+    }
+
+    getKeyEventsChronologicalOrder() {
+        let conditions = this.getConditions();
+        let result = [];
+        conditions.forEach((c, i) => {
+            result.push({
+                name: "diagnosis date - " + c.specificType.coding[0].displayText,
+                start_time: c.whenClinicallyRecognized
+            });
+        });
+        result.sort(this._eventTimeSorter);
+        return result;
+    }
 
     getKeyEventsForConditionChronologicalOrder(condition) {
         let conditions = this.getConditions();
         let result = [];
         conditions.forEach((c) => {
-            if(c.entryInfo.entryId === condition.entryInfo.entryId) {
-                result.push({name: "diagnosis date - " + c.specificType.value.coding[0].displayText.value, start_time: c.whenClinicallyRecognized.value.value.value.timePeriodStart.value});
+            if (c.entryInfo.entryId === condition.entryInfo.entryId) {
+                result.push({
+                    name: "diagnosis date - " + c.specificType.value.coding[0].displayText.value,
+                    start_time: c.whenClinicallyRecognized.value.value.value.timePeriodStart.value
+                });
             }
         });
         result.sort(this._eventTimeSorter);
         return result;
     }
-	
-	getMedications() {
-		return this.getEntriesOfType(FluxMedicationPrescription);
-	}
-	
-	getMedicationsChronologicalOrder() {
-		let list = this.getMedications();
-		list.sort(this._medsTimeSorter);
-		return list;
-	}
+
+    getMedications() {
+        return this.getEntriesOfType(FluxMedicationPrescription);
+    }
+
+    getMedicationsChronologicalOrder() {
+        let list = this.getMedications();
+        list.sort(this._medsTimeSorter);
+        return list;
+    }
 
     getMedicationsForConditionChronologicalOrder(condition) {
         let medications = this.getMedicationsChronologicalOrder();
         medications = medications.filter((med) => {
-            return med instanceof FluxMedicationPrescription && med.reason.some((r) => { return r.value.entryId === condition.entryInfo.entryId; });
+            return med instanceof FluxMedicationPrescription && med.reason.some((r) => {
+                    return r.value.entryId === condition.entryInfo.entryId;
+                });
         });
         return medications;
     }
-	
-	getProcedures() {
-		return this.getEntriesOfType(FluxProcedure);
-	}
-	
-	getProceduresChronologicalOrder() {
-		let list = this.getProcedures();
-		list.sort(this._proceduresTimeSorter);
-		return list;
-	}
-	
-	getProceduresForCondition(condition) {
-		return this.entries.filter((item) => { 
-			return item instanceof FluxProcedure && item.reason.some((r) => { return r.value.entryId === condition.entryInfo.entryId; });
-		});
-	}
-	
-	getProceduresForConditionChronologicalOrder(condition) {
+
+    getProcedures() {
+        return this.getEntriesOfType(FluxProcedure);
+    }
+
+    getProceduresChronologicalOrder() {
+        let list = this.getProcedures();
+        list.sort(this._proceduresTimeSorter);
+        return list;
+    }
+
+    getProceduresForCondition(condition) {
+        return this.entries.filter((item) => {
+            return item instanceof FluxProcedure && item.reason.some((r) => {
+                    return r.value.entryId === condition.entryInfo.entryId;
+                });
+        });
+    }
+
+    getProceduresForConditionChronologicalOrder(condition) {
         let procedures = this.getProceduresForCondition(condition);
         procedures.sort(this._proceduresTimeSorter);
         return procedures;
-	}
-		
-	getProgressions() {
-		return this.getEntriesOfType(FluxProgression);
-	}
+    }
+
+    getProgressions() {
+        return this.getEntriesOfType(FluxProgression);
+    }
 
     getProgressionsChronologicalOrder() {
         let progressions = this.getProgressions();
         progressions.sort(this._progressionTimeSorter);
         return progressions;
     }
-	
-	getProgressionsForCondition(condition) {
-		return this.entries.filter((item) => {
-			return item instanceof FluxProgression && item.assessmentFocus.entryId === condition.entryInfo.entryId;
-		});
-	}
+
+    getProgressionsForCondition(condition) {
+        return this.entries.filter((item) => {
+            return item instanceof FluxProgression && item.assessmentFocus.entryId === condition.entryInfo.entryId;
+        });
+    }
 
     getProgressionsForConditionChronologicalOrder(condition) {
         let progressions = this.getProgressionsChronologicalOrder();
@@ -221,94 +254,130 @@ class PatientRecord {
         });
         return progressions;
     }
-	
-	getFocalConditionForProgression(progression) {
-		let result = this.entries.filter((item) => { return (item instanceof Condition) 
-            && progression.assessmentFocus.entryId === item.entryInfo.entryId });
-		return result[0];
-	}
-	
+
+    getFocalConditionForProgression(progression) {
+        let result = this.entries.filter((item) => {
+            return (item instanceof Condition)
+                && progression.assessmentFocus.entryId === item.entryInfo.entryId
+        });
+        return result[0];
+    }
+
     getMostRecentProgressionForCondition(condition, sinceDate = null) {
-		let progressionList = this.getProgressionsForCondition(condition);
+        let progressionList = this.getProgressionsForCondition(condition);
         const sortedProgressionList = progressionList.sort(this._progressionTimeSorter);
         const length = sortedProgressionList.length;
         let p = (sortedProgressionList[length - 1]);
-		if (Lang.isNull(sinceDate)) return p;
-		const startTime = new moment(p.asOfDate, "D MMM YYYY");
-		if (startTime < sinceDate) {
-			return null;
-		} else {
-			return p;
-		}
+        if (Lang.isNull(sinceDate)) return p;
+        const startTime = new moment(p.asOfDate, "D MMM YYYY");
+        if (startTime < sinceDate) {
+            return null;
+        } else {
+            return p;
+        }
     }
 
-	_medsTimeSorter(a, b) {
-		const a_startTime = new moment(a.requestedPerformanceTime.timePeriodStart, "D MMM YYYY");
-		const b_startTime = new moment(b.requestedPerformanceTime.timePeriodStart, "D MMM YYYY");
-		if (a_startTime < b_startTime) { return -1; }
-		if (a_startTime > b_startTime) { return 1; }
-		return 0;
-	}
-	_progressionTimeSorter(a, b) {
-		const a_startTime = new moment(a.asOfDate, "D MMM YYYY");
-		const b_startTime = new moment(b.asOfDate, "D MMM YYYY");
-		if (a_startTime < b_startTime) { return -1; }
-		if (a_startTime > b_startTime) { return 1; }
-		return 0;
-	}
-	_observationTimeSorter(a, b) {
-		const a_startTime = new moment(a.occurrenceTime, "D MMM YYYY");
-		const b_startTime = new moment(b.occurrenceTime, "D MMM YYYY");
-		if (a_startTime < b_startTime) { return -1; }
-		if (a_startTime > b_startTime) { return 1; }
-		return 0;
-	}
-	_proceduresTimeSorter(a, b) {
-		let a_startTime = new moment(a.occurrenceTime, "D MMM YYYY");
-        if(!a_startTime.isValid()) a_startTime = new moment(a.occurrenceTime.timePeriodStart, "D MMM YYYY");
-		let b_startTime = new moment(b.occurrenceTime, "D MMM YYYY");
-        if(!b_startTime.isValid()) b_startTime = new moment(b.occurrenceTime.timePeriodStart, "D MMM YYYY");
-		if (a_startTime < b_startTime) { return -1; }
-		if (a_startTime > b_startTime) { return 1; }
-		return 0;
-	}
-	_eventTimeSorter(a, b) {
-		const a_startTime = new moment(a.start_time, "D MMM YYYY");
-		const b_startTime = new moment(b.start_time, "D MMM YYYY");
-		if (a_startTime < b_startTime) { return -1; }
-		if (a_startTime > b_startTime) { return 1; }
-		return 0;
-	}
+    _medsTimeSorter(a, b) {
+        const a_startTime = new moment(a.requestedPerformanceTime.timePeriodStart, "D MMM YYYY");
+        const b_startTime = new moment(b.requestedPerformanceTime.timePeriodStart, "D MMM YYYY");
+        if (a_startTime < b_startTime) {
+            return -1;
+        }
+        if (a_startTime > b_startTime) {
+            return 1;
+        }
+        return 0;
+    }
 
-	// generic methods
-	getEntriesIncludingType(type) {
-        return this.entries.filter((item) => { return item instanceof type });
-	}
-	
-	getEntriesOfType(type) {
-		return this.entries.filter((item) => { return item instanceof type });
-	}
-    
+    _progressionTimeSorter(a, b) {
+        const a_startTime = new moment(a.asOfDate, "D MMM YYYY");
+        const b_startTime = new moment(b.asOfDate, "D MMM YYYY");
+        if (a_startTime < b_startTime) {
+            return -1;
+        }
+        if (a_startTime > b_startTime) {
+            return 1;
+        }
+        return 0;
+    }
+
+    _observationTimeSorter(a, b) {
+        const a_startTime = new moment(a.occurrenceTime, "D MMM YYYY");
+        const b_startTime = new moment(b.occurrenceTime, "D MMM YYYY");
+        if (a_startTime < b_startTime) {
+            return -1;
+        }
+        if (a_startTime > b_startTime) {
+            return 1;
+        }
+        return 0;
+    }
+
+    _proceduresTimeSorter(a, b) {
+        let a_startTime = new moment(a.occurrenceTime, "D MMM YYYY");
+        if (!a_startTime.isValid()) a_startTime = new moment(a.occurrenceTime.timePeriodStart, "D MMM YYYY");
+        let b_startTime = new moment(b.occurrenceTime, "D MMM YYYY");
+        if (!b_startTime.isValid()) b_startTime = new moment(b.occurrenceTime.timePeriodStart, "D MMM YYYY");
+        if (a_startTime < b_startTime) {
+            return -1;
+        }
+        if (a_startTime > b_startTime) {
+            return 1;
+        }
+        return 0;
+    }
+
+    _eventTimeSorter(a, b) {
+        const a_startTime = new moment(a.start_time, "D MMM YYYY");
+        const b_startTime = new moment(b.start_time, "D MMM YYYY");
+        if (a_startTime < b_startTime) {
+            return -1;
+        }
+        if (a_startTime > b_startTime) {
+            return 1;
+        }
+        return 0;
+    }
+
+    // generic methods
+    getEntriesIncludingType(type) {
+        return this.entries.filter((item) => {
+            return item instanceof type
+        });
+    }
+
+    getEntriesOfType(type) {
+        return this.entries.filter((item) => {
+            return item instanceof type
+        });
+    }
+
     static getEntriesOfTypeFromList(list, type) {
-        return list.filter((item) => { return item.entryType[0] === type });
+        return list.filter((item) => {
+            return item.entryType[0] === type
+        });
     }
-	
-	getMostRecentEntryOfType(type) {
-		let list = this.getEntriesOfType(type);
-		return PatientRecord.getMostRecentEntryFromList(list);
-	}
-	
-	static getMostRecentEntryFromList(list) {
-		if (list.length === 0) return null;
+
+    getMostRecentEntryOfType(type) {
+        let list = this.getEntriesOfType(type);
+        return PatientRecord.getMostRecentEntryFromList(list);
+    }
+
+    static getMostRecentEntryFromList(list) {
+        if (list.length === 0) return null;
         if (list.length === 1) return list[0];
-        
-		let maxDate = Math.max.apply(null, list.map(function(o) { return new Date(o._entryInfo._lastUpdateDate);}));
-		let result = list.filter((item) => { return new Date(item._entryInfo._lastUpdateDate).getTime() === new Date(maxDate).getTime() });
-		if (Lang.isUndefined(result) || Lang.isNull(result) || result.length === 0) {
+
+        let maxDate = Math.max.apply(null, list.map(function (o) {
+            return new Date(o._entryInfo._lastUpdateDate);
+        }));
+        let result = list.filter((item) => {
+            return new Date(item._entryInfo._lastUpdateDate).getTime() === new Date(maxDate).getTime()
+        });
+        if (Lang.isUndefined(result) || Lang.isNull(result) || result.length === 0) {
             return null;
         }
-		return result[0];
-	}
+        return result[0];
+    }
 }
 
 export default PatientRecord;

--- a/test/ui/FullApp.js
+++ b/test/ui/FullApp.js
@@ -78,17 +78,17 @@ fixture('Patient Mode - Editor')
 test('Clicking clinical notes in Note Assistance switches view to clinical notes', async t => {
 
     const clinicalNotesButton = Selector('.clinical-notes-btn');
-    const resumeNotesButton = Selector('.resume-note-btn');
+    const newNoteButton = Selector('.note-new');
 
     // clinical notes button is selected
     await t
         .click(clinicalNotesButton)
 
-    const buttonText = await resumeNotesButton.textContent;
+    const buttonText = await newNoteButton.textContent;
 
     await t
         .expect(buttonText.toString().toLowerCase())
-        .eql("resume in-progress note");
+        .eql("new note");
 });
 
 
@@ -295,6 +295,35 @@ test('Clicking "@condition", "#disease status", "#stable", "#as of", "#date" and
     await t
         .expect(expectedNumItems).eql(numItems, 'There should be ' + expectedNumItems + ' progression items on the timeline.');
 
+});
+
+
+fixture('Patient Mode - Clinical Notes list')
+    .page(startPage);
+
+test('Clicking New Note button adds a new in progress note to the list', async t => {
+    const clinicalNotesButton = Selector('.clinical-notes-btn');
+    const newNoteButton = Selector('.note-new');
+    const inProgressNotes = Selector('#in-progress-note');
+    
+    await t
+        .click(clinicalNotesButton);
+    
+    const inProgressNotesLength = await inProgressNotes.count;
+    
+    // There are no unsigned notes on the patient's record initially
+    await t
+        .expect(inProgressNotesLength).eql(0);
+    
+    await t
+        .click(newNoteButton)
+        .click(clinicalNotesButton)
+    
+    const inProgressNotesUpdatedLength = await inProgressNotes.count;
+    
+    // Adding a new note adds an unsigned, inprogress note
+    await t
+        .expect(inProgressNotesUpdatedLength).eql(inProgressNotesLength+1);
 });
 
 

--- a/test/ui/FullApp.js
+++ b/test/ui/FullApp.js
@@ -72,6 +72,24 @@ test('Selecting a condition changes the active condition', async t => {
         .eql("Fracture");
 });
 
+test('Clicking "New Note" button in pre-encounter mode changes layout and displays the note editor', async t => {
+    const clinicalEventSelector = Selector('.clinical-event-select');
+    const editor = Selector("div[data-slate-editor='true']");
+    const newNoteButton = Selector('.note-new');
+
+    // Select pre-encounter mode
+    await t
+        .click(clinicalEventSelector)
+        .click(Selector('[data-test-clinical-event-selector-item="Pre-encounter"]'));
+
+    // Click on new note button to open the editor
+    await t
+        .click(newNoteButton)
+
+    await t
+        .expect(editor.exists).ok();
+});
+
 fixture('Patient Mode - Editor')
     .page(startPage);
 
@@ -89,6 +107,60 @@ test('Clicking clinical notes in Note Assistance switches view to clinical notes
     await t
         .expect(buttonText.toString().toLowerCase())
         .eql("new note");
+});
+
+test('In post-encounter mode, clicking the "New Note" button clears the editor content', async t => {
+    const editor = Selector("div[data-slate-editor='true']");
+    const clinicalNotesButton = Selector('.clinical-notes-btn');
+    const newNoteButton = Selector('.note-new');
+
+    // Enter some text in the editor
+    await t
+        .typeText(editor, "@name ")
+
+    // Switch to clinical notes view
+    await t
+        .click(clinicalNotesButton)
+
+    // Click on new note button
+    await t
+        .click(newNoteButton)
+
+    await t
+        .expect(editor.textContent)
+        .eql("Enter your clinical note here or choose a template to start from...");
+});
+
+test('In pre-encounter mode, clicking the "New Note" button clears the editor content', async t => {
+    const clinicalEventSelector = Selector('.clinical-event-select');
+    const editor = Selector("div[data-slate-editor='true']");
+    const clinicalNotesButton = Selector('.clinical-notes-btn');
+    const newNoteButton = Selector('.note-new');
+
+    // Select pre-encounter mode
+    await t
+        .click(clinicalEventSelector)
+        .click(Selector('[data-test-clinical-event-selector-item="Pre-encounter"]'));
+
+    // Click on new note button to open the editor
+    await t
+        .click(newNoteButton)
+
+    // Enter some text in the editor
+    await t
+        .typeText(editor, "@name ")
+
+    // Switch to clinical notes view
+    await t
+        .click(clinicalNotesButton)
+
+    // Click on new note button to clear the editor
+    await t
+        .click(newNoteButton)
+
+    await t
+        .expect(editor.textContent)
+        .eql("Enter your clinical note here or choose a template to start from...");
 });
 
 


### PR DESCRIPTION
This PR addresses jira issues 803 and 773. It also seems to fix the bug reported in the backlog (https://jira.mitre.org/browse/ASCODCP-709). Can others help verify this? 

Jira issue 803:
- Clicking new note button in post-encounter mode clears the editor content and adds a new note in patient record, which is added to and is displayed in the list of clinical notes
- Clicking new note button in pre-encounter mode changes the layout to add the note editor
- Once the editor is added to the layout, clicking new note button clears the content in pre encounter mode
- Added UI tests to check that content is cleared in post and pre encounter modes as well as check that the editor is added in pre encounter mode when the new note button is pressed
- Implementing add new note button functionality seems to have fixed jira issue 709

Jira issue 773:
(This branch has been merged with @jafeltra 's branch which addresses issue 773)
- @jafeltra added signed/unsigned field to clinical notes
- @jafeltra added functionality to display in progress notes in clinical notes viewer. Unsigned notes are displayed as in progress notes whereas signed notes appear in the main list
- @jafeltra added initial functionality to visualize a selected note with a blue boarder. 773 did not actually include being able to view the content of a note in the editor.
- @jafeltra added a UI test to verify that in progress note are added to the clinical notes view as new notes are added (new note button is pressed)

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- N/A Cheat sheet is updated
- N/A Demo script is updated 
- N/A Documentation on Wiki has been updated 
- N/A Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- N/A Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- N/A Added UI tests for slim mode 
- [x] Added UI tests for full mode
- N/A Added backend tests for fluxNotes code
- N/A Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
