### PR TITLE
Laterality option

### DIFF
--- a/src/dataaccess/HardCodedPatient.json
+++ b/src/dataaccess/HardCodedPatient.json
@@ -107,6 +107,7 @@
         "specificType": {"value": {"coding": [{"value": "408643008", "codeSystem": {"value": "http://snomed.info/sct"}, "displayText": "Invasive ductal carcinoma of breast"}]}},
         "category": [ {"coding": [{"value": "#disease"}]} ],
         "clinicalStatus": "recurrence",
+        "bodySite": {"laterality": {"value": {"coding": [{"value": "C25228", "codeSystem": {"value": "https://evs.nci.nih.gov/ftp1/CDISC/SDTM/"}, "displayText": "Right"}]}}},
         "includeOnProblemList": true,
         "whenClinicallyRecognized": {"generalizedTemporalContext": { "timePeriodStart": "13 JAN 2012" } },
         "observation": [

--- a/src/lib/laterality_lookup.jsx
+++ b/src/lib/laterality_lookup.jsx
@@ -1,0 +1,26 @@
+import codeableConceptUtils from '../model/CodeableConceptUtils.jsx';
+
+const lateralityOptions = [
+    {
+        name: 'Left', 
+        description: "Being or located on or directed toward the side of the body to the west when facing north",
+        code: "C25229",
+        codeSystem: "https://evs.nci.nih.gov/ftp1/CDISC/SDTM/"
+    },
+    {
+        name: 'Right',
+        description: "Being or located on or directed toward the side of the body to the east when facing north.",
+        code: "C25228",
+        codeSystem: "https://evs.nci.nih.gov/ftp1/CDISC/SDTM/"
+    }
+];
+
+
+/*
+ * Searches for value in lateralityOptions list
+ * Will return CodeableConcept object with empty strings if not found
+ * If value found in list, function will return CodeableConcept with value, codeSystem, and displayText
+ */
+exports.getReceptorCodeableConcept = (possibleReceptorValue) => {
+    return codeableConceptUtils.getCodeableConceptFromOptions(possibleReceptorValue, receptorOptions);
+}

--- a/src/model/oncology/FluxBreastCancer.js
+++ b/src/model/oncology/FluxBreastCancer.js
@@ -167,7 +167,14 @@ class FluxBreastCancer extends BreastCancer {
         } else {
             return s;
         }
+    }    
+  
+    get laterality() {
+        if (!this.bodySite && !this.bodySite.laterality) return null;
+        return this.bodySite.laterality.value.coding[0].displayText.value;        
     }
+
+
 }
 
 export default FluxBreastCancer;

--- a/src/model/shr/condition/Condition.js
+++ b/src/model/shr/condition/Condition.js
@@ -21,7 +21,6 @@ export function initCondition() {
                 if (json.category) this._category = json.category.map((c) => new Category(c));
                 if (json.clinicalStatus) this._clinicalStatus = new ClinicalStatus(json.clinicalStatus);
                 this._whenClinicallyRecognized = new WhenClinicallyRecognized(json.whenClinicallyRecognized);
-                //if (json.bodySite) this._bodySite = new BodySite(json.bodySite);
                 if (json.observation) this._observation = json.observation.map((o) => ShrObjectFactory.createInstance(o.entryType[0], o));
             } else {
                 this._entryInfo = Entry.createEntry("http://standardhealthrecord.org/condition/Condition");

--- a/src/model/shr/condition/Condition.js
+++ b/src/model/shr/condition/Condition.js
@@ -21,6 +21,7 @@ export function initCondition() {
                 if (json.category) this._category = json.category.map((c) => new Category(c));
                 if (json.clinicalStatus) this._clinicalStatus = new ClinicalStatus(json.clinicalStatus);
                 this._whenClinicallyRecognized = new WhenClinicallyRecognized(json.whenClinicallyRecognized);
+                //if (json.bodySite) this._bodySite = new BodySite(json.bodySite);
                 if (json.observation) this._observation = json.observation.map((o) => ShrObjectFactory.createInstance(o.entryType[0], o));
             } else {
                 this._entryInfo = Entry.createEntry("http://standardhealthrecord.org/condition/Condition");

--- a/src/model/shr/core/BodySite.js
+++ b/src/model/shr/core/BodySite.js
@@ -1,5 +1,12 @@
+import Laterality from './Laterality';
 /** Generated from SHR definition for shr.core.BodySite */
 class BodySite {
+        constructor(json) {
+        if (json) {
+            this._laterality = new Laterality(json.laterality);
+            
+        } 
+    }
 
   /**
    * Convenience getter for value (accesses this.codeableConcept)

--- a/src/model/shr/core/Laterality.js
+++ b/src/model/shr/core/Laterality.js
@@ -1,6 +1,12 @@
+import CodeableConcept from './CodeableConcept';
 /** Generated from SHR definition for shr.core.Laterality */
 class Laterality {
+    constructor(json) {
+        if (json) {
+            this.codeableConcept = new CodeableConcept(json.value);
 
+        } 
+    }
   /**
    * Convenience getter for value (accesses this.codeableConcept)
    */

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -45,6 +45,12 @@ class SummaryMetadata {
                                         shortcut: "@condition"
                                     },
                                     {
+                                        name: "Laterality",
+                                        value: (patient, currentConditionEntry) => {
+                                            return currentConditionEntry.laterality;
+                                        },
+                                    },                                    
+                                    {
                                         name: "Stage",
                                         value: (patient, currentConditionEntry) => {
                                             let s = currentConditionEntry.getMostRecentStaging();

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -14,7 +14,7 @@ class SummaryMetadata {
                         /*eslint no-template-curly-in-string: "off"*/
                         narrative: [
                             {
-                                defaultTemplate: "Patient has ${Current Diagnosis.Name} stage ${Current Diagnosis.Stage}"
+                                defaultTemplate: "Patient has ${Current Diagnosis.Name} laterality ${Current Diagnosis.Laterality} stage ${Current Diagnosis.Stage}"
                             },
                             {
                                 defaultTemplate: "As of ${Current Diagnosis.As Of Date}, disease is ${Current Diagnosis.Disease Status} based on ${Current Diagnosis.Rationale}",

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -48,7 +48,7 @@ class SummaryMetadata {
                                         name: "Laterality",
                                         value: (patient, currentConditionEntry) => {
                                             return currentConditionEntry.laterality;
-                                        },
+                                        }
                                     },                                    
                                     {
                                         name: "Stage",


### PR DESCRIPTION
In the summary panel for the patient there is now a laterality section that has been set to "Right" in the hard coded patient json. 


## Submitter: Laura

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- NA Cheat sheet is updated
- NA Demo script is updated 
- NA Documentation on Wiki has been updated 
- NA Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- NA Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- NA Added UI tests for slim mode 
- NA Added UI tests for full mode
- NA Added backend tests for fluxNotes code
- NA Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
