### PR TITLE
Implement @HPI shortcut

### DIFF
--- a/src/model/condition/FluxCondition.js
+++ b/src/model/condition/FluxCondition.js
@@ -96,7 +96,7 @@ class FluxCondition extends Condition {
             return results;
         });
 
-        // Generate array from lookup table to pass back to summary meta data 
+        // Generate array from lookup table
         let mostRecentLabResultsArray = [];
 
         for (var key in mostRecentLabResultsLookupTable) {

--- a/src/model/condition/FluxCondition.js
+++ b/src/model/condition/FluxCondition.js
@@ -1,5 +1,10 @@
 import Condition from '../shr/condition/Condition';
+import FluxTest from '../lab/FluxTest';
+import FluxProcedure from '../procedure/FluxProcedure';
+import FluxMedicationPrescription from '../medication/FluxMedicationPrescription';
+import FluxProgression from '../oncology/FluxProgression';
 import Lang from 'lodash';
+import moment from 'moment';
 
 class FluxCondition extends Condition {
     get diagnosisDate() {
@@ -10,6 +15,254 @@ class FluxCondition extends Condition {
     get type() {
         if (!this.specificType) return null;
         return this.specificType.value.coding[0].displayText.value;
+    }
+
+    getObservationsOfType(type) {
+        if (!this.observation) return [];
+        return this.observation.filter((item) => {
+            return item instanceof type;
+        });
+    }
+
+    getTests() {
+        return this.getObservationsOfType(FluxTest);
+    }
+
+    // This method takes in a sinceDate, oldest date acceptable. All results returned must be more recent than sinceDate
+    getLabResultsChronologicalOrder(sinceDate) {
+        let results = this.getTests();
+        results.sort(this._labResultsTimeSorter);
+
+        let mostRecentLabResults = results;
+
+        if (sinceDate && !Lang.isNull(sinceDate)) {
+            mostRecentLabResults = this.getMostRecentLabResults(results, sinceDate);
+        }
+
+        return mostRecentLabResults;
+    }
+
+    // Sorts the lab results in chronological order
+    _labResultsTimeSorter(a, b) {
+        const a_startTime = new moment(a.clinicallyRelevantTime, "D MMM YYYY");
+        const b_startTime = new moment(b.clinicallyRelevantTime, "D MMM YYYY");
+        if (a_startTime < b_startTime) {
+            return -1;
+        }
+        if (a_startTime > b_startTime) {
+            return 1;
+        }
+        return 0;
+    }
+
+    // Grab the most recent lab results within a set threshold date
+    getMostRecentLabResults(results, sinceDate) {
+        let mostRecentLabResultsLookupTable = {};
+
+        // Convert the sinceDate to a moment.js date
+        let sinceDateMoment = new moment(sinceDate, "D MMM YYYY");
+
+        // Create mostRecentLabResultsLookupTable with unique lab results that fall after threshold date
+        results.map((lab, i) => {
+            const startTime = new moment(lab.clinicallyRelevantTime, "D MMM YYYY");
+
+            // Check that the current lab result date is more later than the threshold date
+            if (startTime > sinceDateMoment) {
+                let id = lab.specificType.value.coding[0].code;
+
+                // Check that the lab result type (i.e hemoglobin, white blood cell, etc) doesn't already exist in the lookup table
+                if (!mostRecentLabResultsLookupTable[id]) {
+
+                    // If the lab result type doesn't already exist, add it to the table
+                    mostRecentLabResultsLookupTable[id] = {
+                        labResult: lab,
+                        clinicallyRelevantTime: lab.clinicallyRelevantTime
+                    }
+                } else {
+                    // Check if current lab result is the most recent compared to what is in the lookup table
+                    let time1 = new moment(mostRecentLabResultsLookupTable[id].clinicallyRelevantTime, "D MMM YYYY");
+                    let time2 = new moment(lab.clinicallyRelevantTime, "D MMM YYYY");
+
+                    // If the current lab result is more recent than what is stored in the lookup table, update the data
+                    // Lookup will only contain the most recent lab result for that type
+                    if (time2 > time1) {
+                        mostRecentLabResultsLookupTable[id] = {
+                            labResult: lab,
+                            clinicallyRelevantTime: lab.clinicallyRelevantTime
+                        }
+                    }
+                }
+            }
+            return results;
+        });
+
+        // Generate array from lookup table to pass back to summary meta data 
+        let mostRecentLabResultsArray = [];
+
+        for (var key in mostRecentLabResultsLookupTable) {
+            if (mostRecentLabResultsLookupTable.hasOwnProperty(key)) {
+                mostRecentLabResultsArray.push(mostRecentLabResultsLookupTable[key].labResult);
+            }
+        }
+
+        return mostRecentLabResultsArray;
+    }
+
+    /**
+     *  function to build HPI Narrative
+     *  Starts with initial summary of patient information
+     *  Then details chronological history of patient's procedures, medications, and most recent progression
+     */
+    buildHpiNarrative(patient) {
+        // Initial patient introduction section
+        const name = patient.getName();
+        const age = patient.getAge();
+        const gender = patient.getGender();
+
+        let hpiText = `${name} is a ${age} year old ${gender}.`;
+        hpiText += ` Patient was diagnosed with ${this.type} on ${this.diagnosisDate}.`;
+        
+        // Build narrative from sorted events
+        // Get procedures, medications, recent lab results, and most recent progression from patient
+        // Sort by start time and add snippets about each event to result text
+        let events = [];
+        events = events.concat(patient.getProceduresForCondition(this));
+        events = events.concat(patient.getMedicationsForConditionChronologicalOrder(this));
+        events = events.concat(this.getLabResultsChronologicalOrder(moment().subtract(6, 'months')));
+        const recentProgression = patient.getMostRecentProgressionForCondition(this);
+        if (recentProgression) {
+            events.push(recentProgression);
+        }
+        events.sort(this._eventsTimeSorter);
+
+        const procedureTemplates = {
+            range: 'Patient underwent {0} from {1} to {2}.',
+            single: 'Patient underwent {0} on {1}.'
+        };
+        const medicationTemplates = {
+            range: 'Patient took {0} from {1} to {2}.',
+            single: 'Patient started {0} on {1}.'
+        };
+        const today = new moment();
+        events.forEach((event) => {
+            console.log(event);
+            switch (event.constructor) {
+                case FluxProcedure: {
+                    if (event.occurrenceTime.timePeriodStart) {
+                        let procedureText = '\r\n' + procedureTemplates['range'];
+                        procedureText = procedureText.replace('{0}', event.name);
+                        procedureText = procedureText.replace('{1}', event.occurrenceTime.timePeriodStart);
+                        procedureText = procedureText.replace('{2}', event.occurrenceTime.timePeriodEnd);
+                        hpiText += procedureText;
+                    } else {
+                        let procedureText = '\r\n' + procedureTemplates['single'];
+                        procedureText = procedureText.replace('{0}', event.name);
+                        procedureText = procedureText.replace('{1}', event.occurrenceTime);
+                        hpiText += procedureText;
+                    }
+                    break;
+                }
+                case FluxMedicationPrescription: {
+                    const active = event.isActiveAsOf(today);
+                    if (!active) {
+                        let medicationText = '\r\n' + medicationTemplates['range'];
+                        medicationText = medicationText.replace('{0}', event.medication);
+                        medicationText = medicationText.replace('{1}', event.requestedPerformanceTime.timePeriodStart);
+                        medicationText = medicationText.replace('{2}', event.requestedPerformanceTime.timePeriodEnd);
+                        hpiText += medicationText;
+                    } else {
+                        let medicationText = '\r\n' + medicationTemplates['single'];
+                        medicationText = medicationText.replace('{0}', event.medication);
+                        medicationText = medicationText.replace('{1}', event.requestedPerformanceTime.timePeriodStart);
+                        hpiText += medicationText;
+                    }
+                    break;
+                }
+                case FluxProgression: {
+                    if (event.asOfDate && event.status) {
+                        hpiText += `\r\nAs of ${event.asOfDate}, disease is ${event.status}`;
+                        if (event.evidence && event.evidence.length > 0) {
+                            hpiText += ` based on ${event.evidence.join(', ')}.`;
+                        } else {
+                            hpiText += '.';
+                        }
+                    }
+                    break;
+                }
+                case FluxTest: {
+                    if (event.quantity && event.quantity.number && event.quantity.unit) {
+                        hpiText += `\r\nPatient had a ${event.name} lab result of ${event.quantity.number} ${event.quantity.unit} on ${event.clinicallyRelevantTime}.`;
+                    }
+                    break;
+                }
+                default: {
+                    console.error("There should only be instances of FluxProcedure, FluxMedicationPrescription, and FluxProgression");
+                }
+            }
+        });
+        
+        return hpiText;
+    }
+
+    // sorter for array with instances of FluxProcedure, FluxMedicationPrescription, and FluxProgression
+    _eventsTimeSorter(a, b) {
+        let a_startTime, b_startTime;
+
+        switch (a.constructor) {
+            case FluxProcedure: {
+                a_startTime = new moment(a.occurrenceTime, "D MMM YYYY");
+                if (!a_startTime.isValid()) a_startTime = new moment(a.occurrenceTime.timePeriodStart, "D MMM YYYY");
+                break;
+            }
+            case FluxMedicationPrescription: {
+                a_startTime = new moment(a.requestedPerformanceTime.timePeriodStart, "D MMM YYYY");
+                break;
+            }
+            case FluxProgression: {
+                a_startTime = new moment(a.asOfDate, "D MMM YYYY");
+                break;
+            }
+            case FluxTest: {
+                a_startTime = new moment(a.clinicallyRelevantTime, "D MMM YYYY");
+                break;
+            }
+            default: {
+                console.error("This object is not an instance of FluxProcedure, FluxMedicationPrescription, or FluxProgression.");
+                return 0;
+            }
+        }
+
+        switch (b.constructor) {
+            case FluxProcedure: {
+                b_startTime = new moment(b.occurrenceTime, "D MMM YYYY");
+                if (!b_startTime.isValid()) b_startTime = new moment(b.occurrenceTime.timePeriodStart, "D MMM YYYY");
+                break;
+            }
+            case FluxMedicationPrescription: {
+                b_startTime = new moment(b.requestedPerformanceTime.timePeriodStart, "D MMM YYYY");
+                break;
+            }
+            case FluxProgression: {
+                b_startTime = new moment(b.asOfDate, "D MMM YYYY");
+                break;
+            }
+            case FluxTest: {
+                b_startTime = new moment(b.clinicallyRelevantTime, "D MMM YYYY");
+                break;
+            }
+            default: {
+                console.error("This object is not an instance of FluxProcedure, FluxMedicationPrescription, or FluxProgression.");
+                return 0;
+            }
+        }
+
+        if (a_startTime < b_startTime) {
+            return -1;
+        }
+        if (a_startTime > b_startTime) {
+            return 1;
+        }
+        return 0;
     }
 }
 

--- a/src/model/condition/FluxInjury.js
+++ b/src/model/condition/FluxInjury.js
@@ -1,5 +1,10 @@
 import Injury from '../shr/condition/Injury';
-import Lang from 'lodash';
+import FluxTest from '../lab/FluxTest';
+import FluxProcedure from '../procedure/FluxProcedure';
+import FluxMedicationPrescription from '../medication/FluxMedicationPrescription';
+import FluxProgression from '../oncology/FluxProgression';
+import Lang from 'lodash'
+import moment from 'moment';
 
 class FluxInjury extends Injury {
     get diagnosisDate() {
@@ -10,6 +15,254 @@ class FluxInjury extends Injury {
     get type() {
         if (!this.specificType) return null;
         return this.specificType.value.coding[0].displayText.value;
+    }
+
+    getObservationsOfType(type) {
+        if (!this.observation) return [];
+        return this.observation.filter((item) => {
+            return item instanceof type;
+        });
+    }
+
+    getTests() {
+        return this.getObservationsOfType(FluxTest);
+    }
+
+    // This method takes in a sinceDate, oldest date acceptable. All results returned must be more recent than sinceDate
+    getLabResultsChronologicalOrder(sinceDate) {
+        let results = this.getTests();
+        results.sort(this._labResultsTimeSorter);
+
+        let mostRecentLabResults = results;
+
+        if (sinceDate && !Lang.isNull(sinceDate)) {
+            mostRecentLabResults = this.getMostRecentLabResults(results, sinceDate);
+        }
+
+        return mostRecentLabResults;
+    }
+
+    // Sorts the lab results in chronological order
+    _labResultsTimeSorter(a, b) {
+        const a_startTime = new moment(a.clinicallyRelevantTime, "D MMM YYYY");
+        const b_startTime = new moment(b.clinicallyRelevantTime, "D MMM YYYY");
+        if (a_startTime < b_startTime) {
+            return -1;
+        }
+        if (a_startTime > b_startTime) {
+            return 1;
+        }
+        return 0;
+    }
+
+    // Grab the most recent lab results within a set threshold date
+    getMostRecentLabResults(results, sinceDate) {
+        let mostRecentLabResultsLookupTable = {};
+
+        // Convert the sinceDate to a moment.js date
+        let sinceDateMoment = new moment(sinceDate, "D MMM YYYY");
+
+        // Create mostRecentLabResultsLookupTable with unique lab results that fall after threshold date
+        results.map((lab, i) => {
+            const startTime = new moment(lab.clinicallyRelevantTime, "D MMM YYYY");
+
+            // Check that the current lab result date is more later than the threshold date
+            if (startTime > sinceDateMoment) {
+                let id = lab.specificType.value.coding[0].code;
+
+                // Check that the lab result type (i.e hemoglobin, white blood cell, etc) doesn't already exist in the lookup table
+                if (!mostRecentLabResultsLookupTable[id]) {
+
+                    // If the lab result type doesn't already exist, add it to the table
+                    mostRecentLabResultsLookupTable[id] = {
+                        labResult: lab,
+                        clinicallyRelevantTime: lab.clinicallyRelevantTime
+                    }
+                } else {
+                    // Check if current lab result is the most recent compared to what is in the lookup table
+                    let time1 = new moment(mostRecentLabResultsLookupTable[id].clinicallyRelevantTime, "D MMM YYYY");
+                    let time2 = new moment(lab.clinicallyRelevantTime, "D MMM YYYY");
+
+                    // If the current lab result is more recent than what is stored in the lookup table, update the data
+                    // Lookup will only contain the most recent lab result for that type
+                    if (time2 > time1) {
+                        mostRecentLabResultsLookupTable[id] = {
+                            labResult: lab,
+                            clinicallyRelevantTime: lab.clinicallyRelevantTime
+                        }
+                    }
+                }
+            }
+            return results;
+        });
+
+        // Generate array from lookup table to pass back to summary meta data 
+        let mostRecentLabResultsArray = [];
+
+        for (var key in mostRecentLabResultsLookupTable) {
+            if (mostRecentLabResultsLookupTable.hasOwnProperty(key)) {
+                mostRecentLabResultsArray.push(mostRecentLabResultsLookupTable[key].labResult);
+            }
+        }
+
+        return mostRecentLabResultsArray;
+    }
+
+    /**
+     *  function to build HPI Narrative
+     *  Starts with initial summary of patient information
+     *  Then details chronological history of patient's procedures, medications, and most recent progression
+     */
+    buildHpiNarrative(patient) {
+        // Initial patient introduction section
+        const name = patient.getName();
+        const age = patient.getAge();
+        const gender = patient.getGender();
+
+        let hpiText = `${name} is a ${age} year old ${gender}.`;
+        hpiText += ` Patient was diagnosed with ${this.type} on ${this.diagnosisDate}.`;
+        
+        // Build narrative from sorted events
+        // Get procedures, medications, recent lab results, and most recent progression from patient
+        // Sort by start time and add snippets about each event to result text
+        let events = [];
+        events = events.concat(patient.getProceduresForCondition(this));
+        events = events.concat(patient.getMedicationsForConditionChronologicalOrder(this));
+        events = events.concat(this.getLabResultsChronologicalOrder(moment().subtract(6, 'months')));
+        const recentProgression = patient.getMostRecentProgressionForCondition(this);
+        if (recentProgression) {
+            events.push(recentProgression);
+        }
+        events.sort(this._eventsTimeSorter);
+
+        const procedureTemplates = {
+            range: 'Patient underwent {0} from {1} to {2}.',
+            single: 'Patient underwent {0} on {1}.'
+        };
+        const medicationTemplates = {
+            range: 'Patient took {0} from {1} to {2}.',
+            single: 'Patient started {0} on {1}.'
+        };
+        const today = new moment();
+        events.forEach((event) => {
+            console.log(event);
+            switch (event.constructor) {
+                case FluxProcedure: {
+                    if (event.occurrenceTime.timePeriodStart) {
+                        let procedureText = '\r\n' + procedureTemplates['range'];
+                        procedureText = procedureText.replace('{0}', event.name);
+                        procedureText = procedureText.replace('{1}', event.occurrenceTime.timePeriodStart);
+                        procedureText = procedureText.replace('{2}', event.occurrenceTime.timePeriodEnd);
+                        hpiText += procedureText;
+                    } else {
+                        let procedureText = '\r\n' + procedureTemplates['single'];
+                        procedureText = procedureText.replace('{0}', event.name);
+                        procedureText = procedureText.replace('{1}', event.occurrenceTime);
+                        hpiText += procedureText;
+                    }
+                    break;
+                }
+                case FluxMedicationPrescription: {
+                    const active = event.isActiveAsOf(today);
+                    if (!active) {
+                        let medicationText = '\r\n' + medicationTemplates['range'];
+                        medicationText = medicationText.replace('{0}', event.medication);
+                        medicationText = medicationText.replace('{1}', event.requestedPerformanceTime.timePeriodStart);
+                        medicationText = medicationText.replace('{2}', event.requestedPerformanceTime.timePeriodEnd);
+                        hpiText += medicationText;
+                    } else {
+                        let medicationText = '\r\n' + medicationTemplates['single'];
+                        medicationText = medicationText.replace('{0}', event.medication);
+                        medicationText = medicationText.replace('{1}', event.requestedPerformanceTime.timePeriodStart);
+                        hpiText += medicationText;
+                    }
+                    break;
+                }
+                case FluxProgression: {
+                    if (event.asOfDate && event.status) {
+                        hpiText += `\r\nAs of ${event.asOfDate}, disease is ${event.status}`;
+                        if (event.evidence && event.evidence.length > 0) {
+                            hpiText += ` based on ${event.evidence.join(', ')}.`;
+                        } else {
+                            hpiText += '.';
+                        }
+                    }
+                    break;
+                }
+                case FluxTest: {
+                    if (event.quantity && event.quantity.number && event.quantity.unit) {
+                        hpiText += `\r\nPatient had a ${event.name} lab result of ${event.quantity.number} ${event.quantity.unit} on ${event.clinicallyRelevantTime}.`;
+                    }
+                    break;
+                }
+                default: {
+                    console.error("There should only be instances of FluxProcedure, FluxMedicationPrescription, and FluxProgression");
+                }
+            }
+        });
+        
+        return hpiText;
+    }
+
+    // sorter for array with instances of FluxProcedure, FluxMedicationPrescription, and FluxProgression
+    _eventsTimeSorter(a, b) {
+        let a_startTime, b_startTime;
+
+        switch (a.constructor) {
+            case FluxProcedure: {
+                a_startTime = new moment(a.occurrenceTime, "D MMM YYYY");
+                if (!a_startTime.isValid()) a_startTime = new moment(a.occurrenceTime.timePeriodStart, "D MMM YYYY");
+                break;
+            }
+            case FluxMedicationPrescription: {
+                a_startTime = new moment(a.requestedPerformanceTime.timePeriodStart, "D MMM YYYY");
+                break;
+            }
+            case FluxProgression: {
+                a_startTime = new moment(a.asOfDate, "D MMM YYYY");
+                break;
+            }
+            case FluxTest: {
+                a_startTime = new moment(a.clinicallyRelevantTime, "D MMM YYYY");
+                break;
+            }
+            default: {
+                console.error("This object is not an instance of FluxProcedure, FluxMedicationPrescription, or FluxProgression.");
+                return 0;
+            }
+        }
+
+        switch (b.constructor) {
+            case FluxProcedure: {
+                b_startTime = new moment(b.occurrenceTime, "D MMM YYYY");
+                if (!b_startTime.isValid()) b_startTime = new moment(b.occurrenceTime.timePeriodStart, "D MMM YYYY");
+                break;
+            }
+            case FluxMedicationPrescription: {
+                b_startTime = new moment(b.requestedPerformanceTime.timePeriodStart, "D MMM YYYY");
+                break;
+            }
+            case FluxProgression: {
+                b_startTime = new moment(b.asOfDate, "D MMM YYYY");
+                break;
+            }
+            case FluxTest: {
+                b_startTime = new moment(b.clinicallyRelevantTime, "D MMM YYYY");
+                break;
+            }
+            default: {
+                console.error("This object is not an instance of FluxProcedure, FluxMedicationPrescription, or FluxProgression.");
+                return 0;
+            }
+        }
+
+        if (a_startTime < b_startTime) {
+            return -1;
+        }
+        if (a_startTime > b_startTime) {
+            return 1;
+        }
+        return 0;
     }
 }
 

--- a/src/model/condition/FluxInjury.js
+++ b/src/model/condition/FluxInjury.js
@@ -96,7 +96,7 @@ class FluxInjury extends Injury {
             return results;
         });
 
-        // Generate array from lookup table to pass back to summary meta data 
+        // Generate array from lookup table
         let mostRecentLabResultsArray = [];
 
         for (var key in mostRecentLabResultsLookupTable) {

--- a/src/model/lab/FluxTest.js
+++ b/src/model/lab/FluxTest.js
@@ -19,7 +19,7 @@ class FluxTest extends Test {
         }
     }
 
-    get codeableConceptDisplayText() { 
+    get name() { 
         if (this._specificType instanceof SpecificType) { 
             if (this._specificType._codeableConcept._coding.length > 0) { 
                 return this._specificType._codeableConcept._coding[0].displayText.string;

--- a/src/model/medication/FluxMedicationPrescription.js
+++ b/src/model/medication/FluxMedicationPrescription.js
@@ -54,6 +54,14 @@ class FluxMedicationPrescription extends MedicationPrescription {
             units: this._dosage.timingOfDoses.units
         };
     }
+
+    /*
+     *  Getter for status
+     *  Returns status string
+     */
+    get status() {
+        return this._status.value;
+    }
 }
 
 export default FluxMedicationPrescription;

--- a/src/model/oncology/FluxBreastCancer.js
+++ b/src/model/oncology/FluxBreastCancer.js
@@ -191,23 +191,22 @@ class FluxBreastCancer extends BreastCancer {
         const gender = patient.getGender();
         const labResults = this.getLabResultsChronologicalOrder(moment().subtract(6, 'months'));
 
-        let result = "\r\nHISTORY OF PRESENT ILLNESS\r\n";
-        result += `\r\n${name} is a ${age} year old ${gender}.`;
-        result += ` Patient was diagnosed with ${this.type} on ${this.diagnosisDate}.`;
+        let hpiText = `\r\n\r\n${name} is a ${age} year old ${gender}.`;
+        hpiText += ` Patient was diagnosed with ${this.type} on ${this.diagnosisDate}.`;
 
         // Laterality
         if (this.laterality) {
-            result += ` Breast cancer diagnosed in ${this.laterality} breast.`;
+            hpiText += ` Breast cancer diagnosed in ${this.laterality} breast.`;
         }
 
         // Tumor Size and HistologicGrade
         const tumorSize = this.getObservationsOfType(FluxTumorSize);
         const histologicGrade = this.getObservationsOfType(FluxHistologicGrade);
         if (tumorSize.length > 0) {
-            result += ` Primary tumor size is ${tumorSize[0].quantity.value} ${tumorSize[0].quantity.unit}.`;
+            hpiText += ` Primary tumor size is ${tumorSize[0].quantity.value} ${tumorSize[0].quantity.unit}.`;
         }
         if (histologicGrade.length > 0) {
-            result += ` Histological grade is ${histologicGrade[0].grade}.`;
+            hpiText += ` Histological grade is ${histologicGrade[0].grade}.`;
         }
 
         // ER, PR, HER2
@@ -215,22 +214,22 @@ class FluxBreastCancer extends BreastCancer {
         const prStatus = this.getPRReceptorStatus();
         const her2Status = this.getHER2ReceptorStatus();
         if (erStatus) {
-            result += ` Estrogen receptor was ${erStatus.status}.`;
+            hpiText += ` Estrogen receptor was ${erStatus.status}.`;
         }
         if (prStatus) {
-            result += ` Progesteron receptor was ${prStatus.status}.`;
+            hpiText += ` Progesteron receptor was ${prStatus.status}.`;
         }
         if (her2Status) {
-            result += ` HER2 was ${her2Status.status}.`;
+            hpiText += ` HER2 was ${her2Status.status}.`;
         }
 
         // Lab Results
         if (labResults.length > 0) {
-            result += ' Recent lab results include ';
-            result += labResults.map((lab) => {
+            hpiText += ' Recent lab results include ';
+            hpiText += labResults.map((lab) => {
                 return `${lab.codeableConceptDisplayText}: ${lab.quantity.number} ${lab.quantity.unit} (${lab.clinicallyRelevantTime})`;
             }).join(', ');
-            result += '.';
+            hpiText += '.';
         }
         
         // Build narrative from sorted events
@@ -259,12 +258,12 @@ class FluxBreastCancer extends BreastCancer {
                         procedureText = procedureText.replace('{0}', event.name);
                         procedureText = procedureText.replace('{1}', event.occurrenceTime.timePeriodStart);
                         procedureText = procedureText.replace('{2}', event.occurrenceTime.timePeriodEnd);
-                        result += procedureText;
+                        hpiText += procedureText;
                     } else {
                         let procedureText = '\r\n' + procedureTemplates['single'];
                         procedureText = procedureText.replace('{0}', event.name);
                         procedureText = procedureText.replace('{1}', event.occurrenceTime);
-                        result += procedureText;
+                        hpiText += procedureText;
                     }
                     break;
                 }
@@ -275,22 +274,22 @@ class FluxBreastCancer extends BreastCancer {
                         medicationText = medicationText.replace('{0}', event.medication);
                         medicationText = medicationText.replace('{1}', event.requestedPerformanceTime.timePeriodStart);
                         medicationText = medicationText.replace('{2}', event.requestedPerformanceTime.timePeriodEnd);
-                        result += medicationText;
+                        hpiText += medicationText;
                     } else {
                         let medicationText = '\r\n' + medicationTemplates['single'];
                         medicationText = medicationText.replace('{0}', event.medication);
                         medicationText = medicationText.replace('{1}', event.requestedPerformanceTime.timePeriodStart);
-                        result += medicationText;
+                        hpiText += medicationText;
                     }
                     break;
                 }
                 case FluxProgression: {
                     if (event.asOfDate && event.status) {
-                        result += `\r\nAs of ${event.asOfDate}, disease is ${event.status}`;
+                        hpiText += `\r\nAs of ${event.asOfDate}, disease is ${event.status}`;
                         if (event.evidence && event.evidence.length > 0) {
-                            result += ` based on ${event.evidence.join(', ')}.`;
+                            hpiText += ` based on ${event.evidence.join(', ')}.`;
                         } else {
-                            result += '.';
+                            hpiText += '.';
                         }
                     }
                     break;
@@ -301,7 +300,7 @@ class FluxBreastCancer extends BreastCancer {
             }
         });
         
-        return result;
+        return hpiText;
     }
 
     // sorter for array with instances of FluxProcedure, FluxMedicationPrescription, and FluxProgression

--- a/src/model/oncology/FluxBreastCancer.js
+++ b/src/model/oncology/FluxBreastCancer.js
@@ -44,10 +44,8 @@ class FluxBreastCancer extends BreastCancer {
         return this.getObservationsOfType(FluxTest);
     }
 
-
     // This method takes in a sinceDate, oldest date acceptable. All results returned must be more recent than sinceDate
     getLabResultsChronologicalOrder(sinceDate) {
-
         let results = this.getTests();
         results.sort(this._labResultsTimeSorter);
 
@@ -75,7 +73,6 @@ class FluxBreastCancer extends BreastCancer {
 
     // Grab the most recent lab results within a set threshold date
     getMostRecentLabResults(results, sinceDate) {
-
         let mostRecentLabResultsLookupTable = {};
 
         // Convert the sinceDate to a moment.js date
@@ -235,7 +232,10 @@ class FluxBreastCancer extends BreastCancer {
         events = events.concat(patient.getProceduresForCondition(this));
         events = events.concat(patient.getMedicationsForConditionChronologicalOrder(this));
         events = events.concat(this.getLabResultsChronologicalOrder(moment().subtract(6, 'months')));
-        events.push(patient.getMostRecentProgressionForCondition(this));
+        const recentProgression = patient.getMostRecentProgressionForCondition(this);
+        if (recentProgression) {
+            events.push(recentProgression);
+        }
         events.sort(this._eventsTimeSorter);
 
         const procedureTemplates = {

--- a/src/model/oncology/FluxBreastCancer.js
+++ b/src/model/oncology/FluxBreastCancer.js
@@ -293,7 +293,7 @@ class FluxBreastCancer extends BreastCancer {
                 }
                 case FluxTest: {
                     if (event.quantity && event.quantity.number && event.quantity.unit) {
-                        hpiText += `\r\nPatient had a ${event.name} lab result of ${event.quantity.number} ${event.quantity.unit} on ${event.clinicallyRelevantTime}`;
+                        hpiText += `\r\nPatient had a ${event.name} lab result of ${event.quantity.number} ${event.quantity.unit} on ${event.clinicallyRelevantTime}.`;
                     }
                     break;
                 }

--- a/src/model/oncology/FluxBreastCancer.js
+++ b/src/model/oncology/FluxBreastCancer.js
@@ -177,34 +177,36 @@ class FluxBreastCancer extends BreastCancer {
         return this.bodySite.laterality.value.coding[0].displayText.value;        
     }
 
+    /**
+     *  function to build HPI Narrative
+     *  Starts with initial summary of patient information
+     *  Then details chronological history of patient's procedures, medications, and most recent progression
+     */
     buildHpiNarrative(patient) {
-        // const name = this.getName();
-        // const age = this.getAge();
-        // const gender = this.getGender();
-        // const condition = this.getLastBreastCancerCondition();
-        // const labResults = condition.getLabResultsChronologicalOrder("16 AUG 2010");
+        // Initial patient introduction section
+        const name = patient.getName();
+        const age = patient.getAge();
+        const gender = patient.getGender();
+        const labResults = this.getLabResultsChronologicalOrder("16 AUG 2010");
 
-        // let result = "";
-        // result += `${name} is a ${age} year old ${gender}.`;
-        // result += ` Patient has ${condition.type}.`;
-        // if (labResults.length > 0) {
-        //     result += ' Recent lab results include ';
-        //     result += labResults.map((lab) => {
-        //         return `${lab.codeableConceptDisplayText}: ${lab.quantity.number} ${lab.quantity.unit} (${lab.clinicallyRelevantTime})`;
-        //     }).join(', ');
-        //     result += '.';
-        // }
+        let result = "\r\nHISTORY OF PRESENT ILLNESS\r\n";
+        result += `\r\n${name} is a ${age} year old ${gender}.`;
+        result += ` Patient has ${this.type}.`;
+        if (labResults.length > 0) {
+            result += ' Recent lab results include ';
+            result += labResults.map((lab) => {
+                return `${lab.codeableConceptDisplayText}: ${lab.quantity.number} ${lab.quantity.unit} (${lab.clinicallyRelevantTime})`;
+            }).join(', ');
+            result += '.';
+        }
         
-        // return result;
         let events = [];
-
         events = events.concat(patient.getProceduresForCondition(this));
         events = events.concat(patient.getMedicationsForConditionChronologicalOrder(this));
         events.push(patient.getMostRecentProgressionForCondition(this));
         events.sort(this._eventsTimeSorter);
-        // console.log(events);
 
-        return "HI";
+        return result;
     }
 
     // sorter for array with instances of FluxProcedure, FluxMedicationPrescription, and FluxProgression

--- a/src/model/oncology/FluxBreastCancer.js
+++ b/src/model/oncology/FluxBreastCancer.js
@@ -174,7 +174,28 @@ class FluxBreastCancer extends BreastCancer {
         return this.bodySite.laterality.value.coding[0].displayText.value;        
     }
 
+    getHpi() {
+        // const name = this.getName();
+        // const age = this.getAge();
+        // const gender = this.getGender();
+        // const condition = this.getLastBreastCancerCondition();
+        // const labResults = condition.getLabResultsChronologicalOrder("16 AUG 2010");
 
+        // let result = "";
+        // result += `${name} is a ${age} year old ${gender}.`;
+        // result += ` Patient has ${condition.type}.`;
+        // if (labResults.length > 0) {
+        //     result += ' Recent lab results include ';
+        //     result += labResults.map((lab) => {
+        //         return `${lab.codeableConceptDisplayText}: ${lab.quantity.number} ${lab.quantity.unit} (${lab.clinicallyRelevantTime})`;
+        //     }).join(', ');
+        //     result += '.';
+        // }
+        
+        // return result;
+        console.log("HPI");
+        return "HI";
+    }
 }
 
 export default FluxBreastCancer;

--- a/src/model/oncology/FluxBreastCancer.js
+++ b/src/model/oncology/FluxBreastCancer.js
@@ -189,7 +189,6 @@ class FluxBreastCancer extends BreastCancer {
         const name = patient.getName();
         const age = patient.getAge();
         const gender = patient.getGender();
-        const labResults = this.getLabResultsChronologicalOrder(moment().subtract(6, 'months'));
 
         let hpiText = `\r\n\r\n${name} is a ${age} year old ${gender}.`;
         hpiText += ` Patient was diagnosed with ${this.type} on ${this.diagnosisDate}.`;
@@ -199,14 +198,21 @@ class FluxBreastCancer extends BreastCancer {
             hpiText += ` Breast cancer diagnosed in ${this.laterality} breast.`;
         }
 
+        // Staging
+        const staging = this.getMostRecentStaging();
+        console.log(staging);
+        if (staging) {
+            hpiText += ` Stage ${staging.stage} ${staging.t_Stage} ${staging.n_Stage} ${staging.m_Stage} disease.`;
+        }
+
         // Tumor Size and HistologicGrade
         const tumorSize = this.getObservationsOfType(FluxTumorSize);
         const histologicGrade = this.getObservationsOfType(FluxHistologicGrade);
         if (tumorSize.length > 0) {
-            hpiText += ` Primary tumor size is ${tumorSize[0].quantity.value} ${tumorSize[0].quantity.unit}.`;
+            hpiText += ` Primary tumor size was ${tumorSize[0].quantity.value} ${tumorSize[0].quantity.unit}.`;
         }
         if (histologicGrade.length > 0) {
-            hpiText += ` Histological grade is ${histologicGrade[0].grade}.`;
+            hpiText += ` Histological grade was ${histologicGrade[0].grade}.`;
         }
 
         // ER, PR, HER2
@@ -224,6 +230,7 @@ class FluxBreastCancer extends BreastCancer {
         }
 
         // Lab Results
+        const labResults = this.getLabResultsChronologicalOrder(moment().subtract(6, 'months'));
         if (labResults.length > 0) {
             hpiText += ' Recent lab results include ';
             hpiText += labResults.map((lab) => {

--- a/src/model/oncology/FluxBreastCancer.js
+++ b/src/model/oncology/FluxBreastCancer.js
@@ -174,7 +174,7 @@ class FluxBreastCancer extends BreastCancer {
         return this.bodySite.laterality.value.coding[0].displayText.value;        
     }
 
-    getHpi() {
+    buildHpiNarrative(patient) {
         // const name = this.getName();
         // const age = this.getAge();
         // const gender = this.getGender();
@@ -193,7 +193,7 @@ class FluxBreastCancer extends BreastCancer {
         // }
         
         // return result;
-        console.log("HPI");
+        console.log(patient);
         return "HI";
     }
 }

--- a/src/model/oncology/FluxBreastCancer.js
+++ b/src/model/oncology/FluxBreastCancer.js
@@ -200,7 +200,6 @@ class FluxBreastCancer extends BreastCancer {
 
         // Staging
         const staging = this.getMostRecentStaging();
-        console.log(staging);
         if (staging) {
             hpiText += ` Stage ${staging.stage} ${staging.t_Stage} ${staging.n_Stage} ${staging.m_Stage} disease.`;
         }
@@ -234,7 +233,7 @@ class FluxBreastCancer extends BreastCancer {
         if (labResults.length > 0) {
             hpiText += ' Recent lab results include ';
             hpiText += labResults.map((lab) => {
-                return `${lab.codeableConceptDisplayText}: ${lab.quantity.number} ${lab.quantity.unit} (${lab.clinicallyRelevantTime})`;
+                return `${lab.name}: ${lab.quantity.number} ${lab.quantity.unit} (${lab.clinicallyRelevantTime})`;
             }).join(', ');
             hpiText += '.';
         }

--- a/src/model/oncology/FluxBreastCancer.js
+++ b/src/model/oncology/FluxBreastCancer.js
@@ -201,6 +201,8 @@ class FluxBreastCancer extends BreastCancer {
         }
         
         // Build narrative from sorted events
+        // Get procedures, medications, and most recent progression from patient
+        // Sort by start time and add snippets about each event to result text
         let events = [];
         events = events.concat(patient.getProceduresForCondition(this));
         events = events.concat(patient.getMedicationsForConditionChronologicalOrder(this));

--- a/src/model/oncology/FluxBreastCancer.js
+++ b/src/model/oncology/FluxBreastCancer.js
@@ -190,7 +190,7 @@ class FluxBreastCancer extends BreastCancer {
         const age = patient.getAge();
         const gender = patient.getGender();
 
-        let hpiText = `\r\n\r\n${name} is a ${age} year old ${gender}.`;
+        let hpiText = `${name} is a ${age} year old ${gender}.`;
         hpiText += ` Patient was diagnosed with ${this.type} on ${this.diagnosisDate}.`;
 
         // Laterality
@@ -200,7 +200,7 @@ class FluxBreastCancer extends BreastCancer {
 
         // Staging
         const staging = this.getMostRecentStaging();
-        if (staging) {
+        if (staging && staging.stage) {
             hpiText += ` Stage ${staging.stage} ${staging.t_Stage} ${staging.n_Stage} ${staging.m_Stage} disease.`;
         }
 

--- a/src/model/oncology/FluxBreastCancer.js
+++ b/src/model/oncology/FluxBreastCancer.js
@@ -195,15 +195,6 @@ class FluxBreastCancer extends BreastCancer {
         result += `\r\n${name} is a ${age} year old ${gender}.`;
         result += ` Patient was diagnosed with ${this.type} on ${this.diagnosisDate}.`;
 
-        // Lab Results
-        if (labResults.length > 0) {
-            result += ' Recent lab results include ';
-            result += labResults.map((lab) => {
-                return `${lab.codeableConceptDisplayText}: ${lab.quantity.number} ${lab.quantity.unit} (${lab.clinicallyRelevantTime})`;
-            }).join(', ');
-            result += '.';
-        }
-
         // Laterality
         if (this.laterality) {
             result += ` Breast cancer diagnosed in ${this.laterality} breast.`;
@@ -231,6 +222,15 @@ class FluxBreastCancer extends BreastCancer {
         }
         if (her2Status) {
             result += ` HER2 was ${her2Status.status}.`;
+        }
+
+        // Lab Results
+        if (labResults.length > 0) {
+            result += ' Recent lab results include ';
+            result += labResults.map((lab) => {
+                return `${lab.codeableConceptDisplayText}: ${lab.quantity.number} ${lab.quantity.unit} (${lab.clinicallyRelevantTime})`;
+            }).join(', ');
+            result += '.';
         }
         
         // Build narrative from sorted events

--- a/src/model/oncology/FluxBreastCancer.js
+++ b/src/model/oncology/FluxBreastCancer.js
@@ -112,7 +112,7 @@ class FluxBreastCancer extends BreastCancer {
             return results;
         });
 
-        // Generate array from lookup table to pass back to summary meta data 
+        // Generate array from lookup table
         let mostRecentLabResultsArray = [];
 
         for (var key in mostRecentLabResultsLookupTable) {

--- a/src/model/procedure/FluxProcedure.js
+++ b/src/model/procedure/FluxProcedure.js
@@ -19,6 +19,22 @@ class FluxProcedure extends Procedure {
             return this._occurrenceTime.value;
         }
     }
+
+    /*
+     *  Getter for status
+     *  Returns status string
+     */
+    get status() {
+        return this._status.value;
+    }
+
+    /*
+     *  Getter for procedure name
+     *  Returns procedure name string
+     */
+    get name() {
+        return this._specificType.value.coding[0].displayText.value;
+    }
 }
 
 export default FluxProcedure;

--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -353,63 +353,6 @@ class PatientRecord {
         }
     }
 
-    // Function returns all procedures, medications, and most recent progression for condition
-    getEventsForConditionChronologicalOrder(condition) {
-        let events = [];
-
-        events = events.concat(this.getProceduresForCondition(condition));
-        events = events.concat(this.getMedicationsForConditionChronologicalOrder(condition));
-        events.push(this.getMostRecentProgressionForCondition(condition));
-        events.sort(this._eventsTimeSorter);
-
-        return events;
-    }
-
-    // sorter for array with instances of FluxProcedure, FluxMedicationPrescription, and FluxProgression
-    _eventsTimeSorter(a, b) {
-        let a_startTime, b_startTime;
-
-        switch (a.constructor) {
-            case FluxProcedure:
-                a_startTime = new moment(a.occurrenceTime, "D MMM YYYY");
-                if (!a_startTime.isValid()) a_startTime = new moment(a.occurrenceTime.timePeriodStart, "D MMM YYYY");
-                break;
-            case FluxMedicationPrescription:
-                a_startTime = new moment(a.requestedPerformanceTime.timePeriodStart, "D MMM YYYY");
-                break;
-            case FluxProgression:
-                a_startTime = new moment(a.asOfDate, "D MMM YYYY");
-                break;
-            default:
-                console.error("This object is not an instance of FluxProcedure, FluxMedicationPrescription, or FluxProgression.");
-                return 0;
-        }
-
-        switch (b.constructor) {
-            case FluxProcedure:
-                b_startTime = new moment(b.occurrenceTime, "D MMM YYYY");
-                if (!b_startTime.isValid()) b_startTime = new moment(b.occurrenceTime.timePeriodStart, "D MMM YYYY");
-                break;
-            case FluxMedicationPrescription:
-                b_startTime = new moment(b.requestedPerformanceTime.timePeriodStart, "D MMM YYYY");
-                break;
-            case FluxProgression:
-                b_startTime = new moment(b.asOfDate, "D MMM YYYY");
-                break;
-            default:
-                console.error("This object is not an instance of FluxProcedure, FluxMedicationPrescription, or FluxProgression.");
-                return 0;
-        }
-
-        if (a_startTime < b_startTime) {
-            return -1;
-        }
-        if (a_startTime > b_startTime) {
-            return 1;
-        }
-        return 0;
-    }
-    
     _medsTimeSorter(a, b) {
         const a_startTime = new moment(a.requestedPerformanceTime.timePeriodStart, "D MMM YYYY");
         const b_startTime = new moment(b.requestedPerformanceTime.timePeriodStart, "D MMM YYYY");

--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -358,9 +358,18 @@ class PatientRecord {
         const age = this.getAge();
         const gender = this.getGender();
         const condition = this.getLastBreastCancerCondition();
+        const labResults = condition.getLabResultsChronologicalOrder("16 AUG 2010");
+
         let result = "";
         result += `${name} is a ${age} year old ${gender}.`;
         result += ` Patient has ${condition.type}.`;
+        if (labResults.length > 0) {
+            result += ' Recent lab results include ';
+            result += labResults.map((lab) => {
+                return `${lab.codeableConceptDisplayText}: ${lab.quantity.number} ${lab.quantity.unit} (${lab.clinicallyRelevantTime})`;
+            }).join(', ');
+            result += '.';
+        }
         return result;
     }
     

--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -353,6 +353,17 @@ class PatientRecord {
         }
     }
 
+    getHpi() {
+        const name = this.getName();
+        const age = this.getAge();
+        const gender = this.getGender();
+        const condition = this.getLastBreastCancerCondition();
+        let result = "";
+        result += `${name} is a ${age} year old ${gender}.`;
+        result += ` Patient has ${condition.type}.`;
+        return result;
+    }
+    
     _medsTimeSorter(a, b) {
         const a_startTime = new moment(a.requestedPerformanceTime.timePeriodStart, "D MMM YYYY");
         const b_startTime = new moment(b.requestedPerformanceTime.timePeriodStart, "D MMM YYYY");

--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -352,26 +352,6 @@ class PatientRecord {
             return p;
         }
     }
-
-    getHpi() {
-        const name = this.getName();
-        const age = this.getAge();
-        const gender = this.getGender();
-        const condition = this.getLastBreastCancerCondition();
-        const labResults = condition.getLabResultsChronologicalOrder("16 AUG 2010");
-
-        let result = "";
-        result += `${name} is a ${age} year old ${gender}.`;
-        result += ` Patient has ${condition.type}.`;
-        if (labResults.length > 0) {
-            result += ' Recent lab results include ';
-            result += labResults.map((lab) => {
-                return `${lab.codeableConceptDisplayText}: ${lab.quantity.number} ${lab.quantity.unit} (${lab.clinicallyRelevantTime})`;
-            }).join(', ');
-            result += '.';
-        }
-        return result;
-    }
     
     _medsTimeSorter(a, b) {
         const a_startTime = new moment(a.requestedPerformanceTime.timePeriodStart, "D MMM YYYY");

--- a/src/shortcuts/InsertValue.jsx
+++ b/src/shortcuts/InsertValue.jsx
@@ -95,11 +95,10 @@ export default class InsertValue extends Shortcut {
         } else if (callObject === "parent") {
         //   "getData": {"object": "parent", "attribute": "stage"},
             const attribute = callSpec["attribute"];
-            //console.log(this.contextManager.getActiveContexts());
-            return this.contextManager.getActiveContexts()[0].getAttributeValue(attribute);
+            return this.contextManager.getActiveContextOfType(this.metadata.knownParentContexts).getAttributeValue(attribute);
         } else if (callObject === "$parentValueObject") {
             const patient = this.contextManager.getPatient();
-            return this.contextManager.getActiveContexts()[0].getValueObject()[callSpec["method"]](patient);
+            return this.contextManager.getActiveContextOfType(this.metadata.knownParentContexts).getValueObject()[callSpec["method"]](patient);
         } else {
             console.error("not support yet " + callSpec.object + " / " + callSpec.method);
         }

--- a/src/shortcuts/InsertValue.jsx
+++ b/src/shortcuts/InsertValue.jsx
@@ -97,6 +97,8 @@ export default class InsertValue extends Shortcut {
             const attribute = callSpec["attribute"];
             //console.log(this.contextManager.getActiveContexts());
             return this.contextManager.getActiveContexts()[0].getAttributeValue(attribute);
+        } else if (callObject === "$parentValueObject") {
+            return this.contextManager.getActiveContexts()[0].getValueObject()[callSpec["method"]]();
         } else {
             console.error("not support yet " + callSpec.object + " / " + callSpec.method);
         }

--- a/src/shortcuts/InsertValue.jsx
+++ b/src/shortcuts/InsertValue.jsx
@@ -98,7 +98,8 @@ export default class InsertValue extends Shortcut {
             //console.log(this.contextManager.getActiveContexts());
             return this.contextManager.getActiveContexts()[0].getAttributeValue(attribute);
         } else if (callObject === "$parentValueObject") {
-            return this.contextManager.getActiveContexts()[0].getValueObject()[callSpec["method"]]();
+            const patient = this.contextManager.getPatient();
+            return this.contextManager.getActiveContexts()[0].getValueObject()[callSpec["method"]](patient);
         } else {
             console.error("not support yet " + callSpec.object + " / " + callSpec.method);
         }

--- a/src/shortcuts/Shortcuts.json
+++ b/src/shortcuts/Shortcuts.json
@@ -378,9 +378,9 @@
   },
   { "type": "InsertValue",
     "id": "HistoryOfPresentIllnessInserter",
-    "getData": {"object": "patient", "method": "getHpi"},
+    "getData": {"object": "$parentValueObject", "method": "getHpi"},
     "isContext": false,
     "stringTriggers": [{"name": "@HPI", "description": "Insert patient's history of present illness"}],
-    "knownParentContexts": "Patient"
+    "knownParentContexts": "ConditionInserter"
   }
 ]

--- a/src/shortcuts/Shortcuts.json
+++ b/src/shortcuts/Shortcuts.json
@@ -375,5 +375,12 @@
     "isContext": false,
     "stringTriggers": [{"name":"@active medications", "description": "Insert a summary of the active (currently being taken) patient medications"}],
     "knownParentContexts": "Patient"
+  },
+  { "type": "InsertValue",
+    "id": "HistoryOfPresentIllnessInserter",
+    "getData": {},
+    "isContext": false,
+    "stringTriggers": [{"name": "@HPI", "description": "Insert patient's history of present illness"}],
+    "knownParentContexts": "Patient"
   }
 ]

--- a/src/shortcuts/Shortcuts.json
+++ b/src/shortcuts/Shortcuts.json
@@ -378,7 +378,7 @@
   },
   { "type": "InsertValue",
     "id": "HistoryOfPresentIllnessInserter",
-    "getData": {"object": "$parentValueObject", "method": "getHpi"},
+    "getData": {"object": "$parentValueObject", "method": "buildHpiNarrative"},
     "isContext": false,
     "stringTriggers": [{"name": "@HPI", "description": "Insert patient's history of present illness"}],
     "knownParentContexts": "ConditionInserter"

--- a/src/shortcuts/Shortcuts.json
+++ b/src/shortcuts/Shortcuts.json
@@ -378,7 +378,7 @@
   },
   { "type": "InsertValue",
     "id": "HistoryOfPresentIllnessInserter",
-    "getData": {},
+    "getData": {"object": "patient", "method": "getHpi"},
     "isContext": false,
     "stringTriggers": [{"name": "@HPI", "description": "Insert patient's history of present illness"}],
     "knownParentContexts": "Patient"

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -506,7 +506,7 @@ class SummaryMetadata {
 
         return labResultsInOrder.map((l, i) => {
             const value = `${l.quantity.number} ${l.quantity.unit} (${l.clinicallyRelevantTime})`;
-            const name = `${l.specificType.value.coding[0].displayText.value}`;
+            const name = `${l.name}`;
 
             return {
                 name: name,
@@ -645,7 +645,7 @@ class SummaryMetadata {
                 group: assignedGroup,
                 icon: 'hospital-o',
                 className: classes,
-                hoverTitle: proc.codeableConceptDisplayText,
+                hoverTitle: proc.name,
                 hoverText: hoverText,
                 start_time: startTime,
                 end_time: endTime


### PR DESCRIPTION
Address JIRA-816

To use shortcut, first type "@condition" and then "@HPI" shortcut should appear in the context panel.  A blob of text should get added to the editor describing the patient and the current condition.  The history of the patient's procedures, medications, lab results, and most recent disease status will also appear in chronological order.

Shortcomings:
- The buildHpiNarrative(along with some other functions to get recent lab results) had to be duplicated in FluxCondition and FluxInjury for the "@hpi" shortcut to work with the Fracture condition and the conditions in /p3.  Ideally, we would only want to have to write these functions once in FluxCondition and have any other condition classes inherit the functions.  We will try to improve on our wrapper classes when we import the new ES6 classes.

- Text printing out the events in chronological is going to feel really repetitive since I am just using a template and including the event name and dates.  Let me know if you have an idea for improving this or if you think the text should say something else.

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
-  Cheat sheet is updated
-  Demo script is updated 
-  Documentation on Wiki has been updated 
-  Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
-  Added UI tests for slim mode 
-  Added UI tests for full mode
-  Added backend tests for fluxNotes code
-  Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
