### PR TITLE
loading a note back into editor no longer updates patient

### DIFF
--- a/src/containers/FullApp.jsx
+++ b/src/containers/FullApp.jsx
@@ -85,8 +85,8 @@ class FullApp extends Component {
     }
 
     // Given a shortcutClass, a type and an object, create a new shortcut and change errors is needed.
-    newCurrentShortcut = (shortcutC, shortcutType, obj) => {
-        let newShortcut = this.shortcutManager.createShortcut(shortcutC, shortcutType, this.handleShortcutUpdate, obj);
+    newCurrentShortcut = (shortcutC, shortcutType, updatePatient = true) => {
+        let newShortcut = this.shortcutManager.createShortcut(shortcutC, shortcutType, this.handleShortcutUpdate);
         const errors = newShortcut.validateInCurrentContext(this.contextManager);
         if (errors.length > 0) {
             errors.forEach((error) => {
@@ -94,7 +94,7 @@ class FullApp extends Component {
             });
             newShortcut = null;
         } else {
-            newShortcut.initialize(this.contextManager, shortcutType);
+            newShortcut.initialize(this.contextManager, shortcutType, updatePatient);
         }
         this.updateErrors(errors);
         return newShortcut;

--- a/src/context/Context.jsx
+++ b/src/context/Context.jsx
@@ -4,7 +4,7 @@ export default class Context {
 	constructor() {
 		this.children = [];
 	}
-	initialize(contextManager) {
+	initialize(contextManager, trigger = undefined, updatePatient = true) {
         this.contextManager = contextManager;
         this.isInContext = false;
 	}
@@ -51,7 +51,7 @@ export default class Context {
 	getAttributeValue(name) {
 		throw new Error("[getAttributeValue]Unsupported attribute " + name + " for context shortcut " + this.constructor.name);
 	}
-	setAttributeValue(name, value, publishChanges) {
+	setAttributeValue(name, value, publishChanges, updatePatient = true) {
 		throw new Error("[setAttributeValue]Unsupported attribute " + name + " for context shortcut " + this.constructor.name);
 	}
     shouldBeInContext() {

--- a/src/dataaccess/HardCodedPatient.json
+++ b/src/dataaccess/HardCodedPatient.json
@@ -51,7 +51,7 @@
 			"subject": "Clinical follow-up",
 			"hospital": "Dana Farber Cancer Institute",
 			"clinician": "Dr. Smith",
-            "content": "@name is a @age year old @gender presenting with @condition[[Invasive ductal carcinoma of breast]].\nDisease #disease status #Stable based on #Physical exam #as of #08/02/2015.",
+            "content": "@name is a @age year old @gender presenting with @condition[[Invasive ductal carcinoma of breast]].\nDisease #disease status #Stable based on #Pathology and #Symptoms #as of #08/02/2015.",
 			"originalCreationDate": "02 AUG 2015",
 			"lastUpdateDate": "02 AUG 2015",
             "signed": true
@@ -65,7 +65,7 @@
 			"subject": "Consult",
 			"hospital": "Dana Farber Cancer Institute",
 			"clinician": "Dr. Zheng",
-            "content": "@patient presenting with @condition[[Invasive ductal carcinoma of breast]].\nPathology report indicates @name has #staging values #T1 #N1 and #M0, corresponding to @stage.",
+            "content": "@patient presenting with @condition[[Invasive ductal carcinoma of breast]].\nPathology report indicates @name has staging values T1 N1 and M0, corresponding to stage IIA.",
             "originalCreationDate": "12 JUL 2012",
 			"lastUpdateDate": "12 JUL 2012",
             "signed": true
@@ -79,7 +79,7 @@
 			"subject": "Clinical post-op",
 			"hospital": "Brigham and Women's Hospital",
 			"clinician": "Dr. Smith",
-            "content": "@patient presenting with @condition[[Invasive ductal carcinoma of breast]].\nToxicity of #Toxicity #Grade 4 #Anemia related to #Treatment",
+            "content": "@patient presenting with @condition[[Invasive ductal carcinoma of breast]].\nToxicity Grade 4 Anemia related to Treatment",
             "originalCreationDate": "20 JUN 2012",
 			"lastUpdateDate": "20 JUN 2012",
             "signed": true
@@ -93,7 +93,7 @@
 			"subject": "Clinical follow-up",
 			"hospital": "Dana Farber Cancer Institute",
 			"clinician": "Dr. Strauss",
-            "content": "@patient presenting with @condition[[Invasive ductal carcinoma of breast]].\n@name is enrolled in the #clinical trial #PATINA #enrolled on #12/24/2017.",
+            "content": "@patient presenting with @condition[[Invasive ductal carcinoma of breast]].\n@name is enrolled in the clinical trial PATINA on 12/24/2017.",
             "originalCreationDate": "16 MAY 2012",
 			"lastUpdateDate": "16 MAY 2012",
             "signed": true
@@ -408,13 +408,13 @@
 			"value": { "coding": [{ "value": "C0205360", "codeSystem": {"value":"http://ncimeta.nci.nih.gov"}, "displayText": "Stable, neither improving nor worsening"}]},
 			"assessmentFocus": [{"entryType": "http://standardhealthrecord.org/condition/Condition", "shrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "entryId": "8"}],
 			"clinicallyRelevantTime": {"value": "13 JAN 2012"},
-			"asOfDate": "14 JUN 2015",
+			"asOfDate": "2 AUG 2015",
 			"evidence": [ 	{ "coding": [{ "value": "C0030664", "codeSystem": {"value":"http://ncimeta.nci.nih.gov"}, "displayText": "pathology"}]},
 							{ "coding": [{ "value": "C1457887", "codeSystem": {"value":"http://ncimeta.nci.nih.gov"}, "displayText": "symptoms"}]} ],
 			"assessmentType": { "coding": [{ "value": "#disease status"}]},
 			"status": "completed",
-			"originalCreationDate": "14 JUN 2015",
-			"lastUpdateDate": "14 JUN 2015"
+			"originalCreationDate": "2 AUG 2015",
+			"lastUpdateDate": "2 AUG 2015"
 		},
 		{
 			"shrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -244,11 +244,11 @@ class FluxNotesEditor extends React.Component {
         }
     }
 
-    insertShortcut(shortcutC, shortcutTrigger, text, transform = undefined) {
+    insertShortcut(shortcutC, shortcutTrigger, text, transform = undefined, updatePatient = true) {
         if (Lang.isUndefined(transform)) {
             transform = this.state.state.transform();
         }
-        let shortcut = this.props.newCurrentShortcut(shortcutC, shortcutTrigger);
+        let shortcut = this.props.newCurrentShortcut(shortcutC, shortcutTrigger, updatePatient);
         if (!Lang.isNull(shortcut) && shortcut.needToSelectValueFromMultipleOptions()) {
 //            console.log(text);
             if (text.length > 0) {
@@ -336,7 +336,7 @@ class FluxNotesEditor extends React.Component {
     insertStructuredFieldTransform(transform, shortcut) {
         //console.log(shortcut);
         if (Lang.isNull(shortcut)) return transform.focus();
-        let result = this.structuredFieldPlugin.transforms.insertStructuredField(transform, shortcut); //2nd param needs to be Shortcut Object, how to create?
+        let result = this.structuredFieldPlugin.transforms.insertStructuredField(transform, shortcut);
         //console.log(result[0]);
         return result[0];
     }
@@ -408,7 +408,7 @@ class FluxNotesEditor extends React.Component {
 
                 this.resetEditorAndContext();
 
-                this.insertTextWithStructuredPhrases(nextProps.updatedEditorNote.content);
+                this.insertTextWithStructuredPhrases(nextProps.updatedEditorNote.content, undefined, false);
 
                 // If the note is in progress, set readOnly to false. If the note is an existing note, set readOnly to true
                 if (nextProps.updatedEditorNote.signed) {
@@ -447,7 +447,7 @@ class FluxNotesEditor extends React.Component {
     /*
      * Handle updates when we have a new
      */
-    insertTextWithStructuredPhrases = (textToBeInserted, currentTransform = undefined) => {
+    insertTextWithStructuredPhrases = (textToBeInserted, currentTransform = undefined, updatePatient = true) => {
         let state;
         const currentState = this.state.state;
 
@@ -495,7 +495,7 @@ class FluxNotesEditor extends React.Component {
                     after = "";
                 }
 
-                transform = this.insertShortcut(trigger.definition, trigger.trigger, after, transform);
+                transform = this.insertShortcut(trigger.definition, trigger.trigger, after, transform, updatePatient);
             });
         }
 

--- a/src/shortcuts/CreatorBase.jsx
+++ b/src/shortcuts/CreatorBase.jsx
@@ -44,8 +44,8 @@ export default class CreatorBase extends Shortcut {
         this.setAttributeValue = this.setAttributeValue.bind(this);
     }
 
-    initialize(contextManager) {
-        super.initialize(contextManager);
+    initialize(contextManager, trigger = undefined, updatePatient = true) {
+        super.initialize(contextManager, trigger, updatePatient);
 
         const knownParent = this.metadata["knownParentContexts"];
 
@@ -63,7 +63,7 @@ export default class CreatorBase extends Shortcut {
         const metadataVOA = this.metadata["valueObjectAttributes"];
         metadataVOA.forEach((attrib) => {
             if (attrib.isSettable && attrib.type !== "list") {
-                this.setAttributeValue(attrib.name, null);
+                this.setAttributeValue(attrib.name, null, true, updatePatient);
             }
         });
     }
@@ -261,7 +261,7 @@ export default class CreatorBase extends Shortcut {
         }
     }
 
-    setAttributeValue(name, value, publishChanges = true) {
+    setAttributeValue(name, value, publishChanges = true, updatePatient = true) {
         //console.log("setAttributeValue " + name + " to " + value);
         const voa = this.valueObjectAttributes[name];
         if (Lang.isUndefined(voa)) throw new Error("Unknown attribute '" + name + "' for structured phrase '" + this.text + "'");
@@ -302,7 +302,7 @@ export default class CreatorBase extends Shortcut {
             }
         }
         if (this.isContext()) this.updateContextStatus();
-        if (this.onUpdate) this.onUpdate(this);
+        if (this.onUpdate && updatePatient) this.onUpdate(this);
         if (publishChanges) {
             this.notifyValueChangeHandlers(name);
         }

--- a/src/shortcuts/CreatorChild.jsx
+++ b/src/shortcuts/CreatorChild.jsx
@@ -13,8 +13,8 @@ export default class CreatorChild extends Shortcut {
         return "#";
     }
 
-    initialize(contextManager, trigger) {
-        super.initialize(contextManager);
+    initialize(contextManager, trigger, updatePatient = true) {
+        super.initialize(contextManager, trigger, updatePatient);
         let text = this.determineText(contextManager);
         if (!Lang.isUndefined(text)) {
             if (Lang.isArray(text) || text === 'date-id') {
@@ -55,7 +55,7 @@ export default class CreatorChild extends Shortcut {
         }
         if (!found || !picker) {
             //console.log("not found: " + trigger);
-            this.setText(trigger);
+            this.setText(trigger, updatePatient);
             this.clearValueSelectionOptions();
         }
     }
@@ -108,7 +108,7 @@ export default class CreatorChild extends Shortcut {
         }
     }
 
-    setText(text) {
+    setText(text, updatePatient = true) {
         if (text.startsWith('#')) {
             text = text.substring(1);
         }
@@ -120,7 +120,7 @@ export default class CreatorChild extends Shortcut {
         }
         if (!Lang.isUndefined(this.parentContext)) {
             //console.log("set " + this.metadata.parentAttribute + " to " + value);
-            this.parentContext.setAttributeValue(this.metadata.parentAttribute, value, false);
+            this.parentContext.setAttributeValue(this.metadata.parentAttribute, value, false, updatePatient);
         }
     }
 

--- a/src/shortcuts/CreatorIntermediary.jsx
+++ b/src/shortcuts/CreatorIntermediary.jsx
@@ -12,8 +12,8 @@ export default class CreatorIntermediary extends Shortcut {
         this.setAttributeValue = this.setAttributeValue.bind(this);
     }
 
-    initialize(contextManager) {
-        super.initialize(contextManager);
+    initialize(contextManager, trigger = undefined, updatePatient = true) {
+        super.initialize(contextManager, trigger, updatePatient);
 
         const knownParent = this.metadata["knownParentContexts"];
 
@@ -24,7 +24,7 @@ export default class CreatorIntermediary extends Shortcut {
         }
 
         if (!Lang.isUndefined(this.parentContext)) {
-            this.parentContext.setAttributeValue(this.metadata["parentAttribute"], true, false);
+            this.parentContext.setAttributeValue(this.metadata["parentAttribute"], true, false, updatePatient);
             this.parentContext.addChild(this);
         }
     }
@@ -110,13 +110,13 @@ export default class CreatorIntermediary extends Shortcut {
         }
     }
 
-    setAttributeValue(name, value, publishChanges = true) {
+    setAttributeValue(name, value, publishChanges = true, updatePatient = true) {
         const voaList = this.metadata["valueObjectAttributes"];
         let result = voaList.filter(function (item) {
             return item.name === name;
         });
         if (result && result[0]) {
-            this.parentContext.setAttributeValue(result[0].toParentAttribute, value, publishChanges);
+            this.parentContext.setAttributeValue(result[0].toParentAttribute, value, publishChanges, updatePatient);
             if (this.isContext()) this.updateContextStatus();
         } else {
             throw new Error("Unknown attribute " + name + " on " + this.metadata["id"]);

--- a/src/shortcuts/InsertValue.jsx
+++ b/src/shortcuts/InsertValue.jsx
@@ -8,8 +8,8 @@ export default class InsertValue extends Shortcut {
 		this.text = null;
     }
     
-	initialize(contextManager) {
-		super.initialize(contextManager);
+	initialize(contextManager, trigger = undefined, updatePatient = true) {
+		super.initialize(contextManager, trigger, updatePatient);
 		let text = this.determineText(contextManager);
 		if (Lang.isArray(text)) {
 			this.flagForTextSelection(text);

--- a/src/shortcuts/Shortcut.jsx
+++ b/src/shortcuts/Shortcut.jsx
@@ -12,8 +12,8 @@ class Shortcut extends Context {
         this.valueChangeHandlers = {};
     }
     
-    initialize(contextManager) {
-        super.initialize(contextManager);
+    initialize(contextManager, trigger = undefined, updatePatient = true) {
+        super.initialize(contextManager, trigger, updatePatient);
     }
 
     setConfiguration(config) {


### PR DESCRIPTION
Loading a note back into editor no longer updates patient at all. It should have done that when it was created!

Cleaned up ShortcutManager code. Also updated clinical notes in hard coded patient to match structured data better. Took some hash tags out to support data curation scenarios later where corresponding structured data didn't exist.

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [ ] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [ ] This pull request describes why these changes were made
- [ ] Recognizes any potential shortcomings/bugs in the description 
- [ ] Cheat sheet is updated
- [ ] Demo script is updated 
- [ ] Documentation on Wiki has been updated 
- [ ] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [ ] Note parser has been updated if structured phrases change

**Code Quality**

- [ ] 4-space indents - convert any tabs to spaces
- [ ] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [ ] Code is commented

**Tests**

- [ ] Existing tests passed
- [ ] Added UI tests for slim mode 
- [ ] Added UI tests for full mode
- [ ] Added backend tests for fluxNotes code
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
