### PR TITLE
New allergies inserter

### DIFF
--- a/src/dataaccess/HardCodedPatient.json
+++ b/src/dataaccess/HardCodedPatient.json
@@ -466,5 +466,14 @@
 			"whenClinicallyRecognized": {"generalizedTemporalContext": { "timePeriodStart": "13 JUN 2017" } },
 			"originalCreationDate": "13 JUN 2017",
 			"lastUpdateDate": "13 JUN 2017"
-		}
+		},
+        {
+			"shrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+			"entryId": "28",
+			"entryType": 	[ "http://standardhealthrecord.org/allergy/AllergyIntolerance" ],
+			"focalSubject": {"entryType": "http://standardhealthrecord.org/demographics/PersonOfRecord", "shrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "entryId": "1"},
+			"allergenIrritant": {"value": {"coding": [{"value": "412533000", "codeSystem": {"value": "http://snomed.info/sct"}, "displayText": "Wheat Bran"}]}},
+			"originalCreationDate": "13 JUN 2015",
+			"lastUpdateDate": "13 JUN 2015"
+        }
 ]

--- a/src/dataaccess/HardCodedPatient.json
+++ b/src/dataaccess/HardCodedPatient.json
@@ -475,5 +475,14 @@
 			"allergenIrritant": {"value": {"coding": [{"value": "412533000", "codeSystem": {"value": "http://snomed.info/sct"}, "displayText": "Wheat Bran"}]}},
 			"originalCreationDate": "13 JUN 2015",
 			"lastUpdateDate": "13 JUN 2015"
+        },
+        {
+			"shrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+			"entryId": "29",
+			"entryType": 	[ "http://standardhealthrecord.org/allergy/AllergyIntolerance" ],
+			"focalSubject": {"entryType": "http://standardhealthrecord.org/demographics/PersonOfRecord", "shrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "entryId": "1"},
+			"allergenIrritant": {"value": {"coding": [{"value": "412533000", "codeSystem": {"value": "http://snomed.info/sct"}, "displayText": "Wheat Bran"}]}},
+			"originalCreationDate": "13 JUN 2015",
+			"lastUpdateDate": "13 JUN 2015"
         }
 ]

--- a/src/dataaccess/HardCodedPatient.json
+++ b/src/dataaccess/HardCodedPatient.json
@@ -481,7 +481,7 @@
 			"entryId": "29",
 			"entryType": 	[ "http://standardhealthrecord.org/allergy/AllergyIntolerance" ],
 			"focalSubject": {"entryType": "http://standardhealthrecord.org/demographics/PersonOfRecord", "shrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "entryId": "1"},
-			"allergenIrritant": {"value": {"coding": [{"value": "412533000", "codeSystem": {"value": "http://snomed.info/sct"}, "displayText": "Wheat Bran"}]}},
+			"allergenIrritant": {"value": {"coding": [{"value": "70813002", "codeSystem": {"value": "http://snomed.info/sct"}, "displayText": "Milk - dietary"}]}},
 			"originalCreationDate": "13 JUN 2015",
 			"lastUpdateDate": "13 JUN 2015"
         }

--- a/src/dataaccess/HardCodedPatient.json
+++ b/src/dataaccess/HardCodedPatient.json
@@ -484,5 +484,14 @@
 			"allergenIrritant": {"value": {"coding": [{"value": "70813002", "codeSystem": {"value": "http://snomed.info/sct"}, "displayText": "Milk - dietary"}]}},
 			"originalCreationDate": "13 JUN 2015",
 			"lastUpdateDate": "13 JUN 2015"
+        },
+        {
+			"shrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+			"entryId": "30",
+			"entryType": 	[   "http://standardhealthrecord.org/allergy/NoKnownDrugAllergy",
+                                "http://standardhealthrecord.org/allergy/AllergyIntolerance" ],
+			"focalSubject": {"entryType": "http://standardhealthrecord.org/demographics/PersonOfRecord", "shrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "entryId": "1"},
+			"originalCreationDate": "13 JUN 2015",
+			"lastUpdateDate": "13 JUN 2015"
         }
 ]

