### PR TITLE
Implemented new context tray vertical list design

### DIFF
--- a/public/icons/icon_arrow_left.svg
+++ b/public/icons/icon_arrow_left.svg
@@ -1,0 +1,9 @@
+<svg width="90px" height="59px" viewBox="0 0 90 59" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 45.2 (43514) - http://www.bohemiancoding.com/sketch -->
+    <title>Shape</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <path d="M33.6,1.2 C34.4,2 34.8,3 34.8,4 C34.8,5 34.4,6 33.6,6.8 L15.4,25 L86,25 C88.2,25 90,26.8 90,29 C90,31.2 88.2,33 86,33 L15.4,33 L33.6,51.2 C35.2,52.8 35.2,55.3 33.6,56.9 C32,58.5 29.5,58.5 27.9,56.9 L0,29 L27.9,1.2 C29.5,-0.4 32,-0.4 33.6,1.2 Z" id="Shape" fill="#000000" fill-rule="nonzero"></path>
+    </g>
+</svg>

--- a/src/containers/FullApp.jsx
+++ b/src/containers/FullApp.jsx
@@ -5,13 +5,14 @@ import {MuiThemeProvider, createMuiTheme} from 'material-ui/styles';
 import lightBlue from 'material-ui/colors/purple';
 import green from 'material-ui/colors/green';
 import red from 'material-ui/colors/red';
+import Lang from 'lodash';
+
 import DashboardManager from '../dashboard/DashboardManager'
 import ShortcutManager from '../shortcuts/ShortcutManager';
 import ContextManager from '../context/ContextManager';
 import DataAccess from '../dataaccess/DataAccess';
 import SummaryMetadata from '../summary/SummaryMetadata';
 import PatientControlPanel from '../panels/PatientControlPanel';
