### PR TITLE
Progression chart

### DIFF
--- a/src/model/oncology/FluxProgression.js
+++ b/src/model/oncology/FluxProgression.js
@@ -1,6 +1,5 @@
 import AssessmentFocus from '../shr/assessment/AssessmentFocus';
 import CodeableConcept from '../shr/core/CodeableConcept';
-import SpecificType from '../shr/core/SpecificType';
 import Evidence from '../shr/observation/Evidence';
 import Progression from '../shr/oncology/Progression';
 import Reference from '../Reference';
@@ -54,6 +53,14 @@ class FluxProgression extends Progression {
             ev.value = lookup.getEvidenceCodeableConcept(e);   
             return ev;
         });
+    }
+
+    /**
+     *  Getter for code
+     *  This will return the code string from CodeableConcept
+     */
+    get code() {
+        return this._codeableConcept.coding[0].code;
     }
 
     // Flux added

--- a/src/model/oncology/FluxProgression.js
+++ b/src/model/oncology/FluxProgression.js
@@ -1,5 +1,6 @@
 import AssessmentFocus from '../shr/assessment/AssessmentFocus';
 import CodeableConcept from '../shr/core/CodeableConcept';
+import SpecificType from '../shr/core/SpecificType';
 import Evidence from '../shr/observation/Evidence';
 import Progression from '../shr/oncology/Progression';
 import Reference from '../Reference';
@@ -53,6 +54,18 @@ class FluxProgression extends Progression {
             ev.value = lookup.getEvidenceCodeableConcept(e);   
             return ev;
         });
+    }
+
+    get codeableConceptDisplayText() { 
+        if (this._specificType instanceof SpecificType) { 
+            if (this._specificType.codeableConcept.coding.length > 0) { 
+                return this._specificType.codeableConcept.coding[0].displayText.string;
+            } else { 
+                return null;
+            }
+        } else { 
+            return null;
+        }        
     }
 
     // Flux added

--- a/src/model/oncology/FluxProgression.js
+++ b/src/model/oncology/FluxProgression.js
@@ -56,18 +56,6 @@ class FluxProgression extends Progression {
         });
     }
 