--- a/src/model/ShrAllergyObjectFactory.js
+++ b/src/model/ShrAllergyObjectFactory.js
@@ -1,0 +1,17 @@
+import Lang from 'lodash';
+import AllergyIntolerance from './shr/allergy/AllergyIntolerance';
+import NoKnownDrugAllergy from './shr/allergy/NoKnownDrugAllergy';
+
+export default class ShrAllergyObjectFactory {
+    static createInstance(elementName, entry) {
+        const _elementsToClassNames = { 
+                                "AllergyIntolerance": AllergyIntolerance,
+                                "NoKnownDrugAllergy": NoKnownDrugAllergy
+                              };
+
+        let constructorName = _elementsToClassNames[elementName];
+        if (Lang.isUndefined(constructorName)) throw new Error("Unsupported class in factory '" + this.name + "': '" + elementName + "'");
+        return new constructorName(entry);
+    }
+    
+}

--- a/src/model/ShrObjectFactory.js
+++ b/src/model/ShrObjectFactory.js
@@ -1,4 +1,5 @@
 import ShrActorObjectFactory from './ShrActorObjectFactory';
+import ShrAllergyObjectFactory from './ShrAllergyObjectFactory';
 import ShrBaseObjectFactory from './ShrBaseObjectFactory';
 import ShrConditionObjectFactory from './ShrConditionObjectFactory';
 import ShrCoreObjectFactory from './ShrCoreObjectFactory';
