### PR TITLE
Resize components correctly

### DIFF
--- a/src/summary/BandedLineChartVisualizer.jsx
+++ b/src/summary/BandedLineChartVisualizer.jsx
@@ -35,7 +35,7 @@ class BandedLineChartVisualizer extends Component {
 
     // Adds appropriate event listeners for tracking resizing
     componentDidMount = () => {
-        setTimeout(this.resize, 100);
+        setTimeout(this.resize, 450);
     }
 
     // Turns dates into numeric representations for graphing

--- a/src/summary/BandedLineChartVisualizer.jsx
+++ b/src/summary/BandedLineChartVisualizer.jsx
@@ -4,7 +4,6 @@ import moment from 'moment';
 import {scaleLinear} from "d3-scale";
 import Collection from 'lodash';
 import Lang from 'lodash';
-import Function from 'lodash';
 import PropTypes from 'prop-types';
 
 import './BandedLineChartVisualizer.css';
@@ -16,7 +15,6 @@ class BandedLineChartVisualizer extends Component {
     constructor(props) {
         super(props);
 
-        this.resize = Function.throttle(this.updateDimensions, 100);
         this.updateState = true;
         // This var will be used 
         this.state = {
@@ -31,20 +29,13 @@ class BandedLineChartVisualizer extends Component {
             this.updateState = false;
         } else {
             this.updateState = true;
-            // this.resize();
+            setTimeout(this.resize, 450);
         }
     }
 
     // Adds appropriate event listeners for tracking resizing
     componentDidMount = () => {
-        // window.addEventListener("resize", this.resize);
-        // this.chartParentDiv.addEventListener("resize", this.resize);
         setTimeout(this.resize, 100);
-    }
-
-    // Removes event listeners that track resizing
-    componentWillUnmounnt = () => {
-        // window.removeEventListener("resize", this.resize)
     }
 
     // Turns dates into numeric representations for graphing
@@ -106,7 +97,7 @@ class BandedLineChartVisualizer extends Component {
     }
 
     // Updates the dimensions of the chart
-    updateDimensions = () => {
+    resize = () => {
         const chartParentDivWidth = this.chartParentDiv.offsetWidth;
 
         this.setState({

--- a/src/summary/ProgressionLineChartVisualizer.jsx
+++ b/src/summary/ProgressionLineChartVisualizer.jsx
@@ -4,7 +4,6 @@ import moment from 'moment';
 import {scaleLinear} from "d3-scale";
 import Collection from 'lodash';
 import Lang from 'lodash';
-import Function from 'lodash';
 import PropTypes from 'prop-types';
 
 import './ProgressionLineChartVisualizer.css';
@@ -16,7 +15,6 @@ class ProgressionLineChartVisualizer extends Component {
     constructor(props) { 
         super(props);
 
-        this.resize = Function.throttle(this.updateDimensions, 100);
         this.updateState = true;
         // This var will be used 
         this.state = {
@@ -31,20 +29,13 @@ class ProgressionLineChartVisualizer extends Component {
             this.updateState = false;
         } else {
             this.updateState = true;
-            // this.resize();
+            setTimeout(this.resize, 450);
         }
     }
 
     // Adds appropriate event listeners for tracking resizing
     componentDidMount = () => { 
-        // window.addEventListener("resize", this.resize);
-        // this.chartParentDiv.addEventListener("resize", this.resize);
-        setTimeout(this.resize, 100);
-    }
-
-    // Removes event listeners that track resizing
-    componentWillUnmounnt = () => {  
-        // window.removeEventListener("resize", this.resize)
+        setTimeout(this.resize, 450);
     }
 
     // Turns dates into numeric representations for graphing
@@ -113,7 +104,7 @@ class ProgressionLineChartVisualizer extends Component {
     }
 
     // Updates the dimensions of the chart
-    updateDimensions = () => { 
+    resize = () => { 
         const chartParentDivWidth = this.chartParentDiv.offsetWidth;
 
         this.setState({ 

--- a/src/summary/TargetedDataSection.css
+++ b/src/summary/TargetedDataSection.css
@@ -11,4 +11,5 @@
 .right-icons {
     float: right;
     padding-right: 10px;
+    display: flex;
 }

--- a/src/timeline/TimelineEventsVisualizer.jsx
+++ b/src/timeline/TimelineEventsVisualizer.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Legend from './TimelineLegend';
 import HoverItem from './HoverItem';
 import Timeline from 'react-calendar-timeline';
+import containerResizeDetector from 'react-calendar-timeline/lib/resize-detector/container';
 import Item from './Item';
 import moment from 'moment';
 import './TimelineEventsVisualizer.css';
@@ -50,10 +51,17 @@ class TimelineEventsVisualizer extends Component {
         if (this.props !== nextProps) {
             const items = this.createItems(nextProps.patient, nextProps.condition, nextProps.section);
             const groups = this.createGroupsForItems(this.getMaxGroup(items));
+            let defaultTimeStart;
+            if (nextProps.isWide) { 
+                defaultTimeStart = moment().clone().add(-3, 'years');  // wideview - 3 years ago
+            } else {
+                defaultTimeStart = moment().clone().add(-1, 'years');
+            }
 
             this.setState({
                 items,
-                groups
+                groups,
+                defaultTimeStart
             });
         }
     }
@@ -143,23 +151,26 @@ class TimelineEventsVisualizer extends Component {
                     text={this.state.hoverItem.text}
                     style={this.state.hoverItem.style}
                 />
-                <Timeline
-                    groups={this.state.groups}
-                    items={this.state.items}
-                    defaultTimeStart={this.state.defaultTimeStart}
-                    defaultTimeEnd={this.state.defaultTimeEnd}
-                    rightSidebarWidth={0}
-                    rightSidebarContent={null}
-                    sidebarWidth={0}
-                    sidebarContent={null}
-                    timeSteps={this.state.timeSteps}
-                    lineHeight={40}
-                    itemHeightRatio={0.7}
-                    itemRenderer={Item}
-                    canMove={false}
-                    canResize={false}
-                    canSelect={false}
-                />
+                {/* Null check to ensure timeline is rendered  */}
+                {this.props.condition ?
+                    <Timeline
+                        resizeDetector={containerResizeDetector}
+                        groups={this.state.groups}
+                        items={this.state.items}
+                        defaultTimeStart={this.state.defaultTimeStart}
+                        defaultTimeEnd={this.state.defaultTimeEnd}
+                        rightSidebarWidth={0}
+                        rightSidebarContent={null}
+                        sidebarWidth={0}
+                        sidebarContent={null}
+                        timeSteps={this.state.timeSteps}
+                        lineHeight={40}
+                        itemHeightRatio={0.7}
+                        itemRenderer={Item}
+                        canMove={false}
+                        canResize={false}
+                        canSelect={false}
+                    /> : null}
                 <Legend
                   items={this.state.legendItems}
                 />


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

This makes it so that the LineChart and Timeline Visualizers get resized properly when switching Views (pre/post encounter). The timeline component handled resizing differently than the line chart, so the solutions for fixing each were slightly different.

The Jira item for this task also mentioned considering whether to change the display for tabular components that only have one table. After talking with Greg, I'm going to make a separate Jira to handle that.

## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- [] Cheat sheet is updated
- [] Demo script is updated 
- [] Documentation on Wiki has been updated 
- [] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [] Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- [] Added UI tests for slim mode 
- [] Added UI tests for full mode
- [] Added backend tests for fluxNotes code
- [] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
