### PR TITLE
Get Lab results passes in months since today as a parameter 

### DIFF
--- a/src/model/oncology/FluxBreastCancer.js
+++ b/src/model/oncology/FluxBreastCancer.js
@@ -39,6 +39,8 @@ class FluxBreastCancer extends BreastCancer {
         return this.getObservationsOfType(FluxTest);
     }
 
+
+    // This method takes in a sinceDate, oldest date acceptable. All results returned must be more recent than sinceDate
     getLabResultsChronologicalOrder(sinceDate) {
 
         let results = this.getTests();

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -492,9 +492,11 @@ class SummaryMetadata {
     getItemListForLabResults = (patient, currentConditionEntry) => {
         if (Lang.isNull(patient) || Lang.isNull(currentConditionEntry)) return [];
 
-        // Set sinceDate to null to get all results
-        const sinceDate = "16 AUG 2010";
-        const labResultsInOrder = currentConditionEntry.getLabResultsChronologicalOrder(sinceDate);
+        // Set the max number of months prior to today that a lab result can be
+        const numberOfMonths = 6;
+
+        // labResultsInOrder contains all lab results within a specified number of months from today
+        const labResultsInOrder = currentConditionEntry.getLabResultsChronologicalOrder(moment().subtract(numberOfMonths, 'months'));
 
         return labResultsInOrder.map((l, i) => {
             const value = `${l.quantity.number} ${l.quantity.unit} (${l.clinicallyRelevantTime})`;


### PR DESCRIPTION
Small fix to getting lab results. Return all lab results within x months (currently this is hard coded to 6 months). The method to filter lab results in FluxBreastCancer.js accepts a since date that is calculated by taking today and subtracting the number of months.


_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- N/A Cheat sheet is updated
- N/A Demo script is updated 
- N/A Documentation on Wiki has been updated 
- N/A Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- N/A Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- N/A Added UI tests for slim mode 
- N/A Added UI tests for full mode
- N/A Added backend tests for fluxNotes code
- N/A Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
