### PR TITLE
Added automatic scrolling for new context tray sections

### DIFF
--- a/src/context/ContextTray.jsx
+++ b/src/context/ContextTray.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { findDOMNode } from 'react-dom';
 import PropTypes from 'prop-types';
 import Lang from 'lodash';
 
@@ -28,6 +29,9 @@ export default class ContextTray extends Component {
             this.setState({
                 value: activeContexts.length + 1,
                 lastActiveContextCount: activeContexts.length
+            }, () => {
+                // scrolls to newest ContextOption section
+                findDOMNode(this.refs[`context-option-${this.state.value - 2}`]).scrollIntoView();
             });
         }
     }
@@ -99,6 +103,7 @@ export default class ContextTray extends Component {
                 {value > 0 && activeContexts.map((context, i) =>
                     <ContextOptions
                         key={i}
+                        ref={`context-option-${i}`}
                         contextManager={this.props.contextManager}
                         shortcutManager={this.props.shortcutManager}
                         handleClick={this.handleShortcutClick}

--- a/src/context/ContextTray.jsx
+++ b/src/context/ContextTray.jsx
@@ -31,7 +31,8 @@ export default class ContextTray extends Component {
                 lastActiveContextCount: activeContexts.length
             }, () => {
                 // scrolls to newest ContextOption section
-                findDOMNode(this.refs[`context-option-${this.state.value - 2}`]).scrollIntoView();
+                const newContextSection = findDOMNode(this.refs[`context-option-${this.state.value - 2}`]);
+                if (newContextSection) newContextSection.scrollIntoView();
             });
         }
     }


### PR DESCRIPTION
# Added automatic scrolling for new context tray sections

* Utilized JavaScript's [`scrollIntoView`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView) method to automatically scroll newly rendered context tray sections into the visible area of the browser window.
* Tested in Chrome and IE.
* Unable to add UI test as TestCafe not able to determine what DOM elements are in view. However, if it breaks it will not break the functionality of the app, so deemed acceptable.

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- Cheat sheet is updated
- Demo script is updated 
- Documentation on Wiki has been updated 
- Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- Added UI tests for slim mode 
- Added UI tests for full mode
- Added backend tests for fluxNotes code
- Added note parser examples to test new functionality


## Reviewer 1: Nicole

- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
