### PR TITLE
added new inserters for @medication and @procedure +bug fix

### DIFF
--- a/src/context/ContextPortal.jsx
+++ b/src/context/ContextPortal.jsx
@@ -91,7 +91,7 @@ class ContextPortal extends React.Component {
      */
     onKeyDown(keyCode) {
         if (keyCode === DOWN_ARROW_KEY || keyCode === UP_ARROW_KEY) {
-            const positionChange = (keyCode === DOWN_ARROW_KEY) ? -1 : +1; 
+            const positionChange = (keyCode === DOWN_ARROW_KEY) ? 1 : -1; 
             this.changeMenuPosition(positionChange)
         } else if (keyCode === ENTER_KEY) {
             this.setState({ active: false, justActive: false });

--- a/src/shortcuts/Shortcuts.json
+++ b/src/shortcuts/Shortcuts.json
@@ -284,6 +284,20 @@
     "knownParentContexts": "Patient"
   },
   { "type": "InsertValue",
+    "id": "ProcedureInserter",
+    "getData": {"object": "patient", "method": "getProcedures", "itemKey": "entryInfo.entryId", "itemContext":"specificType.value.coding.0.displayText.value"},
+    "isContext": true,
+    "stringTriggers": [{"name":"@procedure", "description": "Select a procedure of the patient to insert and support capturing further information about."}],
+    "knownParentContexts": "Patient"
+  },
+  { "type": "InsertValue",
+    "id": "MedicationInserter",
+    "getData": {"object": "patient", "method": "getMedications", "itemKey": "entryInfo.entryId", "itemContext":"medication"},
+    "isContext": true,
+    "stringTriggers": [{"name":"@medication", "description": "Select a medication of the patient to insert and support capturing further information about."}],
+    "knownParentContexts": "Patient"
+  },
+  { "type": "InsertValue",
     "id": "StageInserter",
     "getData": {"object": "parent", "attribute": "stage"},
     "parentAttribute": "stage",


### PR DESCRIPTION
Portal handling of up and down arrow were reversed so fixed that.

added new inserters for @medication and @procedure by just adding them to shortcuts.json without any coding

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [ ] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [ ] This pull request describes why these changes were made
- [ ] Recognizes any potential shortcomings/bugs in the description 
- [ ] Cheat sheet is updated
- [ ] Demo script is updated 
- [ ] Documentation on Wiki has been updated 
- [ ] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [ ] Note parser has been updated if structured phrases change

**Code Quality**

- [ ] 4-space indents - convert any tabs to spaces
- [ ] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [ ] Code is commented

**Tests**

- [ ] Existing tests passed
- [ ] Added UI tests for slim mode 
- [ ] Added UI tests for full mode
- [ ] Added backend tests for fluxNotes code
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Mike

- [X] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [X] The tests appropriately test the new code, including edge cases
- [X] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