-import Lang from 'lodash';
 import '../styles/FullApp.css';
 
 const theme = createMuiTheme({

--- a/src/context/ContextManager.jsx
+++ b/src/context/ContextManager.jsx
@@ -9,19 +9,19 @@ class ContextManager {
 		this.activeContexts = []; // patient context is always active
 		this.onContextUpdate = onContextUpdate;
 	}
-    
+
     setIsBlock1BeforeBlock2(isBlock1BeforeBlock2) {
         this.isBlock1BeforeBlock2 = isBlock1BeforeBlock2;
     }
-    
+
     getIsBlock1BeforeBlock2() {
         return this.isBlock1BeforeBlock2;
     }
-    
+
 	getActiveContexts() {
 		return this.activeContexts;
 	}
-	
+
 	getCurrentlyValidShortcuts(shortcutManager) {
 		//let result = this.patientContext.getValidChildShortcuts(true);
         let result = shortcutManager.getValidChildShortcutsInContext(this.patientContext, true);
@@ -40,27 +40,27 @@ class ContextManager {
 	isContextOfTypeActive(contextType) {
 		return !Lang.isUndefined(this.getActiveContextOfType(contextType));
 	}
-	
+
 	isContextOfTypeWithValueOfTypeActive(contextType, valueType) {
 		let shortcut = this.getActiveContextOfType(contextType);
 		if (Lang.isUndefined(shortcut)) return false;
 		let object = shortcut.getValueObject();
 		return (object.entryInfo.entryType[0] === valueType);
 	}
-	    
+
 	// returns undefined if not found
 	getActiveContextOfType(contextType) {
-        //console.log(this.activeContexts);
 		let context = this.activeContexts.find((item) => {
 			return (item.getShortcutType() === contextType);
 		});
+
 		return context;
 	}
 
 	contextUpdated() {
 		this.onContextUpdate();
 	}
-    	
+
     adjustActiveContexts(shouldContextBeActive) {
         this.activeContexts = [];
         this.contexts.forEach((context) => {
@@ -69,7 +69,7 @@ class ContextManager {
             }
         });
     }
-	
+
 	addShortcutToContext(shortcut) {
         if (!shortcut.getKey()) return; // if the key hasn't been set for a shortcut yet then it shouldn't be added
         //console.log("adding shortcut to context: " + shortcut.getShortcutType());
@@ -95,7 +95,7 @@ class ContextManager {
 			if (this.onContextUpdate) { this.onContextUpdate(); }
 		}
 	}
-    
+
     removeShortcutFromContext(shortcut) {
         var index = -1;
         this.contexts.forEach((item, i) => {
@@ -103,10 +103,10 @@ class ContextManager {
         });
         if (index === -1) throw new Error("Unable to remove shortcut because not found in contexts.");
         this.contexts.splice(index, 1);
-        
+
         this.removeShortcutFromActiveContexts(shortcut);
     }
-    
+
     removeShortcutFromActiveContexts(shortcut) {
         var index = -1;
         this.activeContexts.forEach((item, i) => {
@@ -119,11 +119,11 @@ class ContextManager {
 	getPatient() {
 		return this.patient;
 	}
-	
+
 	getPatientContext() {
 		return this.patientContext;
 	}
-    
+
     getCurrentContext() {
         const mostRecentContext = this.activeContexts[0];
         if (!Lang.isUndefined(mostRecentContext) || !Lang.isNull(mostRecentContext)) {

--- a/src/context/ContextOptions.css
+++ b/src/context/ContextOptions.css
@@ -1,10 +1,14 @@
-.btn_template_ctx {
-    width: 98%;
-    margin-left: 2px;
-    margin-right: 2px;
-    margin-bottom: 20px;
-    min-width: 10px !important;
-    background-color: white !important;
+.context-option {
+    margin: 10px 20px;
+    cursor: pointer;
+    font-size: 0.9em;
+    color: #999;
+}
+
+.context-option:hover,
+.context-option.selected {
+    color: #555;
+    font-weight: bold;
 }
 
 .context-options-list {
@@ -17,6 +21,29 @@
     background-color: #ffffff;
     text-align: left;
     margin-bottom: 15px;
+}
+
+.shortcut-search-container {
+    position: relative;
+    display: inline-block;
+}
+
+.shortcut-search-title {
+    margin: 0 20px 15px;
+    font-size: 0.9em;
+}
+
+.shortcut-search-title .count {
+    font-style: italic;
+}
+
+.shortcut-search-text {
+    left: 20px;
+    font-size: 0.9em;
+}
+
+.hidden {
+    display: none;
 }
 
 /*
@@ -32,4 +59,11 @@
 
 .context-panel-tooltip .large .rc-tooltip-inner{
     width: 220px;
+}
+
+#data-element-description {
+    margin: 0 20px;
+    padding-top: 10px;
+    font-size: 0.9em;
+    font-style: italic;
 }

--- a/src/context/ContextOptions.css
+++ b/src/context/ContextOptions.css
@@ -29,7 +29,7 @@
 }
 
 .shortcut-search-title {
-    margin: 0 20px 15px;
+    margin: 0 20px 5px;
     font-size: 0.9em;
 }
 
@@ -39,7 +39,7 @@
 
 .shortcut-search-text {
     left: 20px;
-    font-size: 0.9em;
+    font-size: 0.8em;
 }
 
 .hidden {

--- a/src/context/ContextOptions.jsx
+++ b/src/context/ContextOptions.jsx
@@ -3,9 +3,7 @@ import PropTypes from 'prop-types';
 import Lang from 'lodash';
 import Tooltip from 'rc-tooltip';
 import TextField from 'material-ui/TextField';
-import { Row, Col } from 'react-flexbox-grid';
 
-import Button from '../elements/Button';
 import 'rc-tooltip/assets/bootstrap.css';
 import './ContextOptions.css'
 
@@ -79,7 +77,7 @@ export default class ContextOptions extends Component {
         let currentGroup = { group: "", triggers:[] };
         let countToShow = 0;
         let totalShown = 0;
-          triggers.forEach((trigger, i) => {
+        triggers.forEach((trigger, i) => {
             if (trigger.group !== currentGroup.group) {
                 countToShow = 0;
                 totalShown++;
@@ -87,83 +85,75 @@ export default class ContextOptions extends Component {
                 groupList.push(currentGroup);
             }
             else {
-                if(countToShow === 5) return;
+                if (countToShow === 5) return;
+
                 countToShow++;
                 totalShown++;
                 currentGroup.triggers.push(trigger);
             }
-
         });
 
         // do we add search bar
         let filterBar = "";
         if (showFilter) {
             filterBar = (
-            <div id="shortcut-search">
-                <div style={{position: 'relative', display: 'inline-block'}}>
-                    <div style={{display: 'flex', justifyContent:'center',alignItems: 'center'}}><h1>Filter:&nbsp;&nbsp;</h1><span>(Showing {totalShown} of {count})</span></div>
-                    <TextField
-                        style={{textIndent: 25, left: "15%", textAlign: "left", minWidth: "80%", width: "100%"}}
-                        label="Search for a shortcut"
-                        value={this.state.searchString}
-                        onChange={(event) => this._handleSearch(event.target.value)}
-                    />
+                <div id="shortcut-search">
+                    <div className="shortcut-search-container">
+                        <div className="shortcut-search-title">
+                            <div>Filter:</div>
+                            <div className="count">(showing {totalShown} of {count})</div>
+                        </div>
+
+                        <TextField
+                            className="shortcut-search-text"
+                            label="Search for a shortcut"
+                            value={this.state.searchString}
+                            onChange={(event) => this._handleSearch(event.target.value)}
+                        />
+                    </div>
                 </div>
-            </div>
             );
         }
 
-        let numCols, maxCols = 0;
-        let numChars, maxChars = 0;
-        groupList.forEach((groupObj, i) => {
-            numCols = groupObj.triggers.length;
-            groupObj.triggers.forEach((trigger) => {
-                numChars = trigger.name.length;
-                if (numChars > maxChars) maxChars = numChars;
-            });
-            if (numCols > maxCols) maxCols = numCols;
-        });
+        const activeContextTriggers = this.props.contextManager.getActiveContexts().map(({ initiatingTrigger }) => initiatingTrigger);
 
-        let colWidth = Math.ceil(maxChars / 2.5);
-
-        // now iterate and create a Row for each group and a Col for each
         return (
             <div className='context-options-list'>
                 {filterBar}
+
                 {groupList.map((groupObj, i) => {
                     return  (
                     <div key={`group-${i}`}>
-                    {groupObj.groupName !== "" ?<p id="data-element-description">{groupObj.groupName}</p>: ""}
-                        <Row key={i} start="sm">
+                        {groupObj.groupName != null ? <div id="data-element-description">{groupObj.groupName}</div> : <div className="hidden"></div>}
+
+                        <div key={i}>
                             {groupObj.triggers.map((trigger, i) => {
                                 const tooltipClass = (trigger.description.length > 100) ? "context-panel-tooltip large" : "context-panel-tooltip";
                                 const text = <span>{trigger.description}</span>
 
                                 return (
-                                    <Col sm={colWidth > 0 ? colWidth : null} key={i*100+1}>
-                                        <Tooltip
+                                    <Tooltip
+                                        key={trigger.name}
+                                        overlayStyle={{'visibility': this.state.tooltipVisibility}}
+                                        placement="left"
+                                        overlayClassName={tooltipClass}
+                                        overlay={text}
+                                        destroyTooltipOnHide={true}
+                                        mouseEnterDelay={0.5}
+                                        onMouseEnter={this.mouseEnter}
+                                        onMouseLeave={this.mouseLeave}
+                                    >
+                                        <div
+                                            className={`context-option${activeContextTriggers.indexOf(trigger.name) > -1 ? ' selected' : ''}`}
                                             key={trigger.name}
-                                            overlayStyle={{'visibility': this.state.tooltipVisibility}}
-                                            placement="top"
-                                            overlayClassName={tooltipClass}
-                                            overlay={text}
-                                            destroyTooltipOnHide={true}
-                                            mouseEnterDelay={0.5}
-                                            onMouseEnter={this.mouseEnter}
-                                            onMouseLeave={this.mouseLeave}
+                                            onClick={(e) => this._handleClick(e, trigger.name)}
                                         >
-                                            <Button dense raised
-                                                className='btn_template_ctx'
-                                                key={trigger.name}
-                                                onClick={(e) => this._handleClick(e, trigger.name)}
-                                            >
-                                                {trigger.name}
-                                            </Button>
-                                        </Tooltip>
-                                    </Col>
+                                            {trigger.name}
+                                        </div>
+                                    </Tooltip>
                                 );
                             })}
-                        </Row>
+                        </div>
                     </div>);
                 })}
             </div>

--- a/src/context/ContextOptions.jsx
+++ b/src/context/ContextOptions.jsx
@@ -109,7 +109,7 @@ export default class ContextOptions extends Component {
 
                         <TextField
                             className="shortcut-search-text"
-                            label="Search for a shortcut"
+                            label="Search shortcuts"
                             value={this.state.searchString}
                             onChange={(event) => this._handleSearch(event.target.value)}
                         />

--- a/src/context/ContextOptions.jsx
+++ b/src/context/ContextOptions.jsx
@@ -93,6 +93,10 @@ export default class ContextOptions extends Component {
             }
         });
 
+        if (totalShown === 0) {
+            return null;
+        }
+
         // do we add search bar
         let filterBar = "";
         if (showFilter) {
@@ -118,45 +122,47 @@ export default class ContextOptions extends Component {
         const activeContextTriggers = this.props.contextManager.getActiveContexts().map(({ initiatingTrigger }) => initiatingTrigger);
 
         return (
-            <div className='context-options-list'>
-                {filterBar}
+            <section>
+                <div className='context-options-list'>
+                    {filterBar}
 
-                {groupList.map((groupObj, i) => {
-                    return  (
-                    <div key={`group-${i}`}>
-                        {groupObj.groupName != null ? <div id="data-element-description">{groupObj.groupName}</div> : <div className="hidden"></div>}
+                    {groupList.map((groupObj, i) => {
+                        return (
+                        <div key={`group-${i}`}>
+                            {groupObj.groupName != null ? <div id="data-element-description">{groupObj.groupName}</div> : <div className="hidden"></div>}
 
-                        <div key={i}>
-                            {groupObj.triggers.map((trigger, i) => {
-                                const tooltipClass = (trigger.description.length > 100) ? "context-panel-tooltip large" : "context-panel-tooltip";
-                                const text = <span>{trigger.description}</span>
+                            <div key={i}>
+                                {groupObj.triggers.map((trigger, i) => {
+                                    const tooltipClass = (trigger.description.length > 100) ? "context-panel-tooltip large" : "context-panel-tooltip";
+                                    const text = <span>{trigger.description}</span>
 
-                                return (
-                                    <Tooltip
-                                        key={trigger.name}
-                                        overlayStyle={{'visibility': this.state.tooltipVisibility}}
-                                        placement="left"
-                                        overlayClassName={tooltipClass}
-                                        overlay={text}
-                                        destroyTooltipOnHide={true}
-                                        mouseEnterDelay={0.5}
-                                        onMouseEnter={this.mouseEnter}
-                                        onMouseLeave={this.mouseLeave}
-                                    >
-                                        <div
-                                            className={`context-option${activeContextTriggers.indexOf(trigger.name) > -1 ? ' selected' : ''}`}
+                                    return (
+                                        <Tooltip
                                             key={trigger.name}
-                                            onClick={(e) => this._handleClick(e, trigger.name)}
+                                            overlayStyle={{'visibility': this.state.tooltipVisibility}}
+                                            placement="left"
+                                            overlayClassName={tooltipClass}
+                                            overlay={text}
+                                            destroyTooltipOnHide={true}
+                                            mouseEnterDelay={0.5}
+                                            onMouseEnter={this.mouseEnter}
+                                            onMouseLeave={this.mouseLeave}
                                         >
-                                            {trigger.name}
-                                        </div>
-                                    </Tooltip>
-                                );
-                            })}
-                        </div>
-                    </div>);
-                })}
-            </div>
+                                            <div
+                                                className={`context-option${activeContextTriggers.indexOf(trigger.name) > -1 ? ' selected' : ''}`}
+                                                key={trigger.name}
+                                                onClick={(e) => this._handleClick(e, trigger.name)}
+                                            >
+                                                {trigger.name}
+                                            </div>
+                                        </Tooltip>
+                                    );
+                                })}
+                            </div>
+                        </div>);
+                    })}
+                </div>
+            </section>
         );
     }
 }

--- a/src/context/ContextOptions.jsx
+++ b/src/context/ContextOptions.jsx
@@ -44,7 +44,6 @@ export default class ContextOptions extends Component {
             context = this.props.contextManager.getPatientContext();
         }
 
-        //console.log(context);
         let validShortcuts = this.props.shortcutManager.getValidChildShortcutsInContext(context);
 
         // count how many triggers we have
@@ -119,7 +118,12 @@ export default class ContextOptions extends Component {
             );
         }
 
-        const activeContextTriggers = this.props.contextManager.getActiveContexts().map(({ initiatingTrigger }) => initiatingTrigger);
+        // generates list of active triggers (triggers that have at least 1 shortcut)
+        // used to bold the active triggers in the sidebar
+        const activeContextTriggers = this.props.contextManager.getActiveContexts()
+            .map((context) => ({ context, shortcuts: this.props.shortcutManager.getValidChildShortcutsInContext(context) }))
+            .filter(({ shortcuts }) => shortcuts.length > 0)
+            .map(({ context }) => context.initiatingTrigger);
 
         return (
             <section>

--- a/src/context/ContextOptions.jsx
+++ b/src/context/ContextOptions.jsx
@@ -1,14 +1,15 @@
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Lang from 'lodash'
-import Button from '../elements/Button';
+import Lang from 'lodash';
 import Tooltip from 'rc-tooltip';
 import TextField from 'material-ui/TextField';
-import {Row, Col} from 'react-flexbox-grid';
+import { Row, Col } from 'react-flexbox-grid';
+
+import Button from '../elements/Button';
 import 'rc-tooltip/assets/bootstrap.css';
 import './ContextOptions.css'
 
-class ContextOptions extends Component {
+export default class ContextOptions extends Component {
     constructor(props) {
         super(props);
         this._handleClick = this._handleClick.bind(this);
@@ -22,20 +23,20 @@ class ContextOptions extends Component {
 
     _handleClick(e, i) {
         e.preventDefault();
-        this.setState({searchString: "", tooltipVisibility: 'hidden'});
+        this.setState({ searchString: "", tooltipVisibility: 'hidden' });
         this.props.handleClick(i);
     }
-    
+
     mouseLeave = () => {
-        this.setState({tooltipVisibility: 'hidden'})
+        this.setState({ tooltipVisibility: 'hidden' })
     }
-    
+
     mouseEnter = () => {
-        this.setState({tooltipVisibility: 'visible'})
+        this.setState({ tooltipVisibility: 'visible' })
     }
-    
+
     _handleSearch(value) {
-        this.setState({searchString: value});
+        this.setState({ searchString: value });
     }
 
     render() {
@@ -44,7 +45,7 @@ class ContextOptions extends Component {
             // patient
             context = this.props.contextManager.getPatientContext();
         }
-        
+
         //console.log(context);
         let validShortcuts = this.props.shortcutManager.getValidChildShortcutsInContext(context);
 
@@ -75,14 +76,14 @@ class ContextOptions extends Component {
 
         // lets create a list of groups with associated shortcut triggers for each
         let groupList = [];
-        let currentGroup = {group: "", triggers:[]};
+        let currentGroup = { group: "", triggers:[] };
         let countToShow = 0;
         let totalShown = 0;
           triggers.forEach((trigger, i) => {
             if (trigger.group !== currentGroup.group) {
                 countToShow = 0;
                 totalShown++;
-                currentGroup = {"group": trigger.group, "groupName": trigger.groupName, "triggers": [ trigger ]};
+                currentGroup = { "group": trigger.group, "groupName": trigger.groupName, "triggers": [ trigger ] };
                 groupList.push(currentGroup);
             }
             else {
@@ -122,7 +123,9 @@ class ContextOptions extends Component {
             });
             if (numCols > maxCols) maxCols = numCols;
         });
+
         let colWidth = Math.ceil(maxChars / 2.5);
+
         // now iterate and create a Row for each group and a Col for each
         return (
             <div className='context-options-list'>
@@ -131,10 +134,11 @@ class ContextOptions extends Component {
                     return  (
                     <div key={`group-${i}`}>
                     {groupObj.groupName !== "" ?<p id="data-element-description">{groupObj.groupName}</p>: ""}
-                    <Row key={i} start="sm">
+                        <Row key={i} start="sm">
                             {groupObj.triggers.map((trigger, i) => {
                                 const tooltipClass = (trigger.description.length > 100) ? "context-panel-tooltip large" : "context-panel-tooltip";
                                 const text = <span>{trigger.description}</span>
+
                                 return (
                                     <Col sm={colWidth > 0 ? colWidth : null} key={i*100+1}>
                                         <Tooltip
@@ -159,19 +163,17 @@ class ContextOptions extends Component {
                                     </Col>
                                 );
                             })}
-                     </Row>
-                     </div>);
+                        </Row>
+                    </div>);
                 })}
             </div>
         );
     }
 }
 
-ContextOptions.proptypes = { 
+ContextOptions.proptypes = {
     shortcutManager: PropTypes.object.isRequired,
     contextManager: PropTypes.object.isRequired,
     handleClick: PropTypes.func.isRequired,
     context: PropTypes.object,
 }
-
-export default ContextOptions;

--- a/src/context/ContextTray.css
+++ b/src/context/ContextTray.css
@@ -1,20 +1,3 @@
-.tabs-container > div > div > div {
-    background: white !important;
-}
-
-.tabs-container div button:not(.tab) {
-    background: white !important;
-    color: black !important;
-}
-.tabs-container div div svg {
-    background: white !important;
-    color: black !important;
-}
-
-.tabs-container div .tab{
-    color: black !important;
-}
-
 .context-tray {
   margin: 20px 0;
 }

--- a/src/context/ContextTray.css
+++ b/src/context/ContextTray.css
@@ -14,3 +14,18 @@
 .tabs-container div .tab{
     color: black !important;
 }
+
+.context-tray {
+  margin-bottom: 40px;
+}
+
+.context-tray section {
+  padding: 20px 0;
+  border-bottom: 1px solid #ddd;
+}
+
+.context-tray .section-item {
+  padding: 5px 20px;
+  font-size: 0.9em;
+  cursor: pointer;
+}

--- a/src/context/ContextTray.css
+++ b/src/context/ContextTray.css
@@ -16,11 +16,11 @@
 }
 
 .context-tray {
-  margin-bottom: 40px;
+  margin: 20px 0;
 }
 
 .context-tray section {
-  padding: 20px 0;
+  padding: 10px 0;
   border-bottom: 1px solid #ddd;
 }
 
@@ -28,4 +28,9 @@
   padding: 5px 20px;
   font-size: 0.9em;
   cursor: pointer;
+}
+
+.context-tray .section-item:hover,
+.context-tray .section-item.selected {
+  font-weight: bold;
 }

--- a/src/context/ContextTray.jsx
+++ b/src/context/ContextTray.jsx
@@ -62,9 +62,21 @@ export default class ContextTray extends Component {
         return (
             <div className="context-tray">
                 <section>
-                    <div className={`section-item${value === 0 ? ' selected' : ''}`} onClick={this.handleTemplateSectionClick}>Templates</div>
-                    <div className={`section-item${value > 0 ? ' selected' : ''}`} onClick={this.handlePatientSectionClick}>Patient</div>
+                    <div
+                        className={`section-item${value === 0 ? ' selected' : ''}`}
+                        onClick={this.handleTemplateSectionClick}
+                    >
+                        Templates
+                    </div>
+
+                    <div
+                        className={`section-item${value > 0 ? ' selected' : ''}`}
+                        onClick={this.handlePatientSectionClick}
+                    >
+                        Patient
+                    </div>
                 </section>
+
                 {value === 0 &&
                     <section>
                         <TemplateForm
@@ -75,6 +87,7 @@ export default class ContextTray extends Component {
                         />
                     </section>
                 }
+
                 {value > 0 &&
                     <ContextOptions
                         contextManager={this.props.contextManager}
@@ -82,6 +95,7 @@ export default class ContextTray extends Component {
                         handleClick={this.handleShortcutClick}
                     />
                 }
+
                 {value > 0 && activeContexts.map((context, i) =>
                     <ContextOptions
                         key={i}

--- a/src/context/ContextTray.jsx
+++ b/src/context/ContextTray.jsx
@@ -1,133 +1,109 @@
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import Lang from 'lodash';
+
 import TemplateForm from '../forms/TemplateForm';
-import Tabs, {Tab} from 'material-ui/Tabs';
-import Lang from 'lodash'
 import ContextOptions from './ContextOptions';
 import './ContextTray.css';
 
-function TabContainer(props) {
-  return (
-    <div style={{ paddingTop: '15px' }}>
-      {props.children}
-    </div>
-  );
-}
 
-class ContextTray extends Component {
-    /*
-     need to listen for enterwithinStructuredField and exitwithinStructuredField events. when get an enter, set the showing state
-     to the correct entry form for the structured field. on exit, set to null.
-     */
-    templates = [{name: 'op note', content: 'op note'}, {name: 'follow-up', content:'follow up'}, {name:'consult note', content: '@patient presenting with '}];
-
-    state = {
-        value: 1,
-    };
-
+export default class ContextTray extends Component {
     constructor(props) {
         super(props);
-        
-        this.handleChange = this.handleChange.bind(this);
-        this._insertTemplate = this._insertTemplate.bind(this);
-        this._handleShortcutClick = this._handleShortcutClick.bind(this);
-        this.lastActiveContextCount = 0;
+
+        this.state = {
+            value: 1,
+            lastActiveContextCount: 0,
+            templates: [
+                { name: 'op note', content: 'op note' },
+                { name: 'follow-up', content: 'follow up' },
+                { name: 'consult note', content: '@patient presenting with ' }
+            ]
+        };
     }
 
-    _insertTemplate(i) {
-        this.props.onShortcutClicked(this.templates[i].content);
+    componentDidUpdate(prevProps, prevState) {
+        let activeContexts = this.getActiveContexts();
+
+        if (this.state.lastActiveContextCount !== activeContexts.length) {
+            this.setState({
+                value: activeContexts.length + 1,
+                lastActiveContextCount: activeContexts.length
+            });
+        }
     }
-    
-    _handleShortcutClick(shortcut) {
-        this.props.onShortcutClicked(shortcut); // + shortcut.substring(0, 1)); no longer need trailing @ or #
-    }
-    handleChange(event, value) {
-        this.setState({ value });
-    };
-    _getActiveContexts() {
+
+    getActiveContexts() {
         let activeContexts = [];
+
         this.props.contextManager.getActiveContexts().slice(0).reverse().forEach((context, i) => {
             if (!Lang.isNull(context.getLabel())) {
                 activeContexts.push(context);
             }
         });
+
         return activeContexts;
     }
-    componentDidUpdate(prevProps, prevState) {
-        let activeContexts = this._getActiveContexts();
-        if (this.lastActiveContextCount !== activeContexts.length) {
-            this.setState({ value: activeContexts.length+1 });
-            this.lastActiveContextCount = activeContexts.length;
-        }
-    }
-    render() {
-        let panelContent = null;
-        const { value } = this.state;
 
-        let activeContexts = this._getActiveContexts();
-        panelContent = (
+    insertTemplate = (i) => {
+        this.props.onShortcutClicked(this.state.templates[i].content);
+    }
+
+    handleShortcutClick = (shortcut) => {
+        this.props.onShortcutClicked(shortcut); // + shortcut.substring(0, 1)); no longer need trailing @ or #
+    }
+
+    handleTemplateSectionClick = () => this.setState({ value: 0 })
+    handlePatientSectionClick = () => this.setState({ value: 1 })
+
+    render() {
+        const { value, templates } = this.state;
+        const activeContexts = this.getActiveContexts();
+
+        return (
             <div className="context-tray">
-                <Tabs
-                    scrollable
-                    scrollButtons="auto"
-                    indicatorColor="steelblue"
-                    onChange={this.handleChange}
-                    value={value}
-                >
-                    <Tab value={0} key={0} label="Templates"/>
-                    <Tab value={1} key={1} label="Patient"/>
-                    {activeContexts.map((context, i) => {
-                        let label = context.getLabel();
-                        return (
-                            <Tab value={i+2} key={i+2} label={label} />
-                        );
-                    })}
-                </Tabs>
-                {value === 0 && 
-                    <TabContainer>
+                <section>
+                    <div className={`section-item${value === 0 ? ' selected' : ''}`} onClick={this.handleTemplateSectionClick}>Templates</div>
+                    <div className={`section-item${value > 0 ? ' selected' : ''}`} onClick={this.handlePatientSectionClick}>Patient</div>
+                </section>
+                {value === 0 &&
+                    <section>
                         <TemplateForm
                             patient={this.props.patient}
                             heading=""
-                            templates={this.templates.map((item) => { return item.name })}
-                            handleClick={this._insertTemplate}
+                            templates={templates.map((item) => { return item.name })}
+                            handleClick={this.insertTemplate}
                         />
-                    </TabContainer>
+                    </section>
                 }
-                {value === 1 && 
-                    <TabContainer>
+                {value > 0 &&
+                    <section>
                         <ContextOptions
                             contextManager={this.props.contextManager}
                             shortcutManager={this.props.shortcutManager}
-                            handleClick={this._handleShortcutClick}
+                            handleClick={this.handleShortcutClick}
                         />
-                    </TabContainer>
+                    </section>
                 }
-                {value > 1 && 
-                    <TabContainer>
+                {value > 0 && activeContexts.map((context, i) =>
+                    <section key={i}>
                         <ContextOptions
                             contextManager={this.props.contextManager}
                             shortcutManager={this.props.shortcutManager}
-                            handleClick={this._handleShortcutClick}
-                            context={activeContexts[value - 2]}
+                            handleClick={this.handleShortcutClick}
+                            context={context}
                         />
-                    </TabContainer>
-                }
+                    </section>
+                )}
             </div>
         );
-        return (
-            <div id="forms-panel" className="dashboard-panel">
-                {panelContent}
-            </div>
-        )
     }
 }
 
-ContextTray.proptypes = { 
+ContextTray.proptypes = {
     ref: PropTypes.func.isRequired,
     patient: PropTypes.object.isRequired,
     shortcutManager: PropTypes.object.isRequired,
     contextManager: PropTypes.object.isRequired,
     onShortcutClicked: PropTypes.func.isRequired
 }
-
-export default ContextTray;

--- a/src/context/ContextTray.jsx
+++ b/src/context/ContextTray.jsx
@@ -6,7 +6,6 @@ import TemplateForm from '../forms/TemplateForm';
 import ContextOptions from './ContextOptions';
 import './ContextTray.css';
 
-
 export default class ContextTray extends Component {
     constructor(props) {
         super(props);

--- a/src/context/ContextTray.jsx
+++ b/src/context/ContextTray.jsx
@@ -76,23 +76,20 @@ export default class ContextTray extends Component {
                     </section>
                 }
                 {value > 0 &&
-                    <section>
-                        <ContextOptions
-                            contextManager={this.props.contextManager}
-                            shortcutManager={this.props.shortcutManager}
-                            handleClick={this.handleShortcutClick}
-                        />
-                    </section>
+                    <ContextOptions
+                        contextManager={this.props.contextManager}
+                        shortcutManager={this.props.shortcutManager}
+                        handleClick={this.handleShortcutClick}
+                    />
                 }
                 {value > 0 && activeContexts.map((context, i) =>
-                    <section key={i}>
-                        <ContextOptions
-                            contextManager={this.props.contextManager}
-                            shortcutManager={this.props.shortcutManager}
-                            handleClick={this.handleShortcutClick}
-                            context={context}
-                        />
-                    </section>
+                    <ContextOptions
+                        key={i}
+                        contextManager={this.props.contextManager}
+                        shortcutManager={this.props.shortcutManager}
+                        handleClick={this.handleShortcutClick}
+                        context={context}
+                    />
                 )}
             </div>
         );

--- a/src/dashboard/ClinicianDashboard.css
+++ b/src/dashboard/ClinicianDashboard.css
@@ -1,20 +1,20 @@
-#clinician-dashboard-content { 
+#clinician-dashboard-content {
     margin-top: 16px;
 }
 
-#clinician-dashboard-content .fitted-panel { 
+#clinician-dashboard-content .fitted-panel {
     overflow-y: scroll;
+    overflow-x: hidden;
     text-align: left;
-    margin-right: 5px;
     /* 106px is the height of the Patient Control Panel, 16px is the height of the top margin of post encounter view content */
     max-height: calc(100vh - 106px - 16px);
     min-height: 400px !important;
 }
 
-#clinician-dashboard-content .right-border-box { 
+#clinician-dashboard-content .right-border-box {
     border-right: 2px dashed #ddd;
 }
 
-#clinician-dashboard-content .full-panel { 
+#clinician-dashboard-content .full-panel {
     height: auto;
 }

--- a/src/dashboard/ClinicianDashboard.jsx
+++ b/src/dashboard/ClinicianDashboard.jsx
@@ -1,6 +1,6 @@
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-// import { Row, Col } from 'react-flexbox-grid';
+
 import TargetedDataPanel from '../panels/TargetedDataPanel';
 import NotesPanel from '../panels/NotesPanel';
 import './ClinicianDashboard.css';
@@ -81,7 +81,6 @@ class ClinicianDashboard extends Component {
                 newNotesPanelSize = "60%";
                 break;
             default:
-                // console.warn(`The layout provided, ${currentLayout}, does not have defined panelDimensions.`);
                 newTargetedDataPanelSize = "40%";
                 newNotesPanelSize = "60%";
         }
@@ -174,6 +173,7 @@ class ClinicianDashboard extends Component {
                         {...this.props}
                     />
                 </div>
+
                 <div style={notesPanelStyles}>
                     <NotesPanel
                         contextManager={this.props.contextManager}

--- a/src/forms/FormSearch.jsx
+++ b/src/forms/FormSearch.jsx
@@ -7,16 +7,15 @@ import FontIcon from 'material-ui/FontIcon';
 import './FormSearch.css';
 
 class FormSearch extends Component {
-
     constructor(props) {
         super(props);
-        // this._newShortcut = this._newShortcut.bind(this);
+
         this.underlineStyle = {
             borderColor: "#17263f",
         }
     }
 
-    handleSearch(searchValue) { 
+    handleSearch(searchValue) {
         console.log()
     }
 
@@ -24,12 +23,12 @@ class FormSearch extends Component {
         return (
             <div id="form-search">
                 <div style={{position: 'relative', display: 'inline-block'}}>
-                    <FontIcon 
+                    <FontIcon
                         className="fa fa-search"
                         style={{position: 'absolute', left: "15%", top: 15, fontSize: "16px", color: "#17263f"}}/>
                     <TextField
                         style={{textIndent: 25, left: "15%", textAlign: "left", minWidth: "80%", width: "100%"}}
-                        hintText="Search for a shortcut"
+                        hintText="Search shortcuts"
                         onChange={(event, value) => this.handleSearch(value)}
                         underlineFocusStyle={this.underlineStyle}
 

--- a/src/forms/TemplateForm.css
+++ b/src/forms/TemplateForm.css
@@ -1,7 +1,11 @@
-.btn_template {
-  float: left;
-  clear: left;
-  margin-bottom: 20px;
-  width: 150px;
-  background-color: white !important;
+.template {
+  padding: 5px 20px;
+  font-size: 0.9em;
+  color: #999;
+  cursor: pointer;
+}
+
+.template:hover {
+  color: #555;
+  font-weight: bold;
 }

--- a/src/forms/TemplateForm.jsx
+++ b/src/forms/TemplateForm.jsx
@@ -1,13 +1,19 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Button from '../elements/Button';
 import Divider from 'material-ui/Divider';
+
+import Button from '../elements/Button';
 import './TemplateForm.css';
 
-class TemplateForm extends Component {
+export default class TemplateForm extends Component {
     constructor(props) {
         super(props);
         this._handleClick = this._handleClick.bind(this);
+    }
+
+    _handleClick(e, i) {
+        e.preventDefault();
+        this.props.handleClick(i);
     }
 
     render() {
@@ -15,6 +21,7 @@ class TemplateForm extends Component {
            <div>
                 <h1>{this.props.heading}</h1>
                 <Divider className="divider"/>
+
                 {this.props.templates.map((t, i) => {
                     return (
                         <Button raised className="btn_template"
@@ -22,16 +29,12 @@ class TemplateForm extends Component {
                             key={i}
                             onClick={(e) => this._handleClick(e, i)}
                         >
-                        {t}</Button>
+                            {t}
+                        </Button>
                     ); //this._insertTemplate(e, i)
                 })}
             </div>
         );
-    }
-
-    _handleClick(e, i) {
-        e.preventDefault();
-        this.props.handleClick(i);
     }
 }
 
@@ -41,5 +44,3 @@ TemplateForm.proptypes = {
     templates: PropTypes.array.isRequired,
     handleClick: PropTypes.func.isRequired,
 }
-
-export default TemplateForm;

--- a/src/forms/TemplateForm.jsx
+++ b/src/forms/TemplateForm.jsx
@@ -1,37 +1,30 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Divider from 'material-ui/Divider';
 
-import Button from '../elements/Button';
 import './TemplateForm.css';
 
 export default class TemplateForm extends Component {
-    constructor(props) {
-        super(props);
-        this._handleClick = this._handleClick.bind(this);
-    }
-
-    _handleClick(e, i) {
+    handleClick = (e, index) => {
         e.preventDefault();
-        this.props.handleClick(i);
+        this.props.handleClick(index);
     }
 
     render() {
         return (
            <div>
                 <h1>{this.props.heading}</h1>
-                <Divider className="divider"/>
 
-                {this.props.templates.map((t, i) => {
+                {this.props.templates.map((template, index) => {
                     return (
-                        <Button raised className="btn_template"
-                            label={t}
-                            key={i}
-                            onClick={(e) => this._handleClick(e, i)}
+                        <div
+                            className="template"
+                            label={template}
+                            key={index}
+                            onClick={(e) => this.handleClick(e, index)}
                         >
-                            {t}
-                        </Button>
-                    ); //this._insertTemplate(e, i)
+                            {template}
+                        </div>
+                    );
                 })}
             </div>
         );

--- a/src/index.css
+++ b/src/index.css
@@ -3,7 +3,7 @@ body {
   padding: 0;
   height: 100%;
   font-family: "Open Sans", Arial, sans-serif;
-  color: #444;
+  color: #555;
 }
 
 ::-webkit-scrollbar {

--- a/src/notes/NoteAssistant.css
+++ b/src/notes/NoteAssistant.css
@@ -2,8 +2,8 @@ span.button-hover {
     cursor: pointer;
 }
 
-.clinical-notes-btn .fa { 
-    padding: 0 10px;
+.clinical-notes-btn {
+    padding: 0 20px;
 }
 
 .clinical-notes-panel {
@@ -120,3 +120,7 @@ li.sort-item:hover {
     background: #e6e6e6 !important;
 }
 
+.icon-arrow-left {
+    width: 20px;
+    margin-left: 10px;
+}

--- a/src/notes/NoteAssistant.css
+++ b/src/notes/NoteAssistant.css
@@ -4,6 +4,14 @@ span.button-hover {
 
 .clinical-notes-btn {
     padding: 0 20px;
+    display: inline-block;
+    transform: perspective(1px) translateZ(0);
+    transition-duration: 0.3s;
+    transition-property: transform;
+}
+
+.clinical-notes-btn:hover {
+    transform: scale(1.1);
 }
 
 .clinical-notes-panel {
@@ -21,9 +29,10 @@ span.button-hover {
     margin-top: 10px;
     margin-bottom: 10px;
     text-align: center;
-    height: auto !important;
+    height: 40px;
     width: 9vw !important;
     min-width: 180px !important;
+    display: block;
 }
 
 .note-new-text {

--- a/src/notes/NoteAssistant.css
+++ b/src/notes/NoteAssistant.css
@@ -120,8 +120,8 @@ li.sort-item:hover {
 .note::before {
     content: "";
     position: absolute;
-    top: -1px;
-    right: -1px;
+    top: -2px;
+    right: -2px;
     border-width: 0 16px 16px 0;
     border-style: solid;
     border-color: #ccc #fff;
@@ -151,4 +151,9 @@ li.sort-item:hover {
     font-size: 0.8rem;
     color: #555;
     margin-bottom: 5px;
+}
+
+.selected {
+    border-width: 2px;
+    border-color: #9ecfef;
 }

--- a/src/notes/NoteAssistant.css
+++ b/src/notes/NoteAssistant.css
@@ -5,19 +5,50 @@ span.button-hover {
 .clinical-notes-btn {
     padding: 0 20px;
     display: inline-block;
+    white-space: nowrap;
     transform: perspective(1px) translateZ(0);
     transition-duration: 0.3s;
     transition-property: transform;
 }
 
-.clinical-notes-btn:hover {
-    transform: scale(1.1);
+.previous-notes-label {
+    font-weight: bold;
+    font-size: 0.8em;
+    margin: 10px;
 }
 
-.clinical-notes-panel {
-    float: right;
-    right: 10px;
-    width: 195px;
+/* Sort */
+
+.sort-label {
+    margin-left: 10px;
+    font-size: 0.8em;
+}
+
+.sort-selection {
+    margin-bottom: 20px;
+}
+
+.sort-select {
+    width: 90%;
+    max-width: 200px;
+    margin-left: 10px;
+}
+
+.sort-selection .sort-select {
+    font-size: 0.8em;
+}
+
+li.sort-item:hover {
+    background-color: #1384b5;
+    color: #fff;
+}
+
+/* Buttons */
+
+.note-new {
+    margin: 10px 0 20px;
+    text-align: center;
+    display: block;
 }
 
 .note-new:hover {
@@ -25,18 +56,17 @@ span.button-hover {
     background: #e6e6e6;
 }
 
-.note-new {
-    margin-top: 10px;
-    margin-bottom: 10px;
-    text-align: center;
-    height: 40px;
-    width: 9vw !important;
-    min-width: 180px !important;
-    display: block;
+.note-new-text {
+    color: #555;
+    font-size: 1.1rem;
 }
 
-.note-new-text {
-    font-size: 0.9rem;
+.note-new-text .fa {
+    padding-right: 10px;
+}
+
+.clinical-notes-btn:hover {
+    transform: scale(1.1);
 }
 
 .resume-note-btn {
@@ -52,84 +82,73 @@ span.button-hover {
     background: #e6e6e6 !important;
 }
 
-.previous-notes-label {
-    font-weight: bold;
-    font-size: 0.8em;
-    margin-left: 10px;
-}
-
-.sort-label {
-    margin-left: 10px;
-    font-size: 0.8em;
-}
-
-.sort-selection {
-    margin-bottom: 20px;
-}
-
-.sort-select {
-    width: 50%;
-    margin-left: 10px;
-}
-
-.sort-selection .sort-select {
-    font-size: 0.8em;
-}
-
-li.sort-item:hover {
-    background-color: #1384b5;
-    color: #fff;
-}
-
-.note {
-    padding-top: 0px !important;
-    height: auto !important;
-    width: 9vw !important;
-    min-width: 180px !important;
-}
-
-.note:hover {
-    cursor:pointer;
-    background: #e6e6e6;
-}
-
-.existing-note-date {
-    font-size: 0.7rem;
-    color: #333333 !important;
-    font-weight: bold;
-}
-
-.in-progress-text {
-    font-size: 0.8rem;
-    color: #333333 !important;
-    font-weight: bold;
-}
-
-.existing-note-subject {
-    font-size: 0.7rem;
-    color: #999 !important;
-}
-
-.existing-note-metadata {
-    font-size: 0.7rem;
-    color: #999 !important;
-    margin-bottom: 5px;
-}
-
 .more-notes-btn {
     background-color: white !important;
     padding: 10px !important;
-    margin-top: 10px;
-    height: auto !important;
-    width: 9vw !important;
-    min-width: 180px !important;
+    margin-top: 20px;
 }
 
 .more-notes-btn:hover {
     background: #e6e6e6 !important;
 }
 
+/* Icons */
+
 .icon-arrow-left {
     width: 20px;
     margin-left: 10px;
+}
+
+/* Notes */
+
+.note {
+    position: relative;
+    max-width: 200px;
+    padding: 0.5em 1em;
+    margin: 1em 0;
+    color: #000;
+    background: #fff;
+    border: 1px solid #ccc;
+    border-radius: 5px 0 5px 5px;
+}
+
+.note:hover {
+    cursor: pointer;
+    background-color: #e6e6e6;
+}
+
+.note::before {
+    content: "";
+    position: absolute;
+    top: -1px;
+    right: -1px;
+    border-width: 0 16px 16px 0;
+    border-style: solid;
+    border-color: #ccc #fff;
+}
+
+.existing-note-date {
+    font-size: 0.8rem;
+    padding-bottom: 5px;
+    color: #555;
+    font-weight: bold;
+}
+
+.existing-note-subject {
+    font-size: 0.8rem;
+    color: #555;
+    padding-bottom: 10px;
+    border-bottom: 1px solid #ccc;
+}
+
+.in-progress-text {
+    font-size: 0.8rem;
+    color: #555;
+    font-weight: bold;
+}
+
+.existing-note-metadata {
+    font-size: 0.8rem;
+    color: #555;
+    margin-bottom: 5px;
 }

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -105,6 +105,7 @@ export default class NoteAssistant extends Component {
                 // Render the context tray
                 return (
                     <div>
+			{this.renderNewNoteSVG()}
                         <span className="button-hover clinical-notes-btn" onClick={() => {
 			    this.toggleView("clinical-notes") }}>
                             Clinical notes

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -1,14 +1,14 @@
-import React, {Component} from 'react';
-import Lang from 'lodash';
-import ContextTray from '../context/ContextTray';
-import Button from '../elements/Button';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Select from 'material-ui/Select';
 import MenuItem from 'material-ui/Menu/MenuItem';
 
+import ContextTray from '../context/ContextTray';
+import Button from '../elements/Button';
+import iconArrowLeft from '../../public/icons/icon_arrow_left.svg';
 import './NoteAssistant.css';
 
-class NoteAssistant extends Component {
-
+export default class NoteAssistant extends Component {
     constructor(props) {
         super(props);
 
@@ -51,13 +51,12 @@ class NoteAssistant extends Component {
 
     // Switch view (i.e clinical notes view or context tray)
     toggleView(mode) {
-        // this.setState({noteAssistantMode: mode});
         this.props.updateNoteAssistantMode(mode);
     }
 
     // Update the selected index for the sort drop down
     selectSort(sortIndex) {
-        this.setState({sortIndex: sortIndex});
+        this.setState({ sortIndex: sortIndex });
     }
 
     // Gets called when clicking on the "new note" button
@@ -107,11 +106,11 @@ class NoteAssistant extends Component {
                 return (
                     <div>
                         <span className="button-hover clinical-notes-btn" onClick={() => {
-                            this.toggleView("clinical-notes")
-                        }}>
-                            <i className="fa fa-arrow-left"></i>
-                            Clinical Notes
+			    this.toggleView("clinical-notes") }}>
+                            Clinical notes
+                            <img className="icon-arrow-left" alt="left arrow" src={iconArrowLeft} />
                         </span>
+
                         <ContextTray
                             patient={this.props.patient}
                             contextManager={this.props.contextManager}
@@ -126,19 +125,14 @@ class NoteAssistant extends Component {
             case "clinical-notes":
                 return (
                     <div className="clinical-notes-panel">
-
                         {this.renderNewNoteSVG()}
-
                         {this.renderInProgressNotes()}
 
                         <span className="previous-notes-label">{numberOfPreviousSignedNotes} previous notes</span>
 
                         {this.renderSortSelection()}
-
                         {this.renderNotes()}
-
                         {this.renderMoreNotesButton()}
-
                     </div>
                 );
 
@@ -151,24 +145,24 @@ class NoteAssistant extends Component {
     // Render the new note button
     renderNewNoteSVG() {
         return (
-            <svg className="note-new" onClick={() => this.handleOnNewNoteButtonClick()} viewBox="0 0 150 33"
-                 version="1.1"
+            <svg className="note-new" onClick={() => this.handleOnNewNoteButtonClick()} viewBox="0 0 150 33" version="1.1"
                  xmlns="http://www.w3.org/2000/svg">
                 <defs>
                     <path
                         d="M136.737204,0.069612193 L3.70678711,0.069612193 L3.70678711,0.069612193 C2.04993286,0.069612193 0.706787109,1.41275794 0.706787109,3.06961219 L0.706787109,3.06961219 L0.706787109,30 C0.706787109,31.6568542 2.04993286,33 3.70678711,33 L3.70678711,33 L146.214569,33 C147.871423,33 149.214569,31.6568542 149.214569,30 L149.214569,30 L149.214569,12.5469764 L136.737204,0.069612193 Z"
-                        id="path-1"></path>
+                        id="path-1">
+                    </path>
                 </defs>
-                <svg x="25" y="12" width="11px" height="11px" viewBox="0 0 11 11" version="1.1"
-                     xmlns="http://www.w3.org/2000/svg">
+
+                <svg x="25" y="12" width="11px" height="11px" viewBox="0 0 11 11" version="1.1" xmlns="http://www.w3.org/2000/svg">
                     <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd" strokeLinecap="square">
-                        <g id="Group-Copy-3" transform="translate(0.660429, 0.452719)" stroke="#16253E"
-                           strokeWidth="1.5552">
+                        <g id="Group-Copy-3" transform="translate(0.660429, 0.452719)" stroke="#16253E" strokeWidth="1.5552">
                             <path d="M0.465836188,4.96173944 L8.70583619,4.96173944" id="Line"></path>
                             <path d="M4.59517238,1.04666266 L4.59517238,9.28624923" id="Line-Copy"></path>
                         </g>
                     </g>
                 </svg>
+
                 <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
                     <g id="Group-24">
                         <g id="Combined-Shape">
@@ -176,10 +170,12 @@ class NoteAssistant extends Component {
                             <path stroke="#B3B3B3" strokeWidth="0.5"
                                   d="M136.633651,0.319612193 L3.70678711,0.319612193 C2.18800405,0.319612193 0.956787109,1.55082913 0.956787109,3.06961219 L0.956787109,30 C0.956787109,31.5187831 2.18800405,32.75 3.70678711,32.75 L146.214569,32.75 C147.733352,32.75 148.964569,31.5187831 148.964569,30 L148.964569,12.6505298 L136.633651,0.319612193 Z"></path>
                         </g>
+
                         <polyline id="Path-14" stroke="#B3B3B3" strokeWidth="0.5" fill="#FFFFFF"
                                   points="136.300181 0.370008208 136.300181 13.0028388 148.974379 13.0028388"></polyline>
                     </g>
                 </g>
+
                 <text className="note-new-text" x="40" y="22">New note</text>
             </svg>
         );
@@ -272,8 +268,10 @@ class NoteAssistant extends Component {
                 <defs>
                     <path
                         d="M136.405173,0.069612193 L3.37475586,0.069612193 L3.37475586,0.069612193 C1.71790161,0.069612193 0.374755859,1.41275794 0.374755859,3.06961219 L0.374755859,3.06961219 L0.374755859,98.5117187 C0.374755859,100.168573 1.71790161,101.511719 3.37475586,101.511719 L3.37475586,101.511719 L145.882537,101.511719 C147.539392,101.511719 148.882537,100.168573 148.882537,98.5117187 L148.882537,98.5117187 L148.882537,12.5469764 L136.405173,0.069612193 Z"
-                        id="path-1"></path>
+                        id="path-1">
+                    </path>
                 </defs>
+
                 <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
                     <g id="Group-23">
                         <g id="Combined-Shape">
@@ -285,13 +283,13 @@ class NoteAssistant extends Component {
                                   points="135.968149 0.370008208 135.968149 13.0028388 148.642348 13.0028388"></polyline>
                     </g>
                 </g>
+
                 <text className="existing-note-date" x="20" y="20">{item.date}</text>
                 <text x="20" y="40" className="existing-note-subject">{item.subject}</text>
 
                 <line x1="10" y1="50" x2="140" y2="50" stroke="#999" strokeWidth="1"/>
 
                 {this.renderMetaDataText(item)}
-
             </svg>
         );
     }
@@ -364,10 +362,8 @@ class NoteAssistant extends Component {
 
     // Main render method
     render() {
-
         // If the note viewer is editable then we want to be able to edit notes and view the context tray
         if (this.props.isNoteViewerEditable) {
-
             return (
                 <div>
                     {this.renderNoteAssistantContent(this.props.noteAssistantMode)}
@@ -376,7 +372,6 @@ class NoteAssistant extends Component {
 
             // If the note viewer is read only the we want to be able to view the clinical notes
         } else {
-
             return (
                 <div>
                     {this.renderNoteAssistantContent("clinical-notes")}
@@ -386,4 +381,11 @@ class NoteAssistant extends Component {
     }
 }
 
-export default NoteAssistant;
+NoteAssistant.propTypes = {
+    patient: PropTypes.object,
+    contextManager: PropTypes.object,
+    shortcutManager: PropTypes.object,
+    isNoteViewerEditable: PropTypes.bool,
+    handleSummaryItemSelected: PropTypes.func
+};
+

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -105,10 +105,10 @@ export default class NoteAssistant extends Component {
             case "context-tray":
                 return (
                     <div>
-			{this.renderNewNoteSVG()}
-
-                        <span className="button-hover clinical-notes-btn" onClick={() => {
-			    this.toggleView("clinical-notes") }}>
+                        <span
+                            className="button-hover clinical-notes-btn"
+                            onClick={() => { this.toggleView("clinical-notes") }}
+                        >
                             Clinical notes
                             <img className="icon-arrow-left" alt="left arrow" src={iconArrowLeft} />
                         </span>
@@ -192,7 +192,7 @@ export default class NoteAssistant extends Component {
         const strokeColor = selected ? "#9ecfef" : "#B3B3B3";
         const strokeWidth = selected ? "2" : "0.5";
         return (
-            <svg key={i} className="note" id="in-progress-note" onClick={() => {
+            <svg key={i} className="note in-progress-note" onClick={() => {
                 this.openNote(true, note)
             }} viewBox="0 0 149 129" version="1.1"
                  xmlns="http://www.w3.org/2000/svg">

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Select from 'material-ui/Select';
 import MenuItem from 'material-ui/Menu/MenuItem';
+import Lang from 'lodash';
 
 import ContextTray from '../context/ContextTray';
 import Button from '../elements/Button';
@@ -100,12 +101,12 @@ export default class NoteAssistant extends Component {
         const numberOfPreviousSignedNotes = Lang.filter(allNotes, o => o.signed).length;
 
         switch (noteAssistantMode) {
+            // Render the context tray
             case "context-tray":
-
-                // Render the context tray
                 return (
                     <div>
 			{this.renderNewNoteSVG()}
+
                         <span className="button-hover clinical-notes-btn" onClick={() => {
 			    this.toggleView("clinical-notes") }}>
                             Clinical notes

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -162,7 +162,7 @@ export default class NoteAssistant extends Component {
         const selected = this.props.selectedNote === note;
 
         return (
-            <div className="note in-progress-note" key={i} onClick={() => { this.openNote(true, note) }}>
+            <div className={`note in-progress-note${selected ? " selected" : ""}`} key={i} onClick={() => { this.openNote(true, note) }}>
                 <div className="in-progress-text">In progress note</div>
 
                 <div className="existing-note-date">{note.date}</div>
@@ -207,7 +207,7 @@ export default class NoteAssistant extends Component {
         const selected = this.props.selectedNote === item;
 
         return (
-            <div className="note existing-note" key={i} onClick={() => { this.openNote(false, item) }}>
+            <div className={`note existing-note${selected ? " selected" : ""}`} key={i} onClick={() => { this.openNote(false, item) }}>
                 <div className="existing-note-date">{item.date}</div>
                 <div className="existing-note-subject">{item.subject}</div>
 

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Select from 'material-ui/Select';
 import MenuItem from 'material-ui/Menu/MenuItem';
 import Lang from 'lodash';
+import FontAwesome from 'react-fontawesome';
 
 import ContextTray from '../context/ContextTray';
 import Button from '../elements/Button';
@@ -82,7 +83,6 @@ export default class NoteAssistant extends Component {
 
     // Gets called when clicking on one of the notes in the clinical notes view
     openNote(isInProgressNote, note) {
-
         this.props.updateSelectedNote(note);
         this.props.loadNote(note);
 
@@ -96,7 +96,6 @@ export default class NoteAssistant extends Component {
 
     // Render the content for the Note Assistant panel
     renderNoteAssistantContent(noteAssistantMode) {
-
         const allNotes = this.props.patient.getNotes();
         const numberOfPreviousSignedNotes = Lang.filter(allNotes, o => o.signed).length;
 
@@ -127,10 +126,10 @@ export default class NoteAssistant extends Component {
             case "clinical-notes":
                 return (
                     <div className="clinical-notes-panel">
-                        {this.renderNewNoteSVG()}
+                        {this.renderNewNote()}
                         {this.renderInProgressNotes()}
 
-                        <span className="previous-notes-label">{numberOfPreviousSignedNotes} previous notes</span>
+                        <div className="previous-notes-label">{numberOfPreviousSignedNotes} previous notes</div>
 
                         {this.renderSortSelection()}
                         {this.renderNotes()}
@@ -144,86 +143,33 @@ export default class NoteAssistant extends Component {
         }
     }
 
-    // Render the new note button
-    renderNewNoteSVG() {
+    renderNewNote() {
         return (
-            <svg className="note-new" onClick={() => this.handleOnNewNoteButtonClick()} viewBox="0 0 150 33" version="1.1"
-                 xmlns="http://www.w3.org/2000/svg">
-                <defs>
-                    <path
-                        d="M136.737204,0.069612193 L3.70678711,0.069612193 L3.70678711,0.069612193 C2.04993286,0.069612193 0.706787109,1.41275794 0.706787109,3.06961219 L0.706787109,3.06961219 L0.706787109,30 C0.706787109,31.6568542 2.04993286,33 3.70678711,33 L3.70678711,33 L146.214569,33 C147.871423,33 149.214569,31.6568542 149.214569,30 L149.214569,30 L149.214569,12.5469764 L136.737204,0.069612193 Z"
-                        id="path-1">
-                    </path>
-                </defs>
-
-                <svg x="25" y="12" width="11px" height="11px" viewBox="0 0 11 11" version="1.1" xmlns="http://www.w3.org/2000/svg">
-                    <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd" strokeLinecap="square">
-                        <g id="Group-Copy-3" transform="translate(0.660429, 0.452719)" stroke="#16253E" strokeWidth="1.5552">
-                            <path d="M0.465836188,4.96173944 L8.70583619,4.96173944" id="Line"></path>
-                            <path d="M4.59517238,1.04666266 L4.59517238,9.28624923" id="Line-Copy"></path>
-                        </g>
-                    </g>
-                </svg>
-
-                <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
-                    <g id="Group-24">
-                        <g id="Combined-Shape">
-                            <use fill="#FFFFFF" fillRule="evenodd"></use>
-                            <path stroke="#B3B3B3" strokeWidth="0.5"
-                                  d="M136.633651,0.319612193 L3.70678711,0.319612193 C2.18800405,0.319612193 0.956787109,1.55082913 0.956787109,3.06961219 L0.956787109,30 C0.956787109,31.5187831 2.18800405,32.75 3.70678711,32.75 L146.214569,32.75 C147.733352,32.75 148.964569,31.5187831 148.964569,30 L148.964569,12.6505298 L136.633651,0.319612193 Z"></path>
-                        </g>
-
-                        <polyline id="Path-14" stroke="#B3B3B3" strokeWidth="0.5" fill="#FFFFFF"
-                                  points="136.300181 0.370008208 136.300181 13.0028388 148.974379 13.0028388"></polyline>
-                    </g>
-                </g>
-
-                <text className="note-new-text" x="40" y="22">New note</text>
-            </svg>
+            <div className="note note-new" onClick={() => this.handleOnNewNoteButtonClick()}>
+                <div className="note-new-text">
+                    <FontAwesome name="plus" />
+                    <span>New note</span>
+                </div>
+            </div>
         );
     }
 
     renderInProgressNotes() {
-        return this.inProgressNotes.map((note, i) => this.renderInProgressNoteSVG(note, i));
+        return this.inProgressNotes.map((note, i) => this.renderInProgressNote(note, i));
     }
 
-    renderInProgressNoteSVG(note, i) {
+    renderInProgressNote(note, i) {
         const selected = this.props.selectedNote === note;
-        const strokeColor = selected ? "#9ecfef" : "#B3B3B3";
-        const strokeWidth = selected ? "2" : "0.5";
+
         return (
-            <svg key={i} className="note in-progress-note" onClick={() => {
-                this.openNote(true, note)
-            }} viewBox="0 0 149 129" version="1.1"
-                 xmlns="http://www.w3.org/2000/svg">
-                <defs>
-                    <path
-                        d="M136.405173,0.069612193 L3.37475586,0.069612193 L3.37475586,0.069612193 C1.71790161,0.069612193 0.374755859,1.41275794 0.374755859,3.06961219 L0.374755859,3.06961219 L0.374755859,98.5117187 C0.374755859,100.168573 1.71790161,101.511719 3.37475586,101.511719 L3.37475586,101.511719 L145.882537,101.511719 C147.539392,101.511719 148.882537,100.168573 148.882537,98.5117187 L148.882537,98.5117187 L148.882537,12.5469764 L136.405173,0.069612193 Z"
-                        id="path-1"></path>
-                </defs>
-                <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
-                    <g id="Group-23">
-                        <g id="Combined-Shape">
-                            <use fill="#FFFFFF" fillRule="evenodd"></use>
-                            <path stroke={strokeColor} strokeWidth={strokeWidth}
-                                  d="M136.30162,0.319612193 L3.37475586,0.319612193 C1.8559728,0.319612193 0.624755859,1.55082913 0.624755859,3.06961219 L0.624755859,125.5117187 C0.624755859,127.030502 1.8559728,128.261719 3.37475586,128.261719 L145.882537,128.261719 C147.401321,128.261719 148.632537,127.030502 148.632537,125.5117187 L148.632537,12.6505298 L136.30162,0.319612193 Z"></path>
-                        </g>
-                        <polyline id="Path-14" stroke={strokeColor} strokeWidth={strokeWidth} fill="#FFFFFF"
-                                  points="135.968149 0.370008208 135.968149 13.0028388 148.642348 13.0028388"></polyline>
-                    </g>
-                </g>
-                <text x="20" y="20" className="in-progress-text">In progress note</text>
+            <div className="note in-progress-note" key={i} onClick={() => { this.openNote(true, note) }}>
+                <div className="in-progress-text">In progress note</div>
 
-                <line x1="10" y1="30" x2="140" y2="30" stroke="#999" strokeWidth="1"/>
-
-                <text className="existing-note-date" x="20" y="50">{note.date}</text>
-                <text x="20" y="70" className="existing-note-subject">{note.subject}</text>
-
-                <line x1="10" y1="80" x2="140" y2="80" stroke="#999" strokeWidth="1"/>
+                <div className="existing-note-date">{note.date}</div>
+                <div className="existing-note-subject">{note.subject}</div>
 
                 {this.renderMetaDataText(note, 30)}
-
-            </svg>
+            </div>
         );
     }
 
@@ -231,7 +177,8 @@ export default class NoteAssistant extends Component {
     renderSortSelection() {
         return (
             <div className="sort-selection">
-                <span className="sort-label">Sort by </span>
+                <div className="sort-label">Sort by </div>
+
                 <Select
                     className="sort-select"
                     value={this.state.sortIndex}
@@ -250,49 +197,22 @@ export default class NoteAssistant extends Component {
 
     // Render the list of clinical notes
     renderNotes() {
-
         return this.notesToDisplay.map((item, i) =>
-            this.renderClinicalNoteSVG(item, i)
+            this.renderClinicalNote(item, i)
         );
     }
 
     // For each clinical note, render the note image with the text
-    renderClinicalNoteSVG(item, i) {
+    renderClinicalNote(item, i) {
         const selected = this.props.selectedNote === item;
-        const strokeColor = selected ? "#9ecfef" : "#B3B3B3";
-        const strokeWidth = selected ? "2" : "0.5";
 
         return (
-            <svg key={i} className="note" id="existing-note" onClick={() => {
-                this.openNote(false, item)
-            }} viewBox="0 0 149 102" version="1.1"
-                 xmlns="http://www.w3.org/2000/svg">
-                <defs>
-                    <path
-                        d="M136.405173,0.069612193 L3.37475586,0.069612193 L3.37475586,0.069612193 C1.71790161,0.069612193 0.374755859,1.41275794 0.374755859,3.06961219 L0.374755859,3.06961219 L0.374755859,98.5117187 C0.374755859,100.168573 1.71790161,101.511719 3.37475586,101.511719 L3.37475586,101.511719 L145.882537,101.511719 C147.539392,101.511719 148.882537,100.168573 148.882537,98.5117187 L148.882537,98.5117187 L148.882537,12.5469764 L136.405173,0.069612193 Z"
-                        id="path-1">
-                    </path>
-                </defs>
-
-                <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
-                    <g id="Group-23">
-                        <g id="Combined-Shape">
-                            <use fill="#FFFFFF" fillRule="evenodd"></use>
-                            <path stroke={strokeColor} strokeWidth={strokeWidth}
-                                  d="M136.30162,0.319612193 L3.37475586,0.319612193 C1.8559728,0.319612193 0.624755859,1.55082913 0.624755859,3.06961219 L0.624755859,98.5117187 C0.624755859,100.030502 1.8559728,101.261719 3.37475586,101.261719 L145.882537,101.261719 C147.401321,101.261719 148.632537,100.030502 148.632537,98.5117187 L148.632537,12.6505298 L136.30162,0.319612193 Z"></path>
-                        </g>
-                        <polyline id="Path-14" stroke={strokeColor} strokeWidth={strokeWidth} fill="#FFFFFF"
-                                  points="135.968149 0.370008208 135.968149 13.0028388 148.642348 13.0028388"></polyline>
-                    </g>
-                </g>
-
-                <text className="existing-note-date" x="20" y="20">{item.date}</text>
-                <text x="20" y="40" className="existing-note-subject">{item.subject}</text>
-
-                <line x1="10" y1="50" x2="140" y2="50" stroke="#999" strokeWidth="1"/>
+            <div className="note existing-note" key={i} onClick={() => { this.openNote(false, item) }}>
+                <div className="existing-note-date">{item.date}</div>
+                <div className="existing-note-subject">{item.subject}</div>
 
                 {this.renderMetaDataText(item)}
-            </svg>
+            </div>
         );
     }
 
@@ -334,7 +254,7 @@ export default class NoteAssistant extends Component {
             }
 
             return (
-                <text x="20" y={70 + yOffset} className="existing-note-metadata">
+                <text x="20" y={70 + yOffset} className="existing-note-metadata" fill="#999">
                     <tspan x="20" y={70 + yOffset}>{hospitalFirstString}</tspan>
                     <tspan x="20" y={85 + yOffset}>{hospitalSecondString}</tspan>
                 </text>
@@ -344,7 +264,7 @@ export default class NoteAssistant extends Component {
             hospitalFirstString = item.hospital;
 
             return (
-                <text x="20" y={70 + yOffset} className="existing-note-metadata">
+                <text x="20" y={70 + yOffset} className="existing-note-metadata" fill="#999">
                     <tspan x="20" y={70 + yOffset}>{hospitalFirstString}</tspan>
                 </text>
             );
@@ -355,9 +275,9 @@ export default class NoteAssistant extends Component {
     renderMoreNotesButton() {
         if (this.notesNotDisplayed > 0) {
             return (
-                <Button raised
-                        className="more-notes-btn"
-                >View {this.notesNotDisplayed} more clinical note(s)</Button>
+                <Button raised className="more-notes-btn">
+                    View {this.notesNotDisplayed} more clinical note{this.notesNotDisplayed > 1 ? 's' : ''}
+                </Button>
             );
         }
     }
@@ -390,4 +310,3 @@ NoteAssistant.propTypes = {
     isNoteViewerEditable: PropTypes.bool,
     handleSummaryItemSelected: PropTypes.func
 };
-

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -1,12 +1,12 @@
-import React, {Component} from 'react';
-import {Row, Col} from 'react-flexbox-grid';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Row, Col } from 'react-flexbox-grid';
+
 import FluxNotesEditor from '../notes/FluxNotesEditor';
 import NoteAssistant from '../notes/NoteAssistant';
-
 import './NotesPanel.css';
 
-class NotesPanel extends Component {
-
+export default class NotesPanel extends Component {
     constructor(props) {
         super(props);
 
@@ -58,7 +58,6 @@ class NotesPanel extends Component {
     }
 
     renderNotesPanelContent() {
-
         // If isNoteViewerVisible is true, render the flux notes editor and the note assistant
         if (this.props.isNoteViewerVisible) {
             return (
@@ -137,4 +136,16 @@ class NotesPanel extends Component {
     }
 }
 
-export default NotesPanel;
+NotesPanel.propTypes = {
+    patient: PropTypes.object,
+    contextManager: PropTypes.object,
+    shortcutManager: PropTypes.object,
+    summaryItemToBeInserted: PropTypes.string,
+    errors: PropTypes.array,
+    isNoteViewerEditable: PropTypes.bool,
+    newCurrentShortcut: PropTypes.func,
+    itemInserted: PropTypes.func,
+    updateErrors: PropTypes.func,
+    handleSummaryItemSelected: PropTypes.func,
+    handleSelectionChange: PropTypes.func
+};

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -62,10 +62,11 @@ export default class NotesPanel extends Component {
         if (this.props.isNoteViewerVisible) {
             return (
                 <Row center="xs">
-                    <Col sm={9}>
+                    <Col sm={7} md={8} lg={9}>
                         {this.renderFluxNotesEditor()}
                     </Col>
-                    <Col sm={3}>
+
+                    <Col sm={5} md={4} lg={3}>
                         {this.renderNoteAssistant()}
                     </Col>
                 </Row>

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -62,10 +62,10 @@ export default class NotesPanel extends Component {
         if (this.props.isNoteViewerVisible) {
             return (
                 <Row center="xs">
-                    <Col sm={7}>
+                    <Col sm={9}>
                         {this.renderFluxNotesEditor()}
                     </Col>
-                    <Col sm={5}>
+                    <Col sm={3}>
                         {this.renderNoteAssistant()}
                     </Col>
                 </Row>

--- a/src/panels/PatientControlPanel.css
+++ b/src/panels/PatientControlPanel.css
@@ -17,6 +17,7 @@
     font-size: 24px;
     font-weight: 600;
     vertical-align: 0.5em;
+    padding-left: 5px;
 }
 .patient-control-panel .login {
     margin-left: 0.4rem;

--- a/src/panels/PatientControlPanel.jsx
+++ b/src/panels/PatientControlPanel.jsx
@@ -1,18 +1,20 @@
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import {Grid, Row, Col} from 'react-flexbox-grid';
+import { Grid, Row, Col } from 'react-flexbox-grid';
 import Paper from 'material-ui/Paper';
 import Input from 'material-ui/Input';
+
 import Button from '../elements/Button';
 import SummaryHeader from '../summary/SummaryHeader';
 import './PatientControlPanel.css';
 
 class PatientControlPanel extends Component {
     render() {
-        const {patient} = this.props;
+        const { patient } = this.props;
         const login = (this.props.supportLogin) ? ( <Button style={{color: "#17263f"}}>Dr. X123 Y987</Button> ) : "";
         const firstName = patient.getName().split(' ')[0];
         const patientConditions = this.props.patient ? this.props.patient.getConditions() : [];
+
         return (
             <div className="patient-control-panel">
                 <Paper className="panel-content">
@@ -22,9 +24,7 @@ class PatientControlPanel extends Component {
                                 <Row middle="xs">
                                     <Col sm={12}>
                                         <img src="fluxnotes_logo_color.png" height="40px" width="30px" alt="Flux Notes logo" />
-                                        <span className="title">
-                                            &nbsp; {this.props.appTitle}
-                                        </span>
+                                        <span className="title"> {this.props.appTitle}</span>
                                     </Col>
                                     <span className="login">{login}</span>
                                 </Row>

--- a/src/styles/FullApp.css
+++ b/src/styles/FullApp.css
@@ -14,14 +14,14 @@
 }
 
 .FullApp-content .panel-content {
-    padding: 0 10px 10px 10px;
+    /*padding: 0 10px 10px 10px;*/
+    padding: 5px;
     text-align: left;
 }
 
 .FullApp-content .dashboard-panel {
     text-align: left;
 }
-
 
 .FullApp-content .divider {
     margin: 20px 0px !important;

--- a/test/ui/FullApp.js
+++ b/test/ui/FullApp.js
@@ -36,7 +36,7 @@ test('Clicking event buttons selects corresponding event', async t => {
         .eql("Pre-encounter")
         .expect(Selector('#clinical-notes').exists)
         .notOk();
-    
+
     // Clicking Post-encounter choice selects it and the editor is rendered
     await t
         .click(clinicalEventSelector)
@@ -215,7 +215,7 @@ test("Typing '#deceased' in the editor results in a structured data insertion an
     await t
         .expect(structuredField.innerText)
         .contains('#deceased');
-    const contextPanelElement = Selector(".context-options-list").find('button');
+    const contextPanelElement = Selector('.context-tray section:last-child .context-option');
 
     const deceasedChild = '#DATE';
     const contextPanelElementInnerText = await contextPanelElement.innerText;
@@ -228,11 +228,11 @@ test("Typing '#deceased' in the editor results in a structured data insertion an
 
 test("Switching contexts without closing a context chooses the correct parent context and successfully enters information in editor", async t => {
     const editor = Selector("div[data-slate-editor='true']");
-    const contextPanelElements = Selector(".context-options-list").find('button');
+    const contextPanelElements = Selector(".context-options-list").find('.context-option');
     const structuredField = editor.find("span[class='structured-field']");
     const conditionButton = await contextPanelElements.withText(/@condition/ig);
     const textToType = ["#toxicity ", "#nausea ", "#staging ", "#T0 "];
-    
+
     await t
         .click(conditionButton);
     let correctCondition = Selector(".context-portal").find('li').withText('Invasive ductal carcinoma of breast');
@@ -240,10 +240,10 @@ test("Switching contexts without closing a context chooses the correct parent co
         .click(correctCondition)
         .typeText(editor, ' ');
     for (let i = 0; i < textToType.length; i++) {
-        await t 
+        await t
             .typeText(editor, textToType[i]);
     };
-    
+
 
     textToType.splice(0, 0, 'condition placeholder');
     const structuredFieldCount = await structuredField.count;
@@ -256,11 +256,11 @@ test("Switching contexts without closing a context chooses the correct parent co
 
 test("Typing #PR into the editor followed by #Positive results in structured data insertion and context panel updates", async t => {
     const editor = Selector("div[data-slate-editor='true']");
-    const contextPanelElements = Selector(".context-options-list").find('button');
+    const contextPanelElements = Selector(".context-options-list").find('.context-option');
     const structuredField = editor.find("span[class='structured-field']");
     const conditionButton = await contextPanelElements.withText(/@condition/ig);
     const textToType = ["#PR ", "#Positive "];
-    
+
     await t
         .click(conditionButton);
     let correctCondition = Selector(".context-portal").find('li').withText('Invasive ductal carcinoma of breast');
@@ -268,10 +268,10 @@ test("Typing #PR into the editor followed by #Positive results in structured dat
         .click(correctCondition)
         .typeText(editor, ' ');
     for (let i = 0; i < textToType.length; i++) {
-        await t 
+        await t
             .typeText(editor, textToType[i]);
     };
-    
+
 
     textToType.splice(0, 0, 'condition placeholder');
     const structuredFieldCount = await structuredField.count;
@@ -284,11 +284,11 @@ test("Typing #PR into the editor followed by #Positive results in structured dat
 
 test("Typing #HER2 into the editor followed by #Positive results in structured data insertion and context panel updates", async t => {
     const editor = Selector("div[data-slate-editor='true']");
-    const contextPanelElements = Selector(".context-options-list").find('button');
+    const contextPanelElements = Selector(".context-options-list").find('.context-option');
     const structuredField = editor.find("span[class='structured-field']");
     const conditionButton = await contextPanelElements.withText(/@condition/ig);
     const textToType = ["#HER2 ", "#Positive "];
-    
+
     await t
         .click(conditionButton);
     let correctCondition = Selector(".context-portal").find('li').withText('Invasive ductal carcinoma of breast');
@@ -296,10 +296,10 @@ test("Typing #HER2 into the editor followed by #Positive results in structured d
         .click(correctCondition)
         .typeText(editor, ' ');
     for (let i = 0; i < textToType.length; i++) {
-        await t 
+        await t
             .typeText(editor, textToType[i]);
     };
-    
+
 
     textToType.splice(0, 0, 'condition placeholder');
     const structuredFieldCount = await structuredField.count;
@@ -312,11 +312,11 @@ test("Typing #HER2 into the editor followed by #Positive results in structured d
 
 test("Typing #ER into the editor followed by #Positive results in structured data insertsion and context panel updates", async t => {
     const editor = Selector("div[data-slate-editor='true']");
-    const contextPanelElements = Selector(".context-options-list").find('button');
+    const contextPanelElements = Selector(".context-options-list").find('.context-option');
     const structuredField = editor.find("span[class='structured-field']");
     const conditionButton = await contextPanelElements.withText(/@condition/ig);
     const textToType = ["#ER ", "#Positive "];
-    
+
     await t
         .click(conditionButton);
     let correctCondition = Selector(".context-portal").find('li').withText('Invasive ductal carcinoma of breast');
@@ -324,10 +324,10 @@ test("Typing #ER into the editor followed by #Positive results in structured dat
         .click(correctCondition)
         .typeText(editor, ' ');
     for (let i = 0; i < textToType.length; i++) {
-        await t 
+        await t
             .typeText(editor, textToType[i]);
     };
-    
+
     // We will skip checking for the inserted condition. Add a placeholder so indexes line up.
     textToType.splice(0, 0, 'condition placeholder');
     const structuredFieldCount = await structuredField.count;
@@ -346,7 +346,7 @@ test('Clicking "#clinical trial", "#enrollment date", "#date" and choosing a dat
     const expectedText = ["#clinical trial", "#enrolled on", `#${today}`];
     const editor = Selector("div[data-slate-editor='true']");
     const structuredField = editor.find("span[class='structured-field']");
-    const contextPanelElements = Selector(".context-options-list").find('button');
+    const contextPanelElements = Selector(".context-options-list").find('.context-option');
     const clinicalTrialButton = await contextPanelElements.withText(/#clinical trial/ig);
 
     await t
@@ -372,7 +372,7 @@ test('Clicking "#deceased", "#date" and choosing a date inserts "#deceased #{dat
     const expectedText = ["#deceased", `#${today}`];
     const editor = Selector("div[data-slate-editor='true']");
     const structuredField = editor.find("span[class='structured-field']");
-    const contextPanelElements = Selector(".context-options-list").find('button');
+    const contextPanelElements = Selector(".context-options-list").find('.context-option');
 
     const deceasedButton = await contextPanelElements.withText(/#deceased/ig);
 
@@ -398,7 +398,7 @@ test('Clicking "@condition", "#disease status", "#stable", "#as of", "#date" and
     const expectedNumItems = await progressionItemsBefore.count + 1;
     const editor = Selector("div[data-slate-editor='true']");
     const structuredField = editor.find("span[class='structured-field']");
-    const contextPanelElements = Selector(".context-options-list").find('button');
+    const contextPanelElements = Selector(".context-options-list").find('.context-option');
     const conditionButton = await contextPanelElements.withText(/@condition/ig);
 
     await t
@@ -458,26 +458,26 @@ fixture('Patient Mode - Clinical Notes list')
 test('Clicking New Note button adds a new in progress note to the list', async t => {
     const clinicalNotesButton = Selector('.clinical-notes-btn');
     const newNoteButton = Selector('.note-new');
-    const inProgressNotes = Selector('#in-progress-note');
-    
+    const inProgressNotes = Selector('.in-progress-note');
+
     await t
         .click(clinicalNotesButton);
-    
+
     const inProgressNotesLength = await inProgressNotes.count;
-    
+
     // There are no unsigned notes on the patient's record initially
     await t
         .expect(inProgressNotesLength).eql(0);
-    
+
     await t
         .click(newNoteButton)
-        .click(clinicalNotesButton)
-    
+        .click(clinicalNotesButton);
+
     const inProgressNotesUpdatedLength = await inProgressNotes.count;
-    
+
     // Adding a new note adds an unsigned, in-progress note
     await t
-        .expect(inProgressNotesUpdatedLength).eql(inProgressNotesLength+1);
+        .expect(inProgressNotesUpdatedLength).eql(1);
 });
 
 test('Clicking on an existing note in post encounter mode loads the note in the editor', async t => {
@@ -531,7 +531,7 @@ test('Clicking on an in-progress note in post encounter mode loads the note in t
     const editor = Selector("div[data-slate-editor='true']");
     const clinicalNotesButton = Selector('.clinical-notes-btn');
     const newNoteButton = Selector('.note-new');
-    const inProgressNotes = Selector('#in-progress-note');
+    const inProgressNotes = Selector('.in-progress-note');
 
     // Click on the clinical notes button to switch to clinical notes view
     await t
@@ -556,7 +556,7 @@ test('Clicking on an in-progress note in post encounter mode puts the NotesPanel
     const editor = Selector("div[data-slate-editor='true']");
     const clinicalNotesButton = Selector('.clinical-notes-btn');
     const newNoteButton = Selector('.note-new');
-    const inProgressNotes = Selector('#in-progress-note');
+    const inProgressNotes = Selector('.in-progress-note');
     const contextTray = Selector('.context-tray');
 
     // Click on the clinical notes button to switch to clinical notes view
@@ -644,10 +644,10 @@ test('Medications section appears in targeted data panel in pre-encounter mode o
         let headerText = await header.innerText;
         if (headerText === "Medications") result = true;
     }
-    
+
     await t
         .expect(result === false);
-    
+
     // Clicking Pre-encounter choice selects it and the editor is not rendered
     await t
         .click(clinicalEventSelector)
@@ -655,10 +655,10 @@ test('Medications section appears in targeted data panel in pre-encounter mode o
     await t
         .expect(await clinicalEventSelector.textContent)
         .eql("Pre-encounter");
-    
+
     const sectionsPreEncounter = Selector('#targeted-data-section')
     const numSectionsPreEncounter = await sectionsPreEncounter.count;
-    
+
     // Now check to make sure the Medications sections *does* exist
     result = false;
     for (let i = 0; i < numSectionsPreEncounter; i++) {
@@ -666,7 +666,7 @@ test('Medications section appears in targeted data panel in pre-encounter mode o
         let headerText = await header.innerText;
         if (headerText === "Medications") result = true;
     }
-    
+
     await t
         .expect(result === true);
 });
@@ -773,7 +773,7 @@ test('Selecting a condition changes the timeline summary', async t => {
 
     let progressionItems = Selector("#timeline .rct-canvas .rct-items .rct-item.progression-item");
     let numItems = await progressionItems.count;
-    
+
     // There should be one progression item on the timeline now
     await t
         .expect(1).eql(numItems, 'There should be 1 progression item on the timeline.');

--- a/test/ui/FullApp.js
+++ b/test/ui/FullApp.js
@@ -483,7 +483,7 @@ test('Clicking New Note button adds a new in progress note to the list', async t
 test('Clicking on an existing note in post encounter mode loads the note in the editor', async t => {
     const editor = Selector("div[data-slate-editor='true']");
     const clinicalNotesButton = Selector('.clinical-notes-btn');
-    const note = Selector('#existing-note');
+    const note = Selector('.existing-note');
 
     // Click on the clinical notes button to switch to clinical notes view
     await t
@@ -503,7 +503,7 @@ test('Clicking on an existing note in post encounter mode puts the NotesPanel in
     const editor = Selector("div[data-slate-editor='true']");
     const clinicalNotesButton = Selector('.clinical-notes-btn');
     const clinicalNotesPanel = Selector('.clinical-notes-panel');
-    const note = Selector('#existing-note');
+    const note = Selector('.existing-note');
 
     // Click on the clinical notes button to switch to clinical notes view
     await t
@@ -589,7 +589,7 @@ test('Clicking on an in-progress note in post encounter mode puts the NotesPanel
 test('Clicking on an existing note in pre encounter mode loads the note in the editor', async t => {
     const clinicalEventSelector = Selector('.clinical-event-select');
     const editor = Selector("div[data-slate-editor='true']");
-    const note = Selector('#existing-note');
+    const note = Selector('.existing-note');
 
     // Select pre-encounter mode
     await t


### PR DESCRIPTION
# Implemented new context tray vertical list design

This pull request changes the design of the context tray, but not the functionality. Tabs are removed and replaced with a vertical list. When a context option is selected that triggers additional options, that option will be bolded and the additional options will appear in a section directly under the current section. Context options that do not trigger additional options (ex. `@patient`) will not render any additional sections and will not be bolded.

* Converted context tray tabs/buttons to a vertical list to match new UI design.
* Styled new vertical context options - note: options will bold when corresponding section displayed below.
* Added `icon-arrow-left` svg for context notes button to match design and added a hover transition.
* Moved inline styles to stylesheets.
* Whitespace deletions automatically performed by my editor.
* Fixed all tests and tested in IE.

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter: Noranda

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- Cheat sheet is updated
- [x] Demo script is updated 
- Documentation on Wiki has been updated 
- Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- Added UI tests for slim mode 
- Added UI tests for full mode
- Added backend tests for fluxNotes code
- Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