-    get codeableConceptDisplayText() { 
-        if (this._specificType instanceof SpecificType) { 
-            if (this._specificType.codeableConcept.coding.length > 0) { 
-                return this._specificType.codeableConcept.coding[0].displayText.string;
-            } else { 
-                return null;
-            }
-        } else { 
-            return null;
-        }        
-    }
-
     // Flux added
     get asOfDate() {
         return this._asOfDate;

--- a/src/model/oncology/FluxProgression.js
+++ b/src/model/oncology/FluxProgression.js
@@ -56,10 +56,10 @@ class FluxProgression extends Progression {
     }
 
     /**
-     *  Getter for code
-     *  This will return the code string from CodeableConcept
+     *  Getter for status' code
+     *  This will return the code string from CodeableConcept, corresponding to the status' code
      */
-    get code() {
+    get statusAsCode () {
         return this._codeableConcept.coding[0].code;
     }
 

--- a/src/summary/ProgressionLineChartVisualizer.css
+++ b/src/summary/ProgressionLineChartVisualizer.css
@@ -1,0 +1,16 @@
+.progression-line-chart-subsection { 
+    padding: 10px 0;
+}
+
+.progression-line-chart-subsection .sub-section-heading h2.sub-section-name { 
+    margin: 10px 0;
+    font-weight: bold;  
+}
+
+.progression-line-chart-subsection .recharts-tooltip-wrapper { 
+    font-size: 13px;
+}
+
+.progression-line-chart-subsection .recharts-text { 
+    font-size: 11px;
+}

--- a/src/summary/ProgressionLineChartVisualizer.jsx
+++ b/src/summary/ProgressionLineChartVisualizer.jsx
@@ -48,10 +48,10 @@ class ProgressionLineChartVisualizer extends Component {
     }
 
     // Turns dates into numeric representations for graphing
-    processForGraphing = (data, xVar, xVarNumber, yVar, progressionToValueMap) => { 
+    processForGraphing = (data, xVar, xVarNumber, yVar, codeToValueMap) => { 
         const dataCopy = Lang.clone(data).map((d, i) => { 
             const code = d[yVar];
-            const numberBasedOnCode = progressionToValueMap[code];
+            const numberBasedOnCode = codeToValueMap[code];
 
             // 1. Translate time strings into millisecond representations, storing in a new key:value pair            
             d[xVarNumber]  = Number(new Date(d[xVar]))
@@ -68,8 +68,8 @@ class ProgressionLineChartVisualizer extends Component {
     }
 
     // Function for formatting numeric progression values to strings
-    progressionFormatter = (progStatus, progressionToValueMap) => { 
-        return progressionToValueMap[progStatus]
+    progressionFormatter = (progStatus, codeToValueMap) => { 
+        return codeToValueMap[progStatus]
     }
 
     // Gets the min/max values of the numeric representation of xVar
@@ -126,11 +126,11 @@ class ProgressionLineChartVisualizer extends Component {
         const xVar = "start_time";
         const xVarNumber = `${xVar}Number`;
         const yVar = "Disease status";
-        const progressionToValueMap = conditionSection.progressionToValueMap;
+        const codeToValueMap = conditionSection.codeToValueMap;
         const valueToProgressionMap = conditionSection.valueToProgressionMap;
         const data = conditionSection.itemsFunction(patient, condition, conditionSection);  
         // process dates into numbers for graphing
-        const processedData = this.processForGraphing(data, xVar, xVarNumber, yVar, progressionToValueMap);
+        const processedData = this.processForGraphing(data, xVar, xVarNumber, yVar, codeToValueMap);
         // Get all possible values for progression, that are numbers, and sort them
         const yTicks = Object.keys(valueToProgressionMap)
                             .filter((val) => {return typeof(val) === "number"})

--- a/src/summary/ProgressionLineChartVisualizer.jsx
+++ b/src/summary/ProgressionLineChartVisualizer.jsx
@@ -1,0 +1,190 @@
+import React, {Component} from 'react';
+import { LineChart, Line, XAxis, YAxis, Tooltip } from 'recharts';
+import moment from 'moment';
+import {scaleLinear} from "d3-scale";
+import Collection from 'lodash';
+import Lang from 'lodash';
+import Function from 'lodash';
+import PropTypes from 'prop-types';
+
+import './ProgressionLineChartVisualizer.css';
+
+/*
+ A BandedLineGraphVisualizer that graphs a set of data over time
+ */
+class ProgressionLineChartVisualizer extends Component {
+    constructor(props) { 
+        super(props);
+
+        this.resize = Function.throttle(this.updateDimensions, 100);
+        this.updateState = true;
+        // This var will be used 
+        this.state = {
+            chartWidth: 600,
+            chartHeight: 400,
+        }
+    }
+
+    // Makesure to update data and resize the component when its contents update.
+    componentDidUpdate = () => {
+        if (this.updateState) {
+            this.updateState = false;
+        } else {
+            this.updateState = true;
+            // this.resize();
+        }
+    }
+
+    // Adds appropriate event listeners for tracking resizing
+    componentDidMount = () => { 
+        // window.addEventListener("resize", this.resize);
+        // this.chartParentDiv.addEventListener("resize", this.resize);
+        setTimeout(this.resize, 100);
+    }
+
+    // Removes event listeners that track resizing
+    componentWillUnmounnt = () => {  
+        // window.removeEventListener("resize", this.resize)
+    }
+
+    // Turns dates into numeric representations for graphing
+    processForGraphing = (data, xVar, xVarNumber, yVar, progressionToValueMap) => { 
+        // 1. Translate time strings into millisecond representations, storing in a new key:value pair
+        const dataCopy = Lang.clone(data);
+        Collection.map(dataCopy, (d) => { 
+            d[xVarNumber]  = Number(new Date(d[xVar]))
+        });
+
+        // 2. Translate progression status values into numeric representations, inplace
+        dataCopy.map((d, i) => { 
+            const status = d[yVar];
+            const numberBasedOnStatus = progressionToValueMap[status];
+            d[yVar] = numberBasedOnStatus;
+        })
+        return dataCopy;
+    }
+
+    // Function for formatting dates -- uses moment for quick formatting options
+    dateFormat = (timeInMilliseconds) => {
+        return moment(timeInMilliseconds).format('DD MMM YY');
+    }
+
+    // Gets the min/max values of the numeric representation of xVar
+    // Assumes processed data array 
+    getMinMax = (processedData, xVarNumber) => { 
+        // Iterate once to avoid 2x iteration by calling min and max separately
+        return Collection.reduce(processedData, (rangeValues, dataObj) => {
+            const t = dataObj[xVarNumber];
+            
+            if (t < rangeValues[0]) { 
+                rangeValues[0] = t;
+            } else if (t > rangeValues[1]) { 
+                rangeValues[1] = t;
+            }
+            return rangeValues;
+        }, [processedData[0][xVarNumber], processedData[0][xVarNumber]]);
+
+    }
+
+    // Use min/max info to build ticks for the 
+    // Assumes processed data
+    getTicks = (processedData, xVarNumber) => { 
+        if (!processedData || !processedData.length ) {return [];}
+
+        const domain = this.getMinMax(processedData, xVarNumber);
+        const scale = scaleLinear().domain(domain).range([0, 1]);;
+        const ticks = scale.ticks(4);
+        return ticks.sort();
+    } 
+
+    // Formats a xVar (numeric time) value for tooltips
+    xVarFormatFunction = (xVarNumber)  => { 
+        return "Date: " + this.dateFormat(xVarNumber);
+    }   
+
+    // Based on a unit, return a function that formats a yVar (quantatative) value for tooltips 
+    createYVarFormatFunctionWithUnit = (unit) => { 
+        return (value) => { 
+            return `${value} ${unit}`;
+        }
+    }
+
+    // Updates the dimensions of the chart
+    updateDimensions = () => { 
+        const chartParentDivWidth = this.chartParentDiv.offsetWidth;
+
+        this.setState({ 
+            chartWidth: chartParentDivWidth,
+        })
+    }
+
+    renderProgressionChart = (patient, condition, conditionSection) => { 
+        // FIXME: Should start_time be a magic string?
+        const xVar = "start_time";
+        const xVarNumber = `${xVar}Number`;
+        const yVar = "Disease status";
+        const data = subsection.itemsFunction(patient, condition, subsection);  
+        // process dates into numbers for graphing
+        const processedData = this.processForGraphing(data, xVar, xVarNumber, yVar, conditionSection.progressionToValueMap);
+        const yUnit = processedData[0].unit;
+        return (
+            <div 
+                ref={(chartParentDiv) => {this.chartParentDiv = chartParentDiv;}}
+                key={subsection}
+            >
+                <div className="sub-section-heading">
+                    <h2 className="sub-section-name">
+                        {`${yVar} (${yUnit})`}
+                    </h2>
+                </div>
+                <LineChart
+                    width={this.state.chartWidth}
+                    height={this.state.chartHeight}
+                    data={processedData}
+                    margin={{ top: 5, right: 20, left: 10, bottom: 5 }}
+                >
+                    <XAxis 
+                        dataKey={xVarNumber} 
+                        type="number"
+                        domain={[]}
+                        ticks={this.getTicks(processedData, xVarNumber)} 
+                        tickFormatter={this.dateFormat}
+                    />
+                    <YAxis 
+                        dataKey={yVar}
+                        formatter={this.progressionFormat}
+                    />
+                    <Tooltip 
+                        labelFormatter={this.xVarFormatFunction}
+                        formatter={this.createYVarFormatFunctionWithUnit(yUnit)}
+                    />
+                    <Line type="monotone" dataKey={yVar} stroke="#295677" yAxisId={0} />
+                </LineChart>
+           </div>
+        );
+    }
+
+    // Gets called for each section in SummaryMetaData.jsx
+    render() {
+        const {patient, condition, conditionSection} = this.props;
+
+        return (
+            <div className="line-chart-subsection">
+                {
+                    this.renderProgressionChart(patient, condition, conditionSection)
+                }
+            </div>
+        );
+    }
+}
+
+ProgressionLineChartVisualizer.propTypes = {
+    patient: PropTypes.object,
+    condition: PropTypes.object,
+    conditionSection: PropTypes.object,
+    isWide: PropTypes.bool,
+    onItemClicked: PropTypes.func,
+    allowItemClick: PropTypes.bool
+};
+
+export default ProgressionLineChartVisualizer;

--- a/src/summary/ProgressionLineChartVisualizer.jsx
+++ b/src/summary/ProgressionLineChartVisualizer.jsx
@@ -126,8 +126,34 @@ class ProgressionLineChartVisualizer extends Component {
         const xVar = "start_time";
         const xVarNumber = `${xVar}Number`;
         const yVar = "Disease status";
-        const codeToValueMap = conditionSection.codeToValueMap;
-        const valueToProgressionMap = conditionSection.valueToProgressionMap;
+        const codeToValueMap =  {
+            // 'Complete Response'
+            "C0677874": 2,
+            // 'Complete Resection'
+            "C0015250": 2,
+            // 'Responding'
+            "C1272745": 1,
+            // 'Stable'
+            "C0205360": 0,
+            // 'Progressing'
+            "C1546960": -1,
+            // 'Inevaluable'
+            "C3858734": null,
+        };
+         const valueToProgressionMap = {
+            // 'Complete Response'
+            "3" : 'Complete Response',
+            // 'Complete Resection'
+            "2" : 'Complete Resection',
+            // 'Responding'
+            "1" : 'Responding',
+            // 'Stable'
+            "0" : 'Stable',
+            // 'Progressing'
+            "-1" : 'Progressing',
+            // 'Inevaluable'
+            "null" : 'Inevaluable',
+        };
         const data = conditionSection.itemsFunction(patient, condition, conditionSection);  
         // process dates into numbers for graphing
         const processedData = this.processForGraphing(data, xVar, xVarNumber, yVar, codeToValueMap);

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -208,10 +208,10 @@ class SummaryMetadata {
                     },
                     {
                         name: "Disease Status",
-                        // clinicalEvents: ["pre-encounter"],
+                        clinicalEvents: ["pre-encounter"],
                         type: "DiseaseStatusValues",
                         itemsFunction: this.getProgressions,
-                        progressionToValueMap: {
+                        codeToValueMap: {
                             // 'Complete Response'
                             "C0677874": 2,
                             // 'Complete Resection'

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -208,16 +208,36 @@ class SummaryMetadata {
                     },
                     {
                         name: "Disease Status",
-                        clinicalEvents: ["pre-encounter"],
+                        // clinicalEvents: ["pre-encounter"],
                         type: "DiseaseStatusValues",
-                        itemsFunction: this.getProgressions
+                        itemsFunction: this.getProgressions,
                         progressionToValueMap: {
-                            'Complete Response': 2,
-                            'Complete Resection': 2,
-                            'Responding': 1,
-                            'Stable': 0,
-                            'Progressing': -1,
-                            'Inevaluable': null,
+                            // 'Complete Response'
+                            "C0677874": 2,
+                            // 'Complete Resection'
+                            "C0015250": 2,
+                            // 'Responding'
+                            "C1272745": 1,
+                            // 'Stable'
+                            "C0205360": 0,
+                            // 'Progressing'
+                            "C1546960": -1,
+                            // 'Inevaluable'
+                            "C3858734": null,
+                        },  
+                        valueToProgressionMap: {
+                            // 'Complete Response'
+                            "3" : 'Complete Response',
+                            // 'Complete Resection'
+                            "2" : 'Complete Resection',
+                            // 'Responding'
+                            "1" : 'Responding',
+                            // 'Stable'
+                            "0" : 'Stable',
+                            // 'Progressing'
+                            "-1" : 'Progressing',
+                            // 'Inevaluable'
+                            "null" : 'Inevaluable',
                         }
                     },
                     {
@@ -537,17 +557,17 @@ class SummaryMetadata {
         const progressions = patient.getProgressionsForConditionChronologicalOrder(condition);
 
         return progressions.map((prog, i) => {
-            console.log(prog);
 
             const status = prog.status;
+            const code = prog.code
             const focalCondition = patient.getFocalConditionForProgression(prog);
             const focalConditionName = focalCondition.type;
             const tooltipText = focalConditionName + " is " + status + " based on " + prog.evidence.join();
 
             return {
-                "start_time" : prog.asOfDate;
-                "Disease status" : prog.status;
-                "tooltipText" : tooltipText
+                "start_time" : prog.asOfDate,
+                "Disease status" : code,
+                "tooltipText" : tooltipText,
             };
         });
     }
@@ -564,6 +584,7 @@ class SummaryMetadata {
             let classes = 'progression-item';
             // Do not include progression on timeline if status not set
             if (!prog.status) return;
+
             let startDate = new moment(prog.asOfDate, "D MMM YYYY");
             let hoverText = `${startDate.format('MM/DD/YYYY')}`;
             let endDate = startDate.clone().add(1, 'day');

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -559,7 +559,7 @@ class SummaryMetadata {
         return progressions.map((prog, i) => {
 
             const status = prog.status;
-            const code = prog.code
+            const code = prog.statusAsCode
             const focalCondition = patient.getFocalConditionForProgression(prog);
             const focalConditionName = focalCondition.type;
             const tooltipText = focalConditionName + " is " + status + " based on " + prog.evidence.join();

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -211,34 +211,6 @@ class SummaryMetadata {
                         clinicalEvents: ["pre-encounter"],
                         type: "DiseaseStatusValues",
                         itemsFunction: this.getProgressions,
-                        codeToValueMap: {
-                            // 'Complete Response'
-                            "C0677874": 2,
-                            // 'Complete Resection'
-                            "C0015250": 2,
-                            // 'Responding'
-                            "C1272745": 1,
-                            // 'Stable'
-                            "C0205360": 0,
-                            // 'Progressing'
-                            "C1546960": -1,
-                            // 'Inevaluable'
-                            "C3858734": null,
-                        },  
-                        valueToProgressionMap: {
-                            // 'Complete Response'
-                            "3" : 'Complete Response',
-                            // 'Complete Resection'
-                            "2" : 'Complete Resection',
-                            // 'Responding'
-                            "1" : 'Responding',
-                            // 'Stable'
-                            "0" : 'Stable',
-                            // 'Progressing'
-                            "-1" : 'Progressing',
-                            // 'Inevaluable'
-                            "null" : 'Inevaluable',
-                        }
                     },
                     {
                         name: "Labs",

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -207,6 +207,15 @@ class SummaryMetadata {
                         ]
                     },
                     {
+                        name: "Disease Status",
+                        clinicalEvents: ["pre-encounter"],
+                        type: "DiseaseStatusValues",
+                        data: {
+                            name: "",
+                            itemsFunction: this.getDiseaseStatuses
+                        }
+                    },
+                    {
                         name: "Labs",
                         type: "ValueOverTime",
                         data: [
@@ -501,7 +510,8 @@ class SummaryMetadata {
         });
     }
 
-    getTestsForSubSection = (patient, currentConditionEntry, subsection) => {
+    getTestsForSubSection = (patient, currentConditionEntry, subsection) => { 
+        if (Lang.isNull(patient) || Lang.isNull(currentConditionEntry)) return [];
         const labResults = currentConditionEntry.getTests();
 
         const labs = labResults.filter((lab, i) => {
@@ -515,6 +525,19 @@ class SummaryMetadata {
             return processedLab
         });
         return labs
+    }
+
+    getDiseaseStatuses = (patient, condition) => { 
+        if (Lang.isNull(patient) || Lang.isNull(condition)) return [];
+        const progressions = patient.getProgressionsForConditionChronologicalOrder(condition);
+
+        return progressions.map((prog, i) => {
+            const processedProgression = {};
+            processedProgression["start_time"] = prog.asOfDate;
+            // processedProgression[subsection.name] = "";
+
+            console.log(prog);
+        });
     }
 
     getMedicationItems = (patient, condition) => {
@@ -573,7 +596,7 @@ class SummaryMetadata {
                 group: assignedGroup,
                 icon: 'hospital-o',
                 className: classes,
-                hoverTitle: proc.specificType.value.coding[0].displayText.value,
+                hoverTitle: proc.codeableConceptDisplayText,
                 hoverText: hoverText,
                 start_time: startTime,
                 end_time: endTime

--- a/src/summary/TargetedDataSection.jsx
+++ b/src/summary/TargetedDataSection.jsx
@@ -5,6 +5,7 @@ import TabularListVisualizer from './TabularListVisualizer'; //ordering of these
 import TabularNameValuePairsVisualizer from './TabularNameValuePairsVisualizer';
 import NarrativeNameValuePairsVisualizer from './NarrativeNameValuePairsVisualizer';
 import BandedLineChartVisualizer from './BandedLineChartVisualizer';
+import ProgressionLineChartVisualizer from './ProgressionLineChartVisualizer';
 import TimelineEventsVisualizer from '../timeline/TimelineEventsVisualizer';
 import './TargetedDataSection.css';
 
@@ -151,6 +152,8 @@ class TargetedDataSection extends Component {
             options.push('graphic');
         } else if (section.type === "ValueOverTime") { 
             options.push('chart');
+        } else if (section.type === "DiseaseStatusValues") {
+            options.push('chart');
         }
         return options;
     }
@@ -233,6 +236,22 @@ class TargetedDataSection extends Component {
                 } else { 
                     return null;
                 }
+            }
+            case 'DiseaseStatusValues' : { 
+                if (visualization === 'chart') { 
+                    return (
+                        <ProgressionLineChartVisualizer
+                            patient={patient}
+                            condition={condition}
+                            conditionSection={section}
+                            onItemClicked={onItemClicked}
+                            allowItemClick={allowItemClick}
+                            isWide={isWide}
+                        />
+                    );
+                } else { 
+                    return null;
+                }   
             }
             case 'Events': {
                 if (visualization === 'graphic') {


### PR DESCRIPTION
For JIRA 837 - Implement Progression as a line graph visualization

Creates a new visualization component and a new data type for disease status/progression. 

Known issues: 
- While we use Disease Status as the keyword in our application, anything SHR generated uses "progression" instead. This can lead to naming and reference ambiguities throughout our code. Something to discuss so we can define best practices/when variables should be named one after the other. 
- Right now the viz is disabled unless in pre-encounter mode, but because there are issues with resizing viewing this visualization in a demo setting would be impermissible. To see why, see what happens when you go from post- to pre- and back to post-encounter mode -- the WBC will be thrown all out of wack. If we want this vis present in a demo and if we don't fix the resizing, then we may wan to remove the clinicalEvent specific viewing. 

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- N/A Cheat sheet is updated
- N/A Demo script is updated 
- N/A Documentation on Wiki has been updated 
- N/A Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- N/A Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x ] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- N/A Added UI tests for slim mode 
- N/A Added UI tests for full mode
- N/A Added backend tests for fluxNotes code
- N/A Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
