### PR TITLE
Implement view note

### DIFF
--- a/src/containers/FullApp.jsx
+++ b/src/containers/FullApp.jsx
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import { Grid, Row, Col } from 'react-flexbox-grid';
-import { MuiThemeProvider, createMuiTheme } from 'material-ui/styles';
+import {Grid, Row, Col} from 'react-flexbox-grid';
+import {MuiThemeProvider, createMuiTheme} from 'material-ui/styles';
 import lightBlue from 'material-ui/colors/purple';
 import green from 'material-ui/colors/green';
 import red from 'material-ui/colors/red';
@@ -16,8 +16,8 @@ import '../styles/FullApp.css';
 
 const theme = createMuiTheme({
     palette: {
-        primary: { ...lightBlue, A700: '#1384b5' },
-        secondary: { ...green, A400: '#00e677' },
+        primary: {...lightBlue, A700: '#1384b5'},
+        secondary: {...green, A400: '#00e677'},
         error: red
     }
 });
@@ -37,7 +37,6 @@ class FullApp extends Component {
             this.dataAccess = new DataAccess(this.props.dataSource);
         }
 
-        //let patient = new Patient();
         let patient = this.dataAccess.getPatient(DataAccess.DEMO_PATIENT_ID);
         this.summaryMetadata = new SummaryMetadata();
         this.dashboardManager = new DashboardManager();