@@ -22,6 +23,7 @@ const _entryTypeToClassSpec = (entryType) => {
 
 const namespaceFactories = {
     "actor": ShrActorObjectFactory,
+    "allergy": ShrAllergyObjectFactory,
     "base": ShrBaseObjectFactory,
     "condition": ShrConditionObjectFactory,
     "core": ShrCoreObjectFactory,

--- a/src/model/shr/allergy/AllergenIrritant.js
+++ b/src/model/shr/allergy/AllergenIrritant.js
@@ -1,5 +1,12 @@
+import CodeableConcept from '../core/CodeableConcept';
+
 /** Generated from SHR definition for shr.allergy.AllergenIrritant */
 class AllergenIrritant {
+    constructor(json) {
+        if (json) {
+            if (json.value) this.value = new CodeableConcept(json.value);
+        }
+    }
 
   /**
    * Convenience getter for value (accesses this.codeableConcept)

--- a/src/model/shr/allergy/AllergyIntolerance.js
+++ b/src/model/shr/allergy/AllergyIntolerance.js
@@ -1,5 +1,16 @@
+import AllergenIrritant from './AllergenIrritant';
+import Entry from '../base/Entry';
+
 /** Generated from SHR definition for shr.allergy.AllergyIntolerance */
 class AllergyIntolerance {
+    constructor(json) {
+        if (json) {
+            this._entryInfo = new Entry(json);
+            if (json.allergenIrritant) this._allergenIrritant = new AllergenIrritant(json.allergenIrritant);
+        } else {
+            this._entryInfo = Entry.createEntry("http://standardhealthrecord.org/allergy/AllergyIntolerance");
+        }
+    }
 
   /**
    * Getter for entry information (shr.base.Entry)

--- a/src/model/shr/allergy/NoKnownAllergy.js
+++ b/src/model/shr/allergy/NoKnownAllergy.js
@@ -1,7 +1,17 @@
 import AllergyIntolerance from './AllergyIntolerance';
+import Entry from '../base/Entry';
 
 /** Generated from SHR definition for shr.allergy.NoKnownAllergy */
 class NoKnownAllergy extends AllergyIntolerance {
+    constructor(json) {
+        super(json);
+        if (json) {
+            this._entryInfo = new Entry(json);
+        } else {
+            this._entryInfo = Entry.createEntry("http://standardhealthrecord.org/allergy/NoKnownAllergy",
+                                                "http://standardhealthrecord.org/allergy/AllergyIntolerance");
+        }
+    }
 
   /**
    * Getter for entry information (shr.base.Entry)

--- a/src/model/shr/allergy/NoKnownDrugAllergy.js
+++ b/src/model/shr/allergy/NoKnownDrugAllergy.js
@@ -1,7 +1,17 @@
 import AllergyIntolerance from './AllergyIntolerance';
+import Entry from '../base/Entry';
 
 /** Generated from SHR definition for shr.allergy.NoKnownDrugAllergy */
 class NoKnownDrugAllergy extends AllergyIntolerance {
+    constructor(json) {
+        super(json);
+        if (json) {
+            this._entryInfo = new Entry(json);
+        } else {
+            this._entryInfo = Entry.createEntry("http://standardhealthrecord.org/allergy/NoKnownDrugAllergy",
+                                                "http://standardhealthrecord.org/allergy/AllergyIntolerance");
+        }
+    }
 
   /**
    * Getter for entry information (shr.base.Entry)

--- a/src/model/shr/allergy/NoKnownEnvironmentalAllergy.js
+++ b/src/model/shr/allergy/NoKnownEnvironmentalAllergy.js
@@ -1,7 +1,17 @@
 import AllergyIntolerance from './AllergyIntolerance';
+import Entry from '../base/Entry';
 
 /** Generated from SHR definition for shr.allergy.NoKnownEnvironmentalAllergy */
 class NoKnownEnvironmentalAllergy extends AllergyIntolerance {
+    constructor(json) {
+        super(json);
+        if (json) {
+            this._entryInfo = new Entry(json);
+        } else {
+            this._entryInfo = Entry.createEntry("http://standardhealthrecord.org/allergy/NoKnownEnvironmentalAllergy",
+                                                "http://standardhealthrecord.org/allergy/AllergyIntolerance");
+        }
+    }
 
   /**
    * Getter for entry information (shr.base.Entry)

--- a/src/model/shr/allergy/NoKnownFoodAllergy.js
+++ b/src/model/shr/allergy/NoKnownFoodAllergy.js
@@ -1,7 +1,17 @@
 import AllergyIntolerance from './AllergyIntolerance';
+import Entry from '../base/Entry';
 
 /** Generated from SHR definition for shr.allergy.NoKnownFoodAllergy */
 class NoKnownFoodAllergy extends AllergyIntolerance {
+    constructor(json) {
+        super(json);
+        if (json) {
+            this._entryInfo = new Entry(json);
+        } else {
+            this._entryInfo = Entry.createEntry("http://standardhealthrecord.org/allergy/NoKnownFoodAllergy",
+                                                "http://standardhealthrecord.org/allergy/AllergyIntolerance");
+        }
+    }
 
   /**
    * Getter for entry information (shr.base.Entry)

--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -1,4 +1,5 @@
 import ShrObjectFactory from '../model/ShrObjectFactory';
+import AllergyIntolerance from '../model/shr/allergy/AllergyIntolerance';
 import BreastCancer from '../model/shr/oncology/BreastCancer';
 import ClinicalNote from '../model/shr/core/ClinicalNote';
 import Condition from '../model/shr/condition/Condition';
@@ -130,6 +131,25 @@ class PatientRecord {
 
     getConditions() {
         let result = this.getEntriesIncludingType(Condition);
+        return result;
+    }
+    
+    getAllergies() {
+        let result = this.getEntriesIncludingType(AllergyIntolerance);
+        return result;
+    }
+    
+    getAllergiesAsText() {
+        const allergies = this.getAllergies();
+        let result = "";
+        let first = true;
+        allergies.forEach((allergy, index) => {
+            if (!first) {
+                result += "\r\n";
+            }
+            result += allergy.allergenIrritant.value.coding[0].displayText.value;
+            first = false;
+        });
         return result;
     }
 

--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -4,6 +4,10 @@ import BreastCancer from '../model/shr/oncology/BreastCancer';
 import ClinicalNote from '../model/shr/core/ClinicalNote';
 import Condition from '../model/shr/condition/Condition';
 import FluxMedicationPrescription from '../model/medication/FluxMedicationPrescription';
+import NoKnownAllergy from '../model/shr/allergy/NoKnownAllergy';
+import NoKnownDrugAllergy from '../model/shr/allergy/NoKnownDrugAllergy';
+import NoKnownEnvironmentalAllergy from '../model/shr/allergy/NoKnownEnvironmentalAllergy';
+import NoKnownFoodAllergy from '../model/shr/allergy/NoKnownFoodAllergy';
 import PatientIdentifier from '../model/shr/base/PatientIdentifier';
 import PersonOfRecord from '../model/shr/demographics/PersonOfRecord';
 import Photograph from '../model/shr/demographics/Photograph';
@@ -130,13 +134,11 @@ class PatientRecord {
     }
 
     getConditions() {
-        let result = this.getEntriesIncludingType(Condition);
-        return result;
+        return this.getEntriesIncludingType(Condition);
     }
     
     getAllergies() {
-        let result = this.getEntriesIncludingType(AllergyIntolerance);
-        return result;
+        return this.getEntriesIncludingType(AllergyIntolerance);
     }
     
     getAllergiesAsText() {
@@ -147,7 +149,17 @@ class PatientRecord {
             if (!first) {
                 result += "\r\n";
             }
-            result += allergy.allergenIrritant.value.coding[0].displayText.value;
+            if (allergy instanceof NoKnownDrugAllergy) {
+                result += "NKDA";
+            } else if (allergy instanceof NoKnownAllergy) {
+                result += "No known allergies";
+            } else if (allergy instanceof NoKnownEnvironmentalAllergy) {
+                result += "No known environmental allergies";
+            } else if (allergy instanceof NoKnownFoodAllergy) {
+                result += "No known food allergies";
+            } else {
+                result += allergy.allergenIrritant.value.coding[0].displayText.value;
+            }
             first = false;
         });
         return result;

--- a/src/shortcuts/Shortcuts.json
+++ b/src/shortcuts/Shortcuts.json
@@ -354,5 +354,12 @@
     "contextValueObjectEntryType": "http://standardhealthrecord.org/oncology/BreastCancer",
     "knownParentContexts": "ConditionInserter",
     "description": "Human epidermal growth factor receptor 2 (HER2) is a protein involved in normal cell growth. It is found on some types of cancer cells (HER2 positive), including breast and ovarian. Cancer cells removed from the body may be tested for the presence of human epidermal growth factor receptor 2 to help decide the best type of treatment."
+  },
+  { "type": "InsertValue",
+    "id": "StageInserter",
+    "getData": {"object": "patient", "attribute": "stage"},
+    "isContext": false,
+    "stringTriggers": [{"name":"@allergies", "description": "Insert a summary of patient allergies"}],
+    "knownParentContexts": "Patient"
   }
 ]

--- a/src/shortcuts/Shortcuts.json
+++ b/src/shortcuts/Shortcuts.json
@@ -356,8 +356,8 @@
     "description": "Human epidermal growth factor receptor 2 (HER2) is a protein involved in normal cell growth. It is found on some types of cancer cells (HER2 positive), including breast and ovarian. Cancer cells removed from the body may be tested for the presence of human epidermal growth factor receptor 2 to help decide the best type of treatment."
   },
   { "type": "InsertValue",
-    "id": "StageInserter",
-    "getData": {"object": "patient", "attribute": "stage"},
+    "id": "AllergiesInserter",
+    "getData": {"object": "patient", "method": "getAllergiesAsText"},
     "isContext": false,
     "stringTriggers": [{"name":"@allergies", "description": "Insert a summary of patient allergies"}],
     "knownParentContexts": "Patient"


### PR DESCRIPTION
JIRA 817.

Added some allergies to hard coded patient (on client side only right now). Implemented @allergies shortcut that inserts a summary of allergies for the patient. Just outputs names right now. Unfortunately, it looks like latest SHR model has changed substantially on web site vs. what our generated classes are.  As soon as ES6 classes have deserialization methods from SHR JSON and from FHIR, we can update which could be a lot of work.

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [X] Manually tested in Chrome
- [X] Manually tested in IE

**Documentation**

- [X] This pull request describes why these changes were made
- [X] Recognizes any potential shortcomings/bugs in the description 
- [N/A ] Cheat sheet is updated
- [N/A ] Demo script is updated 
- [N/A ] Documentation on Wiki has been updated 
- [N/A ] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [N/A ] Note parser has been updated if structured phrases change

**Code Quality**

- [X] 4-space indents - convert any tabs to spaces
- [X] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [X] Code is commented

**Tests**

- [X] Existing tests passed
- [N/A ] Added UI tests for slim mode 
- [N/A ] Added UI tests for full mode
- [N/A ] Added backend tests for fluxNotes code
- [N/A ] Added note parser examples to test new functionality


## Reviewer 1: Nicole

- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