@@ -62,22 +61,27 @@ class FullApp extends Component {
 
     // pass this function to children to set full app global state
     setFullAppState = (state, value) => {
-        this.setState({ [state]: value });
+        this.setState({[state]: value});
+    }
+
+    // Same function as 'setFullAppState' except this function uses a callback
+    setFullAppStateWithCallback = (state, callback) => {
+        this.setState(state, callback);
     }
 
     // Updates the context manager in it's state
     onContextUpdate = () => {
-        this.setState({ contextManager: this.contextManager });
+        this.setState({contextManager: this.contextManager});
     }
 
     // Update the errors based on the argument provided
     updateErrors = (errors) => {
-        this.setState({ errors });
+        this.setState({errors});
     }
 
     // Determines the item to be inserted
     itemInserted = () => {
-        this.setState({ SummaryItemToInsert: '' });
+        this.setState({SummaryItemToInsert: ''});
     }
 
     // Given a shortcutClass, a type and an object, create a new shortcut and change errors is needed.
@@ -96,8 +100,8 @@ class FullApp extends Component {
         return newShortcut;
     }
 
-    // Update shortcuts and update patients accordignly
-    handleShortcutUpdate = (s) =>{
+    // Update shortcuts and update patients accordingly
+    handleShortcutUpdate = (s) => {
         let p = this.state.patient;
         s.updatePatient(p, this.contextManager);
     }
@@ -124,10 +128,10 @@ class FullApp extends Component {
     }
 
     // Update the summaryitemtoinsert based on the item given
-    handleSummaryItemSelected = (item, arrayIndex = -1) =>{
+    handleSummaryItemSelected = (item, arrayIndex = -1) => {
         if (item) {
             // calls to this method from the buttons on a ListType pass in 'item' as an array.
-            if(Lang.isArray(item) && arrayIndex >= 0){
+            if (Lang.isArray(item) && arrayIndex >= 0) {
                 this.setState({SummaryItemToInsert: item[arrayIndex]});
             } else if (item.shortcut) {
                 this.setState({SummaryItemToInsert: `${item.shortcut}[[${item.value}]]`});
@@ -176,6 +180,7 @@ class FullApp extends Component {
 
                                 // Functions
                                 setFullAppState={this.setFullAppState}
+                                setFullAppStateWithCallback={this.setFullAppStateWithCallback}
                                 updateErrors={this.updateErrors}
                                 onContextUpdate={this.onContextUpdate}
                                 itemInserted={this.itemInserted}

--- a/src/context/ContextTray.jsx
+++ b/src/context/ContextTray.jsx
@@ -66,7 +66,7 @@ class ContextTray extends Component {
 
         let activeContexts = this._getActiveContexts();
         panelContent = (
-            <div>
+            <div className="context-tray">
                 <Tabs
                     scrollable
                     scrollButtons="auto"

--- a/src/dashboard/ClinicianDashboard.jsx
+++ b/src/dashboard/ClinicianDashboard.jsx
@@ -191,6 +191,7 @@ class ClinicianDashboard extends Component {
                         updateLayoutOnNewNoteClicked={this.updateLayoutOnNewNoteClicked}
                         currentViewMode={this.props.appState.clinicalEvent}
                         setFullAppState={this.props.setFullAppState}
+                        setFullAppStateWithCallback={this.props.setFullAppStateWithCallback}
                     />
                 </div>
             </div>
@@ -213,6 +214,7 @@ ClinicianDashboard.proptypes = {
     newCurrentShortcut: PropTypes.func.isRequired,
     possibleClinicalEvents: PropTypes.array.isRequired,
     setFullAppState: PropTypes.func.isRequired,
+    setFullAppStateWithCallback: PropTypes.func.isRequired,
     shortcutManager: PropTypes.object.isRequired,
     summaryMetadata: PropTypes.object.isRequired,
     updateLayoutOnNewNoteClicked: PropTypes.func.isRequired,

--- a/src/dataaccess/HardCodedPatient.json
+++ b/src/dataaccess/HardCodedPatient.json
@@ -51,7 +51,8 @@
 			"subject": "Clinical follow-up",
 			"hospital": "Dana Farber Cancer Institute",
 			"clinician": "Dr. Smith",
-			"content": "@NAME:'Debra Hernandez672' is a @AGE:'51 year old' @GENDER:'female' presenting with @DIAGNOSIS[Lobular carcinoma of the breast]:'Lobular carcinoma of the breast'.\nDisease #disease status[Stable based on physical exam at 02.AUG.2015].",
+
+            "content": "@name is a @age year old @gender presenting with @condition[Invasive ductal carcinoma of breast]",
 			"originalCreationDate": "02 AUG 2015",
 			"lastUpdateDate": "02 AUG 2015",
             "signed": true

--- a/src/dataaccess/HardCodedPatient.json
+++ b/src/dataaccess/HardCodedPatient.json
@@ -51,8 +51,7 @@
 			"subject": "Clinical follow-up",
 			"hospital": "Dana Farber Cancer Institute",
 			"clinician": "Dr. Smith",
-
-            "content": "@name is a @age year old @gender presenting with @condition[Invasive ductal carcinoma of breast]",
+            "content": "@name is a @age year old @gender presenting with @condition[[Invasive ductal carcinoma of breast]].\nDisease #disease status #Stable based on #Physical exam #as of #08/02/2015.",
 			"originalCreationDate": "02 AUG 2015",
 			"lastUpdateDate": "02 AUG 2015",
             "signed": true
@@ -66,7 +65,8 @@
 			"subject": "Consult",
 			"hospital": "Dana Farber Cancer Institute",
 			"clinician": "Dr. Zheng",
-			"originalCreationDate": "12 JUL 2012",
+            "content": "@patient presenting with @condition[[Invasive ductal carcinoma of breast]].\nPathology report indicates @name has #staging values #T1 #N1 and #M0, corresponding to @stage.",
+            "originalCreationDate": "12 JUL 2012",
 			"lastUpdateDate": "12 JUL 2012",
             "signed": true
 		},
@@ -79,7 +79,8 @@
 			"subject": "Clinical post-op",
 			"hospital": "Brigham and Women's Hospital",
 			"clinician": "Dr. Smith",
-			"originalCreationDate": "20 JUN 2012",
+            "content": "@patient presenting with @condition[[Invasive ductal carcinoma of breast]].\nToxicity of #Toxicity #Grade 4 #Anemia related to #Treatment",
+            "originalCreationDate": "20 JUN 2012",
 			"lastUpdateDate": "20 JUN 2012",
             "signed": true
 		},
@@ -92,7 +93,8 @@
 			"subject": "Clinical follow-up",
 			"hospital": "Dana Farber Cancer Institute",
 			"clinician": "Dr. Strauss",
-			"originalCreationDate": "16 MAY 2012",
+            "content": "@patient presenting with @condition[[Invasive ductal carcinoma of breast]].\n@name is enrolled in the #clinical trial #PATINA #enrolled on #12/24/2017.",
+            "originalCreationDate": "16 MAY 2012",
 			"lastUpdateDate": "16 MAY 2012",
             "signed": true
 		},

--- a/src/notes/EditorToolbar.jsx
+++ b/src/notes/EditorToolbar.jsx
@@ -32,27 +32,44 @@ class EditorToolbar extends React.Component {
      * When a mark button is clicked, toggle the current mark.
      */
     onClickMark = (e, type) => {
-        e.preventDefault()
-        this.handleMarkUpdate(type);
+
+        // Only handle click if not in read only mode
+        if (!this.props.isReadOnly) {
+            e.preventDefault()
+            this.handleMarkUpdate(type);
+        }
     }
 
     /**
      * When a block button is clicked, toggle the block type.
      */
     onClickBlock = (e, type) => {
-        e.preventDefault()
-        this.handleBlockUpdate(type);
+
+        // Only handle click if not in read only mode
+        if(!this.props.isReadOnly) {
+            e.preventDefault()
+            this.handleBlockUpdate(type);
+        }
     }
 
     /**
      * Render a mark-toggling toolbar button.
      */
     renderMarkButton = (type, icon) => {
+        let cursorStyle = "pointer";
+
+        // If editor is in read only, change the cursor to indicate button is not clickable
+        if (this.props.isReadOnly) {
+            cursorStyle = "default";
+        } else {
+            cursorStyle = "pointer";
+        }
+
         const isActive = this.handleMarkCheck(type)
         const onMouseDown = e => this.onClickMark(e, type)
 
         return (
-            <span className="button" onMouseDown={onMouseDown} data-active={isActive}>
+            <span className="button" style={{cursor:cursorStyle}} onMouseDown={onMouseDown} data-active={isActive}>
         <i className={"fa fa-fw " + icon} aria-label={"Make text " + type}></i>
       </span>
         )
@@ -61,11 +78,19 @@ class EditorToolbar extends React.Component {
      * Render a block-toggling toolbar button.
      */
     renderBlockButton = (type, icon) => {
+        let cursorStyle = "pointer";
+
+        // If editor is in read only, change the cursor to indicate button is not clickable
+        if (this.props.isReadOnly) {
+            cursorStyle = "default";
+        } else {
+            cursorStyle = "pointer";
+        }
         const isActive = this.handleBlockCheck(type + '-item')
         const onMouseDown = e => this.onClickBlock(e, type)
 
         return (
-            <span className="button" onMouseDown={onMouseDown} data-active={isActive}>
+            <span className="button" style={{cursor:cursorStyle}} onMouseDown={onMouseDown} data-active={isActive}>
         <i className={"fa fa-fw " + icon} aria-label={"Make text " + type}></i>
       </span>
         )

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -635,6 +635,8 @@ class FluxNotesEditor extends React.Component {
                         onMarkUpdate={this.handleMarkUpdate}
                         onBlockUpdate={this.handleBlockUpdate}
                         patient={this.props.patient}
+
+                        isReadOnly={this.isReadOnly}
                     />
                     <Slate.Editor
                         placeholder={'Enter your clinical note here or choose a template to start from...'}

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -387,8 +387,10 @@ class FluxNotesEditor extends React.Component {
 
         // Check if the item to be inserted is updated
         if (this.props.itemToBeInserted !== nextProps.itemToBeInserted && nextProps.itemToBeInserted.length > 0) {
-            this.insertTextWithStructuredPhrases(nextProps.itemToBeInserted);
-            this.props.itemInserted();
+            if (!this.isReadOnly) {
+                this.insertTextWithStructuredPhrases(nextProps.itemToBeInserted);
+                this.props.itemInserted();
+            }
         }
 
         // Check if the updatedEditorNote property has been updated
@@ -458,6 +460,7 @@ class FluxNotesEditor extends React.Component {
         //console.log(textToBeInserted);
         const triggers = this.noteParser.getListOfTriggersFromText(textToBeInserted)[0];
         //console.log(triggers);
+
         if (!Lang.isNull(triggers)) {
             triggers.forEach((trigger) => {
 

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -369,6 +369,9 @@ class FluxNotesEditor extends React.Component {
 
         // Check if the item to be inserted is updated
         if (this.props.itemToBeInserted !== nextProps.itemToBeInserted && nextProps.itemToBeInserted.length > 0) {
+
+            console.log("text to be inserted: ");
+            console.log(nextProps.itemToBeInserted);
             this.insertTextWithStructuredPhrases(nextProps.itemToBeInserted);
             this.props.itemInserted();
         }
@@ -389,6 +392,22 @@ class FluxNotesEditor extends React.Component {
 
                 // This clears the contexts so that the tray starts back at the patient context
                 this.contextManager.clearContexts();
+            } else {
+
+                this.resetEditorState();
+
+                // Calls parent function which resets updatedEditorNote to be null
+                this.props.handleUpdateEditorWithNote(null);
+
+                // This clears error messages from the editor
+                this.structuredFieldPlugin.clearStructuredFieldMap();
+
+                // This clears the contexts so that the tray starts back at the patient context
+                this.contextManager.clearContexts();
+                console.log("new note to load into editor:");
+                console.log(nextProps.updatedEditorNote.content);
+
+                this.insertTextWithStructuredPhrases(nextProps.updatedEditorNote.content.toString());
             }
         }
 

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -101,7 +101,6 @@ class FluxNotesEditor extends React.Component {
         this.onChange = this.onChange.bind(this);
         this.onSelectionChange = this.onSelectionChange.bind(this);
 
-
         this.noteParser = new NoteParser(this.props.shortcutManager, this.props.contextManager);
 
         // Set the initial state when the app is first constructed.
@@ -140,6 +139,8 @@ class FluxNotesEditor extends React.Component {
             this.suggestionsPluginInserters,
             this.structuredFieldPlugin
         ];
+
+        this.isReadOnly = false;
 
         // The logic below that builds the regular expression could possibly be replaced by the regular
         // expression stored in NoteParser (this.noteParser is instance variable). Only difference is
@@ -188,8 +189,25 @@ class FluxNotesEditor extends React.Component {
             portalOptions: null,
             left: 0,
             top: 0
-        }
+        };
+
+        this.isReadOnly = false;
     }
+
+    // Reset editor state and clear context
+    resetEditorAndContext() {
+        this.resetEditorState();
+
+        // Calls parent function which resets updatedEditorNote to be null
+        this.props.handleUpdateEditorWithNote(null);
+
+        // This clears error messages from the editor
+        this.structuredFieldPlugin.clearStructuredFieldMap();
+
+        // This clears the contexts so that the tray starts back at the patient context
+        this.contextManager.clearContexts();
+    }
+
 
     suggestionFunction(initialChar, text) {
         if (Lang.isUndefined(text)) return [];
@@ -369,9 +387,6 @@ class FluxNotesEditor extends React.Component {
 
         // Check if the item to be inserted is updated
         if (this.props.itemToBeInserted !== nextProps.itemToBeInserted && nextProps.itemToBeInserted.length > 0) {
-
-            console.log("text to be inserted: ");
-            console.log(nextProps.itemToBeInserted);
             this.insertTextWithStructuredPhrases(nextProps.itemToBeInserted);
             this.props.itemInserted();
         }
@@ -379,35 +394,27 @@ class FluxNotesEditor extends React.Component {
         // Check if the updatedEditorNote property has been updated
         if (this.props.updatedEditorNote !== nextProps.updatedEditorNote && !Lang.isNull(nextProps.updatedEditorNote)) {
 
-            // If the updated editor note is an empty string, then we are adding a new blank note. Call method to
+            // If the updated editor note is an empty string, then add a new blank note. Call method to
             // re initialize editor state and reset updatedEditorNote state in parent to be null
             if (nextProps.updatedEditorNote === "") {
-                this.resetEditorState();
+               this.resetEditorAndContext();
+            }
 
-                // Calls parent function which resets updatedEditorNote to be null
-                this.props.handleUpdateEditorWithNote(null);
+            // If the updated editor note is an actual note (existing note), then clear the editor and insert the
+            // content of the selected note into the editor and set the editor to read only
+            else {
 
-                // This clears error messages from the editor
-                this.structuredFieldPlugin.clearStructuredFieldMap();
+                this.resetEditorAndContext();
 
-                // This clears the contexts so that the tray starts back at the patient context
-                this.contextManager.clearContexts();
-            } else {
-
-                this.resetEditorState();
-
-                // Calls parent function which resets updatedEditorNote to be null
-                this.props.handleUpdateEditorWithNote(null);
-
-                // This clears error messages from the editor
-                this.structuredFieldPlugin.clearStructuredFieldMap();
-
-                // This clears the contexts so that the tray starts back at the patient context
-                this.contextManager.clearContexts();
-                console.log("new note to load into editor:");
-                console.log(nextProps.updatedEditorNote.content);
-
+                console.log("inserting text");
                 this.insertTextWithStructuredPhrases(nextProps.updatedEditorNote.content.toString());
+
+                // If the note is in progress, set readonly to false. If teh note is an existing note, set readonly to true
+                if (nextProps.updatedEditorNote.signed) {
+                    this.isReadOnly = true;
+                } else {
+                    this.isReadOnly = false;
+                }
             }
         }
 
@@ -629,6 +636,7 @@ class FluxNotesEditor extends React.Component {
                     <Slate.Editor
                         placeholder={'Enter your clinical note here or choose a template to start from...'}
                         plugins={this.plugins}
+                        readOnly={this.isReadOnly}
                         state={this.state.state}
                         ref={function (c) {
                             editor = c;

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -407,7 +407,11 @@ class FluxNotesEditor extends React.Component {
             else {
 
                 this.resetEditorAndContext();
-                this.insertTextWithStructuredPhrases(nextProps.updatedEditorNote.content.toString());
+
+                let stringToInsert = nextProps.updatedEditorNote.date + "\n" + nextProps.updatedEditorNote.subject
+                    + "\n" + nextProps.updatedEditorNote.hospital + "\n\n" + nextProps.updatedEditorNote.content;
+
+                this.insertTextWithStructuredPhrases(stringToInsert);
 
                 // If the note is in progress, set readOnly to false. If the note is an existing note, set readOnly to true
                 if (nextProps.updatedEditorNote.signed) {

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -408,10 +408,7 @@ class FluxNotesEditor extends React.Component {
 
                 this.resetEditorAndContext();
 
-                let stringToInsert = nextProps.updatedEditorNote.date + "\n" + nextProps.updatedEditorNote.subject
-                    + "\n" + nextProps.updatedEditorNote.hospital + "\n\n" + nextProps.updatedEditorNote.content;
-
-                this.insertTextWithStructuredPhrases(stringToInsert);
+                this.insertTextWithStructuredPhrases(nextProps.updatedEditorNote.content);
 
                 // If the note is in progress, set readOnly to false. If the note is an existing note, set readOnly to true
                 if (nextProps.updatedEditorNote.signed) {

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -397,7 +397,7 @@ class FluxNotesEditor extends React.Component {
             // If the updated editor note is an empty string, then add a new blank note. Call method to
             // re initialize editor state and reset updatedEditorNote state in parent to be null
             if (nextProps.updatedEditorNote === "") {
-               this.resetEditorAndContext();
+                this.resetEditorAndContext();
             }
 
             // If the updated editor note is an actual note (existing note), then clear the editor and insert the
@@ -405,11 +405,9 @@ class FluxNotesEditor extends React.Component {
             else {
 
                 this.resetEditorAndContext();
-
-                console.log("inserting text");
                 this.insertTextWithStructuredPhrases(nextProps.updatedEditorNote.content.toString());
 
-                // If the note is in progress, set readonly to false. If teh note is an existing note, set readonly to true
+                // If the note is in progress, set readOnly to false. If the note is an existing note, set readOnly to true
                 if (nextProps.updatedEditorNote.signed) {
                     this.isReadOnly = true;
                 } else {
@@ -420,10 +418,11 @@ class FluxNotesEditor extends React.Component {
 
         // Check if the current view mode changes
         if (this.props.currentViewMode !== nextProps.currentViewMode && !Lang.isNull(nextProps.currentViewMode)) {
-            this.resetEditorState();
+            this.resetEditorAndContext();
             this.props.handleUpdateEditorWithNote(null);
             this.structuredFieldPlugin.clearStructuredFieldMap();
             this.contextManager.clearContexts();
+            this.props.updateSelectedNote(null);
         }
     }
 
@@ -681,6 +680,7 @@ FluxNotesEditor.proptypes = {
     updateErrors: PropTypes.func.isRequired,
     errors: PropTypes.array.isRequired,
     resetEditorState: PropTypes.func.isRequired,
+    resetEditorAndContext: PropTypes.func.isRequired,
 }
 
 export default FluxNotesEditor;

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -13,16 +13,14 @@ class NoteAssistant extends Component {
         super(props);
 
         this.state = {
-            noteAssistantMode: "context-tray",
             sortIndex: null,
-            maxNotesToDisplay: 3,
-            selectedNote: null
+            maxNotesToDisplay: 3
         };
     }
 
-     notesNotDisplayed = null;
-     notesToDisplay = [];
-     inProgressNotes = [];
+    notesNotDisplayed = null;
+    notesToDisplay = [];
+    inProgressNotes = [];
 
     componentWillUpdate(nextProps, nextState) {
         this.getNotesFromPatient(nextProps);
@@ -32,7 +30,6 @@ class NoteAssistant extends Component {
         // Set default value for sort selection
         this.selectSort(0);
         this.getNotesFromPatient(this.props);
-        this.selectedNote = this.inProgressNotes[0];
     }
 
     getNotesFromPatient(props) {
@@ -48,13 +45,14 @@ class NoteAssistant extends Component {
 
         // Set the number of notes that are not being displayed
         let missingNotes = signedNotes.length - this.state.maxNotesToDisplay;
-            this.notesNotDisplayed = missingNotes;
-            this.inProgressNotes = unsignedNotes;
+        this.notesNotDisplayed = missingNotes;
+        this.inProgressNotes = unsignedNotes;
     }
 
     // Switch view (i.e clinical notes view or context tray)
     toggleView(mode) {
-        this.setState({noteAssistantMode: mode});
+        // this.setState({noteAssistantMode: mode});
+        this.props.updateNoteAssistantMode(mode);
     }
 
     // Update the selected index for the sort drop down
@@ -62,6 +60,7 @@ class NoteAssistant extends Component {
         this.setState({sortIndex: sortIndex});
     }
 
+    // Gets called when clicking on the "new note" button
     handleOnNewNoteButtonClick() {
         this.toggleView("context-tray");
         this.props.loadNote("");
@@ -78,18 +77,20 @@ class NoteAssistant extends Component {
         this.props.patient.addClinicalNote(date, subject, hospital, clinician, content, signed);
 
         // Deselect note in the clinical notes view
-        this.setState({ selectedNote: null });
+        this.props.updateSelectedNote(null);
     }
 
+    // Gets called when clicking on one of the notes in the clinical notes view
     openNote(isInProgressNote, note) {
-        this.setState({ selectedNote: note });
-        console.log("In Progress Note: " + isInProgressNote);
 
+        this.props.updateSelectedNote(note);
         this.props.loadNote(note);
 
-        // If the note selected is an In-Progress note, switch to the context tray
+        // If the note selected is an In-Progress note, switch to the context tray e;se use the clinical-notes view
         if (isInProgressNote) {
             this.toggleView("context-tray");
+        } else {
+            this.toggleView("clinical-notes");
         }
     }
 
@@ -105,7 +106,9 @@ class NoteAssistant extends Component {
                 // Render the context tray
                 return (
                     <div>
-                        <span className="button-hover clinical-notes-btn" onClick={() => { this.toggleView("clinical-notes")}}>
+                        <span className="button-hover clinical-notes-btn" onClick={() => {
+                            this.toggleView("clinical-notes")
+                        }}>
                             <i className="fa fa-arrow-left"></i>
                             Clinical Notes
                         </span>
@@ -148,16 +151,19 @@ class NoteAssistant extends Component {
     // Render the new note button
     renderNewNoteSVG() {
         return (
-            <svg className="note-new" onClick={() => this.handleOnNewNoteButtonClick()} viewBox="0 0 150 33" version="1.1"
+            <svg className="note-new" onClick={() => this.handleOnNewNoteButtonClick()} viewBox="0 0 150 33"
+                 version="1.1"
                  xmlns="http://www.w3.org/2000/svg">
                 <defs>
                     <path
                         d="M136.737204,0.069612193 L3.70678711,0.069612193 L3.70678711,0.069612193 C2.04993286,0.069612193 0.706787109,1.41275794 0.706787109,3.06961219 L0.706787109,3.06961219 L0.706787109,30 C0.706787109,31.6568542 2.04993286,33 3.70678711,33 L3.70678711,33 L146.214569,33 C147.871423,33 149.214569,31.6568542 149.214569,30 L149.214569,30 L149.214569,12.5469764 L136.737204,0.069612193 Z"
                         id="path-1"></path>
                 </defs>
-                <svg x="25" y="12" width="11px" height="11px" viewBox="0 0 11 11" version="1.1" xmlns="http://www.w3.org/2000/svg">
+                <svg x="25" y="12" width="11px" height="11px" viewBox="0 0 11 11" version="1.1"
+                     xmlns="http://www.w3.org/2000/svg">
                     <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd" strokeLinecap="square">
-                        <g id="Group-Copy-3" transform="translate(0.660429, 0.452719)" stroke="#16253E" strokeWidth="1.5552">
+                        <g id="Group-Copy-3" transform="translate(0.660429, 0.452719)" stroke="#16253E"
+                           strokeWidth="1.5552">
                             <path d="M0.465836188,4.96173944 L8.70583619,4.96173944" id="Line"></path>
                             <path d="M4.59517238,1.04666266 L4.59517238,9.28624923" id="Line-Copy"></path>
                         </g>
@@ -166,7 +172,7 @@ class NoteAssistant extends Component {
                 <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
                     <g id="Group-24">
                         <g id="Combined-Shape">
-                            <use fill="#FFFFFF" fillRule="evenodd" ></use>
+                            <use fill="#FFFFFF" fillRule="evenodd"></use>
                             <path stroke="#B3B3B3" strokeWidth="0.5"
                                   d="M136.633651,0.319612193 L3.70678711,0.319612193 C2.18800405,0.319612193 0.956787109,1.55082913 0.956787109,3.06961219 L0.956787109,30 C0.956787109,31.5187831 2.18800405,32.75 3.70678711,32.75 L146.214569,32.75 C147.733352,32.75 148.964569,31.5187831 148.964569,30 L148.964569,12.6505298 L136.633651,0.319612193 Z"></path>
                         </g>
@@ -184,11 +190,13 @@ class NoteAssistant extends Component {
     }
 
     renderInProgressNoteSVG(note, i) {
-        const selected = this.state.selectedNote === note;
+        const selected = this.props.selectedNote === note;
         const strokeColor = selected ? "#9ecfef" : "#B3B3B3";
         const strokeWidth = selected ? "2" : "0.5";
         return (
-            <svg key={i} className="note" id="in-progress-note" onClick={() => {this.openNote(true, note)}} viewBox="0 0 149 129" version="1.1"
+            <svg key={i} className="note" id="in-progress-note" onClick={() => {
+                this.openNote(true, note)
+            }} viewBox="0 0 149 129" version="1.1"
                  xmlns="http://www.w3.org/2000/svg">
                 <defs>
                     <path
@@ -252,12 +260,14 @@ class NoteAssistant extends Component {
 
     // For each clinical note, render the note image with the text
     renderClinicalNoteSVG(item, i) {
-        const selected = this.state.selectedNote === item;
+        const selected = this.props.selectedNote === item;
         const strokeColor = selected ? "#9ecfef" : "#B3B3B3";
         const strokeWidth = selected ? "2" : "0.5";
 
         return (
-            <svg key={i} className="note" onClick={() => {this.openNote(false, item)}} viewBox="0 0 149 102" version="1.1"
+            <svg key={i} className="note" onClick={() => {
+                this.openNote(false, item)
+            }} viewBox="0 0 149 102" version="1.1"
                  xmlns="http://www.w3.org/2000/svg">
                 <defs>
                     <path
@@ -324,9 +334,9 @@ class NoteAssistant extends Component {
             }
 
             return (
-                <text x="20" y={70+yOffset} className="existing-note-metadata">
-                    <tspan x="20" y={70+yOffset}>{hospitalFirstString}</tspan>
-                    <tspan x="20" y={85+yOffset}>{hospitalSecondString}</tspan>
+                <text x="20" y={70 + yOffset} className="existing-note-metadata">
+                    <tspan x="20" y={70 + yOffset}>{hospitalFirstString}</tspan>
+                    <tspan x="20" y={85 + yOffset}>{hospitalSecondString}</tspan>
                 </text>
             );
 
@@ -334,8 +344,8 @@ class NoteAssistant extends Component {
             hospitalFirstString = item.hospital;
 
             return (
-                <text x="20" y={70+yOffset} className="existing-note-metadata">
-                    <tspan x="20" y={70+yOffset}>{hospitalFirstString}</tspan>
+                <text x="20" y={70 + yOffset} className="existing-note-metadata">
+                    <tspan x="20" y={70 + yOffset}>{hospitalFirstString}</tspan>
                 </text>
             );
         }
@@ -360,7 +370,7 @@ class NoteAssistant extends Component {
 
             return (
                 <div>
-                    {this.renderNoteAssistantContent(this.state.noteAssistantMode)}
+                    {this.renderNoteAssistantContent(this.props.noteAssistantMode)}
                 </div>
             );
 

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -64,7 +64,7 @@ class NoteAssistant extends Component {
 
     handleOnNewNoteButtonClick() {
         this.toggleView("context-tray");
-        this.props.addNewNote("");
+        this.props.loadNote("");
 
         // Create info to be set for new note
         let date = "5 NOV 2016";
@@ -79,6 +79,7 @@ class NoteAssistant extends Component {
 
     openNote(note) {
         this.setState({ selectedNote: note });
+        this.props.loadNote(note);
     }
 
     // Render the content for the Note Assistant panel

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -265,7 +265,7 @@ class NoteAssistant extends Component {
         const strokeWidth = selected ? "2" : "0.5";
 
         return (
-            <svg key={i} className="note" onClick={() => {
+            <svg key={i} className="note" id="existing-note" onClick={() => {
                 this.openNote(false, item)
             }} viewBox="0 0 149 102" version="1.1"
                  xmlns="http://www.w3.org/2000/svg">

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -71,15 +71,26 @@ class NoteAssistant extends Component {
         let subject = "New Note";
         let hospital = "Dana Farber Cancer Institute";
         let clinician = "Dr. X123";
+        let content = "@name is a @age year old @gender born on @dateofbirth";
         let signed = false;
 
         // Add new unsigned note to patient record
-        this.props.patient.addClinicalNote(date, subject, hospital, clinician, signed);
+        this.props.patient.addClinicalNote(date, subject, hospital, clinician, content, signed);
+
+        // Deselect note in the clinical notes view
+        this.setState({ selectedNote: null });
     }
 
-    openNote(note) {
+    openNote(isInProgressNote, note) {
         this.setState({ selectedNote: note });
+        console.log("In Progress Note: " + isInProgressNote);
+
         this.props.loadNote(note);
+
+        // If the note selected is an In-Progress note, switch to the context tray
+        if (isInProgressNote) {
+            this.toggleView("context-tray");
+        }
     }
 
     // Render the content for the Note Assistant panel
@@ -177,7 +188,7 @@ class NoteAssistant extends Component {
         const strokeColor = selected ? "#9ecfef" : "#B3B3B3";
         const strokeWidth = selected ? "2" : "0.5";
         return (
-            <svg key={i} className="note" id="in-progress-note" onClick={() => {this.openNote(note)}} viewBox="0 0 149 129" version="1.1"
+            <svg key={i} className="note" id="in-progress-note" onClick={() => {this.openNote(true, note)}} viewBox="0 0 149 129" version="1.1"
                  xmlns="http://www.w3.org/2000/svg">
                 <defs>
                     <path
@@ -246,7 +257,7 @@ class NoteAssistant extends Component {
         const strokeWidth = selected ? "2" : "0.5";
 
         return (
-            <svg key={i} className="note" onClick={() => {this.openNote(item)}} viewBox="0 0 149 102" version="1.1"
+            <svg key={i} className="note" onClick={() => {this.openNote(false, item)}} viewBox="0 0 149 102" version="1.1"
                  xmlns="http://www.w3.org/2000/svg">
                 <defs>
                     <path

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -11,32 +11,50 @@ class NotesPanel extends Component {
         super(props);
 
         this.state = {
-            updatedEditorNote: null
+            updatedEditorNote: null,
+            noteAssistantMode: "context-tray",
+            selectedNote: null
         };
 
         this.handleUpdateEditorWithNote = this.handleUpdateEditorWithNote.bind(this);
+        this.updateNoteAssistantMode = this.updateNoteAssistantMode.bind(this);
+        this.updateSelectedNote = this.updateSelectedNote.bind(this);
+    }
+
+    updateNoteAssistantMode(mode) {
+        this.setState({noteAssistantMode: mode});
+    }
+
+    updateSelectedNote(note) {
+        this.setState({selectedNote: note});
     }
 
     // Handle when the editor needs to be updated with a note. The note can be a new blank note or a pre existing note
     handleUpdateEditorWithNote(note) {
 
-        // Check if the app is in pre-encounter and if the note editor should be visible
+        // If in pre-encounter mode and the note editor doesn't exist, update the layout and add the editor
+        // Set the note to be inserted into the editor and the selected note
         if (this.props.currentViewMode === 'pre-encounter' && !this.props.isNoteViewerVisible) {
 
-            console.log("note viewer not visible so set up layout");
-
-            // Change the layout so that the note editor is added to the view
-            this.props.setFullAppState("layout", "split");
-            this.props.setFullAppState("isNoteViewerVisible", true);
-            this.props.setFullAppState("isNoteViewerEditable", true);
-            // this.setState({updatedEditorNote: null});
-
-            //TODO: after setting up the layout need to insert the text into the editor. for some reason the note doesn't get updated after the layout is set
+            // *Note: setFullAppStateWithCallback is used instead of setFullAppState because the editor needs to be created
+            // before editor related states can be set
+            this.props.setFullAppStateWithCallback({
+                layout: 'split',
+                isNoteViewerVisible: true,
+                isNoteViewerEditable: true
+            }, () => {
+                if (this.props.isNoteViewerVisible) {
+                    this.setState({updatedEditorNote: note});
+                    this.setState({selectedNote: note});
+                }
+            });
         }
 
-        // Update the state so that updatedEditorNote has the note to update the editor with
-        this.setState({updatedEditorNote: note});
-
+        // This gets called in other modes besides pre-encounter mode. Check that the editor exists and then update the
+        // state so that updatedEditorNote has the note to update the editor with
+        if (this.props.isNoteViewerVisible) {
+            this.setState({updatedEditorNote: note});
+        }
     }
 
     renderNotesPanelContent() {
@@ -66,7 +84,7 @@ class NotesPanel extends Component {
         }
     }
 
-    renderFluxNotesEditor(){
+    renderFluxNotesEditor() {
         return (
             <div className="fitted-panel panel-content dashboard-panel">
                 <FluxNotesEditor
@@ -85,6 +103,7 @@ class NotesPanel extends Component {
                     handleUpdateEditorWithNote={this.handleUpdateEditorWithNote}
 
                     currentViewMode={this.props.currentViewMode}
+                    updateSelectedNote={this.updateSelectedNote}
                 />
             </div>
         );
@@ -100,6 +119,10 @@ class NotesPanel extends Component {
                     shortcutManager={this.props.shortcutManager}
                     handleSummaryItemSelected={this.props.handleSummaryItemSelected}
                     loadNote={this.handleUpdateEditorWithNote}
+                    noteAssistantMode={this.state.noteAssistantMode}
+                    updateNoteAssistantMode={this.updateNoteAssistantMode}
+                    selectedNote={this.state.selectedNote}
+                    updateSelectedNote={this.updateSelectedNote}
                 />
             </div>
         );

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -20,18 +20,23 @@ class NotesPanel extends Component {
     // Handle when the editor needs to be updated with a note. The note can be a new blank note or a pre existing note
     handleUpdateEditorWithNote(note) {
 
-        // Update the state so that updatedEditorNote has the note to update the editor with
-        this.setState({updatedEditorNote: note});
-
         // Check if the app is in pre-encounter and if the note editor should be visible
         if (this.props.currentViewMode === 'pre-encounter' && !this.props.isNoteViewerVisible) {
+
+            console.log("note viewer not visible so set up layout");
 
             // Change the layout so that the note editor is added to the view
             this.props.setFullAppState("layout", "split");
             this.props.setFullAppState("isNoteViewerVisible", true);
             this.props.setFullAppState("isNoteViewerEditable", true);
-            this.setState({updatedEditorNote: null});
+            // this.setState({updatedEditorNote: null});
+
+            //TODO: after setting up the layout need to insert the text into the editor. for some reason the note doesn't get updated after the layout is set
         }
+
+        // Update the state so that updatedEditorNote has the note to update the editor with
+        this.setState({updatedEditorNote: note});
+
     }
 
     renderNotesPanelContent() {

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -94,7 +94,7 @@ class NotesPanel extends Component {
                     contextManager={this.props.contextManager}
                     shortcutManager={this.props.shortcutManager}
                     handleSummaryItemSelected={this.props.handleSummaryItemSelected}
-                    addNewNote={this.handleUpdateEditorWithNote}
+                    loadNote={this.handleUpdateEditorWithNote}
                 />
             </div>
         );

--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -139,7 +139,7 @@ class PatientRecord {
     }
 
     // Add initial unsigned note to patient record
-    addClinicalNote(date, subject, hospital, clinician, signed) {
+    addClinicalNote(date, subject, hospital, clinician, content, signed) {
 
         // Generate the clinical note json from passed in values
         let clinicalNote = new ClinicalNote(
@@ -148,6 +148,7 @@ class PatientRecord {
                 "subject": subject,
                 "hospital": hospital,
                 "clinician": clinician,
+                "content": content,
                 "signed": signed
             }
         );

--- a/test/ui/FullApp.js
+++ b/test/ui/FullApp.js
@@ -163,8 +163,6 @@ test('In pre-encounter mode, clicking the "New Note" button clears the editor co
         .eql("Enter your clinical note here or choose a template to start from...");
 });
 
-
-
 test('Typing an inserterShortcut in the editor results in a structured data insertion ', async t => {
     const editor = Selector("div[data-slate-editor='true']");
     await t
@@ -481,6 +479,132 @@ test('Clicking New Note button adds a new in progress note to the list', async t
     await t
         .expect(inProgressNotesUpdatedLength).eql(inProgressNotesLength+1);
 });
+
+test('Clicking on an existing note in post encounter mode loads the note in the editor', async t => {
+    const editor = Selector("div[data-slate-editor='true']");
+    const clinicalNotesButton = Selector('.clinical-notes-btn');
+    const note = Selector('#existing-note');
+
+    // Click on the clinical notes button to switch to clinical notes view
+    await t
+        .click(clinicalNotesButton);
+
+    // Click on one of the existing notes
+    await t
+        .click(note)
+
+    // Test that there is some text in the editor and that the editor is not in its initial cleared state
+    await t
+        .expect(editor.textContent)
+        .notEql("Enter your clinical note here or choose a template to start from...");
+})
+
+test('Clicking on an existing note in post encounter mode puts the NotesPanel in a read only mode with the clinical notes view displayed', async t => {
+    const editor = Selector("div[data-slate-editor='true']");
+    const clinicalNotesButton = Selector('.clinical-notes-btn');
+    const clinicalNotesPanel = Selector('.clinical-notes-panel');
+    const note = Selector('#existing-note');
+
+    // Click on the clinical notes button to switch to clinical notes view
+    await t
+        .click(clinicalNotesButton);
+
+    // Click on one of the existing notes
+    await t
+        .click(note)
+
+    // Try to type random text in the editor
+    await t
+        .typeText(editor, "random_text")
+
+    // Because editor is read only, expect that text cannot be entered
+    await t
+        .expect(editor.textContent).notContains('random_text', 'Editor content does not contain the text "random_text"');
+
+    // Expect to see the clinical notes view (not the context tray)
+    await t
+        .expect(clinicalNotesPanel.exists)
+        .ok()
+})
+
+test('Clicking on an in-progress note in post encounter mode loads the note in the editor', async t => {
+    const editor = Selector("div[data-slate-editor='true']");
+    const clinicalNotesButton = Selector('.clinical-notes-btn');
+    const newNoteButton = Selector('.note-new');
+    const inProgressNotes = Selector('#in-progress-note');
+
+    // Click on the clinical notes button to switch to clinical notes view
+    await t
+        .click(clinicalNotesButton);
+
+    // Click on the new note button to create an in-progress note and toggle back to clinical notes view
+    await t
+        .click(newNoteButton)
+        .click(clinicalNotesButton);
+
+    // Click on the in-progress note
+    await t
+        .click(inProgressNotes)
+
+    // Test that there is some text in the editor and that the editor is not in its initial cleared state
+    await t
+        .expect(editor.textContent)
+        .notEql("Enter your clinical note here or choose a template to start from...");
+})
+
+test('Clicking on an in-progress note in post encounter mode puts the NotesPanel in edit mode with the context tray displayed', async t => {
+    const editor = Selector("div[data-slate-editor='true']");
+    const clinicalNotesButton = Selector('.clinical-notes-btn');
+    const newNoteButton = Selector('.note-new');
+    const inProgressNotes = Selector('#in-progress-note');
+    const contextTray = Selector('.context-tray');
+
+    // Click on the clinical notes button to switch to clinical notes view
+    await t
+        .click(clinicalNotesButton);
+
+    // Click on the new note button to create an in-progress note and toggle back to clinical notes view
+    await t
+        .click(newNoteButton)
+        .click(clinicalNotesButton);
+
+    // Click on the in-progress note
+    await t
+        .click(inProgressNotes)
+
+    // Try to type random text in the editor (added a space because chrome created a strange character if no space)
+    await t
+        .typeText(editor, " random_text")
+
+    // Because editor is in edit mode, expect that text can be entered
+    await t
+        .expect(editor.textContent).contains('random_text', 'Editor content contains the text "random_text"');
+
+    // Expect to see the context tray (not the clinical notes view)
+    await t
+        .expect(contextTray.exists)
+        .ok()
+})
+
+test('Clicking on an existing note in pre encounter mode loads the note in the editor', async t => {
+    const clinicalEventSelector = Selector('.clinical-event-select');
+    const editor = Selector("div[data-slate-editor='true']");
+    const note = Selector('#existing-note');
+
+    // Select pre-encounter mode
+    await t
+        .click(clinicalEventSelector)
+        .click(Selector('[data-test-clinical-event-selector-item="Pre-encounter"]'));
+
+    // Click on one of the existing notes
+    await t
+        .click(note)
+
+    // Test that there is some text in the editor and that the editor is not in its initial cleared state
+    await t
+        .expect(editor.textContent)
+        .notEql("Enter your clinical note here or choose a template to start from...");
+})
 
 
 fixture('Patient Mode - Targeted Data Panel')


### PR DESCRIPTION
In post-encounter mode:
- Switching to clinical notes view and clicking an existing note loads the note into the editor in readonly mode. Users cannot enter text into the editor since this is readonly. The note assistant stays in clinical notes view
- Switching to clinical notes view and clicking add new note, then clicking back to clinical notes view and clicking on the newly added in-progress note loads the note into the editor in edit mode. Users can type and edit the note since the note is in-progress and is not yet signed. The note assistant switches to the context tray

In pre-encounter mode;
- Switching to pre-encounter mode and clicking on an existing note adds the editor to the layout and inserts the content of the selected note in read only mode
- Switching to pre-encounter mode, clicking on add new note, switching to clinical notes view, and selecting the in progress note loads the note into the editor in edit mode

Added UI tests to test the above cases

This PR does not look at saving notes. That is covered in another jira task


_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- N/A Cheat sheet is updated
- N/A Demo script is updated 
- N/A Documentation on Wiki has been updated 
- N/A Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- N/A Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- N/A Added UI tests for slim mode 
- [x] Added UI tests for full mode
- N/A Added backend tests for fluxNotes code
- N/A Added note parser examples to test new functionality


## Reviewer 1: Noranda

- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
