### PR TITLE
Saving notes

### DIFF
--- a/src/containers/FullApp.jsx
+++ b/src/containers/FullApp.jsx
@@ -55,7 +55,6 @@ class FullApp extends Component {
             patient: patient,
             selectedText: null,
             documentText: null,
-            saveEditorContents: false,
             superRole: 'Clinician',
             SummaryItemToInsert: '',
             summaryMetadata: this.summaryMetadata.getMetadata(),

--- a/src/containers/FullApp.jsx
+++ b/src/containers/FullApp.jsx
@@ -54,6 +54,8 @@ class FullApp extends Component {
             isNoteViewerEditable: false,
             patient: patient,
             selectedText: null,
+            documentText: null,
+            saveEditorContents: false,
             superRole: 'Clinician',
             SummaryItemToInsert: '',
             summaryMetadata: this.summaryMetadata.getMetadata(),

--- a/src/dashboard/ClinicianDashboard.jsx
+++ b/src/dashboard/ClinicianDashboard.jsx
@@ -185,6 +185,8 @@ class ClinicianDashboard extends Component {
                         handleSummaryItemSelected={this.props.handleSummaryItemSelected}
                         newCurrentShortcut={this.props.newCurrentShortcut}
                         patient={this.props.appState.patient}
+                        documentText={this.props.appState.documentText}
+                        saveEditorContents={this.props.appState.saveEditorContents}
                         shortcutManager={this.props.shortcutManager}
                         summaryItemToBeInserted={this.props.appState.SummaryItemToInsert}
                         updateErrors={this.props.updateErrors}

--- a/src/dashboard/ClinicianDashboard.jsx
+++ b/src/dashboard/ClinicianDashboard.jsx
@@ -186,7 +186,6 @@ class ClinicianDashboard extends Component {
                         newCurrentShortcut={this.props.newCurrentShortcut}
                         patient={this.props.appState.patient}
                         documentText={this.props.appState.documentText}
-                        saveEditorContents={this.props.appState.saveEditorContents}
                         shortcutManager={this.props.shortcutManager}
                         summaryItemToBeInserted={this.props.appState.SummaryItemToInsert}
                         updateErrors={this.props.updateErrors}

--- a/src/noteparser/NoteParser.js
+++ b/src/noteparser/NoteParser.js
@@ -113,6 +113,10 @@ export default class NoteParser {
     }
     
     getNextTriggerIndex(note, triggerPrefixes, pos) {
+        // Handle a saved, empty note
+        if(Lang.isUndefined(note)){
+            return -1;
+        }
         let indexes = triggerPrefixes.map((triggerPrefix) => {
             return note.indexOf(triggerPrefix, pos);
         });

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -340,16 +340,20 @@ class FluxNotesEditor extends React.Component {
     }
 
     onChange = (state) => {
+        console.log(state.toJSON()); //import State from Slate - has fromJSON() too
+        // isAtEndOf https://github.com/ianstormtaylor/slate/blob/master/docs/reference/slate/range.md knows where the end is
+        // we need to have a constant endKey/Offset for the full document. endKey doesn't seem to do that, bases on cursor
+
         // 'copy' the text every time into the note
         // Need to artificially set selection to the whole document
         // state.selection only has a getter for these values so create a new object
-        let allTextSelected = {
+        let entireNote = {
             startKey: "0",
             startOffset: 0,
-            endKey: state.anchorKey,
-            endOffset: state.anchorOffset
+            endKey: state.endKey,
+            endOffset: state.endOffset //at least use toJSON(). inner methods like document.nodes.data.nodes[] (??) to find how many structured phrases and how many chars.
         }; 
-        let fullText = this.structuredFieldPlugin.convertToText(state, allTextSelected);
+        let fullText = this.structuredFieldPlugin.convertToText(state, entireNote);
         this.props.setFullAppStateWithCallback(function(prevState, props){
             return {documentText: fullText};
         });

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -341,8 +341,24 @@ class FluxNotesEditor extends React.Component {
 
     onChange = (state) => {
         console.log(state.toJSON()); //import State from Slate - has fromJSON() too
-        // isAtEndOf https://github.com/ianstormtaylor/slate/blob/master/docs/reference/slate/range.md knows where the end is
-        // we need to have a constant endKey/Offset for the full document. endKey doesn't seem to do that, bases on cursor
+        console.log(state.endKey);
+        console.log(state.endOffset);
+        if(!Lang.isNull(this.props.documentText)){
+            console.log(this.props.documentText.length+1);
+        } else{
+            console.log("this.props.documentText null");
+        }
+        let indexOfLastNode = state.toJSON().document.nodes["0"].nodes.length - 1;
+        let endOfNoteKey = state.toJSON().document.nodes["0"].nodes[indexOfLastNode].key;
+        let endOfNoteOffset = 0;
+        if(!Lang.isNull(this.props.documentText)){
+            console.log("setting endOffset to " + state.toJSON().document.nodes["0"].nodes["0"].characters.length); //empty string until structured phrase, why?
+            //endOfNoteOffset = this.props.documentText.length;
+            endOfNoteOffset = state.toJSON().document.nodes["0"].nodes["0"].characters.length;
+        }
+        console.log("indexOfLastNode: " + indexOfLastNode);
+        console.log("endKey now: " + endOfNoteKey);
+        console.log("endOffset now: " + endOfNoteOffset);
 
         // 'copy' the text every time into the note
         // Need to artificially set selection to the whole document
@@ -350,8 +366,10 @@ class FluxNotesEditor extends React.Component {
         let entireNote = {
             startKey: "0",
             startOffset: 0,
-            endKey: state.endKey,
-            endOffset: state.endOffset //at least use toJSON(). inner methods like document.nodes.data.nodes[] (??) to find how many structured phrases and how many chars.
+           // endKey: state.endKey, // could be toJSON.document.nodes[0].nodes[lastIndex].key == "5" == the key when cursor at end
+            endKey: endOfNoteKey,
+           // endOffset: state.endOffset // could be this.props.documentText.length (for just text is toJSON.document.nodes[0].nodes.length)
+           endOffset: endOfNoteOffset
         }; 
         let fullText = this.structuredFieldPlugin.convertToText(state, entireNote);
         this.props.setFullAppStateWithCallback(function(prevState, props){

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -345,11 +345,9 @@ class FluxNotesEditor extends React.Component {
         let endOfNoteOffset = 0;
         // If the editor has no structured phrases, use the number of characters in the first 'node'
         if(Lang.isEqual(indexOfLastNode, 0)){
-            console.log("setting endOffset to " + state.toJSON().document.nodes["0"].nodes["0"].characters.length); //empty string until structured phrase, why?
-            //endOfNoteOffset = this.props.documentText.length;
             endOfNoteOffset = state.toJSON().document.nodes["0"].nodes["0"].characters.length;
         } else{
-            if(!Lang.isNull(this.props.documentText)){
+            if(!Lang.isNull(this.props.documentText) && !Lang.isUndefined(this.props.documentText)){
                 endOfNoteOffset = this.props.documentText.length
             }
         }

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -342,6 +342,7 @@ class FluxNotesEditor extends React.Component {
     }
 
     onChange = (state) => {
+        this.props.setFullAppState("documentText", state.document.text);
         this.setState({
             state: state
         });

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -340,25 +340,19 @@ class FluxNotesEditor extends React.Component {
     }
 
     onChange = (state) => {
-        console.log(state.toJSON()); //import State from Slate - has fromJSON() too
-        console.log(state.endKey);
-        console.log(state.endOffset);
-        if(!Lang.isNull(this.props.documentText)){
-            console.log(this.props.documentText.length+1);
-        } else{
-            console.log("this.props.documentText null");
-        }
         let indexOfLastNode = state.toJSON().document.nodes["0"].nodes.length - 1;
         let endOfNoteKey = state.toJSON().document.nodes["0"].nodes[indexOfLastNode].key;
         let endOfNoteOffset = 0;
-        if(!Lang.isNull(this.props.documentText)){
+        // If the editor has no structured phrases, use the number of characters in the first 'node'
+        if(Lang.isEqual(indexOfLastNode, 0)){
             console.log("setting endOffset to " + state.toJSON().document.nodes["0"].nodes["0"].characters.length); //empty string until structured phrase, why?
             //endOfNoteOffset = this.props.documentText.length;
             endOfNoteOffset = state.toJSON().document.nodes["0"].nodes["0"].characters.length;
+        } else{
+            if(!Lang.isNull(this.props.documentText)){
+                endOfNoteOffset = this.props.documentText.length
+            }
         }
-        console.log("indexOfLastNode: " + indexOfLastNode);
-        console.log("endKey now: " + endOfNoteKey);
-        console.log("endOffset now: " + endOfNoteOffset);
 
         // 'copy' the text every time into the note
         // Need to artificially set selection to the whole document
@@ -366,9 +360,7 @@ class FluxNotesEditor extends React.Component {
         let entireNote = {
             startKey: "0",
             startOffset: 0,
-           // endKey: state.endKey, // could be toJSON.document.nodes[0].nodes[lastIndex].key == "5" == the key when cursor at end
             endKey: endOfNoteKey,
-           // endOffset: state.endOffset // could be this.props.documentText.length (for just text is toJSON.document.nodes[0].nodes.length)
            endOffset: endOfNoteOffset
         }; 
         let fullText = this.structuredFieldPlugin.convertToText(state, entireNote);

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -187,8 +187,6 @@ class FluxNotesEditor extends React.Component {
             state: initialState,
             isPortalOpen: false,
             portalOptions: null,
-            previousEditorPlainText: "",
-           // documentText: "",
             left: 0,
             top: 0
         };
@@ -329,9 +327,6 @@ class FluxNotesEditor extends React.Component {
         }
 
         const newText = `${text.substring(0, index.start)}`
-
-        // TODO look at choseSuggestedShortcut and here
-        // maybe we want to call setFullAppState() and delete backwards then add the full phrase
         return transform
             .deleteBackward(anchorOffset)
             .insertText(newText)
@@ -339,7 +334,7 @@ class FluxNotesEditor extends React.Component {
 
     insertStructuredFieldTransform(transform, shortcut) {
         if (Lang.isNull(shortcut)) return transform.focus();
-        let result = this.structuredFieldPlugin.transforms.insertStructuredField(transform, shortcut);//Greg says this is the one point always hit when inserting a block
+        let result = this.structuredFieldPlugin.transforms.insertStructuredField(transform, shortcut);
         //console.log(result[0]);
         return result[0];
     }
@@ -367,7 +362,6 @@ class FluxNotesEditor extends React.Component {
     }
 
     onInput = (event, data) => {
-        //console.log("onInput : " + data.newText); not here
         // Create an updated state with the text replaced.
 
         var nextState = this.state.state.transform().select({
@@ -455,7 +449,6 @@ class FluxNotesEditor extends React.Component {
     }
 
     insertPlainText = (transform, text) => {
-        // only runs when loading note, not typing.
         let returnIndex = text.indexOf("\r");
         if (returnIndex >= 0) {
             let result = this.insertPlainText(transform, text.substring(0, returnIndex));

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -343,6 +343,8 @@ class FluxNotesEditor extends React.Component {
 
     onChange = (state) => {
         this.props.setFullAppState("documentText", state.document.text);
+        //console.log(this.props);
+        this.props.saveNoteUponKeypress();
         this.setState({
             state: state
         });

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -128,11 +128,6 @@ export default class NoteAssistant extends Component {
 
     // save the note after every keypress. Invoked by FluxNotesEditor.
     saveNoteOnKeypress = () => {
-        console.log("saving");
-        console.log("is text null? " + Lang.isNull(this.props.documentText)); //still null after @patient then switch notes. Behind by 1
-        if(!Lang.isNull(this.props.documentText)){
-            console.log(this.props.documentText.length);
-        }
         // Don't start saving until there is content in the editor
         if(!Lang.isNull(this.props.documentText) && !Lang.isUndefined(this.props.documentText)){
             if(Lang.isEqual(this.state.currentlyEditingEntryId, -1)){

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -18,7 +18,6 @@ export default class NoteAssistant extends Component {
         this.state = {
             sortIndex: null,
             maxNotesToDisplay: 3,
-            initialNote: true,
             currentlyEditingEntryId: -1
         };
     }
@@ -38,6 +37,7 @@ export default class NoteAssistant extends Component {
     }
     
     componentDidMount() {
+        // set callback so the editor can signal a change and this class can save the note
         this.props.saveNote(this.saveNoteOnKeypress);
     }
 
@@ -71,6 +71,7 @@ export default class NoteAssistant extends Component {
     // Gets called when clicking on the "new note" button
     handleOnNewNoteButtonClick  = () => {
         if(Lang.isEqual(this.state.currentlyEditingEntryId, -1)){
+            // Special case immediately after load
             this.saveEditorContentsToNewNote();        
         } else {
             this.updateExistingNote();
@@ -81,7 +82,8 @@ export default class NoteAssistant extends Component {
 
     updateExistingNote = () => {
         var entryId = this.state.currentlyEditingEntryId;
-        console.log(this.props.patient.getNotes());
+        // List the notes to verify that they are being updated each invocation of this function:
+        // console.log(this.props.patient.getNotes());
         var found = this.props.patient.getNotes().find(function(element){
             return Lang.isEqual(element.entryInfo.entryId, entryId);
         });
@@ -127,12 +129,10 @@ export default class NoteAssistant extends Component {
         this.props.updateSelectedNote(null);
     }
 
-    // alternate approach to Workflow changes: don't make it a special case,
-    // save the note after every keypress.
+    // save the note after every keypress. Invoked by FluxNotesEditor.
     saveNoteOnKeypress = () => {
-        //console.log("key pressed NA " + this.props.documentText);
         // Don't start saving until there is content in the editor
-        if(!Lang.isNull(this.props.documentText) && this.props.documentText.length > 0){
+        if(!Lang.isNull(this.props.documentText) && !Lang.isUndefined(this.props.documentText)  && this.props.documentText.length > 0){
             if(Lang.isEqual(this.state.currentlyEditingEntryId, -1)){
                 this.saveEditorContentsToNewNote();    
             } else {
@@ -142,7 +142,6 @@ export default class NoteAssistant extends Component {
     }
 
     // Gets called when clicking on one of the notes in the clinical notes view
-    // also saves editor content to a new/existing note
     openNote = (isInProgressNote, note) => {
         if(Lang.isEqual(this.state.currentlyEditingEntryId, -1)){
             this.saveEditorContentsToNewNote();    
@@ -160,7 +159,6 @@ export default class NoteAssistant extends Component {
         } else {
             this.toggleView("clinical-notes");
         }
-        console.log(this.props.patient.getNotes());
     }
 
     // Render the content for the Note Assistant panel

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -70,27 +70,24 @@ export default class NoteAssistant extends Component {
 
     // Gets called when clicking on the "new note" button
     handleOnNewNoteButtonClick  = () => {
-        if(Lang.isEqual(this.state.currentlyEditingEntryId, -1)){
-            // Special case immediately after load
-            this.saveEditorContentsToNewNote();        
-        } else {
-            this.updateExistingNote();
-        }
-        
+        this.updateExistingNote();
         this.createBlankNewNote();
     }
 
     updateExistingNote = () => {
         var entryId = this.state.currentlyEditingEntryId;
-        // List the notes to verify that they are being updated each invocation of this function:
-        // console.log(this.props.patient.getNotes());
-        var found = this.props.patient.getNotes().find(function(element){
-            return Lang.isEqual(element.entryInfo.entryId, entryId);
-        });
-        if(!Lang.isNull(found) && !Lang.isUndefined(found)){
-            found.content = this.props.documentText;
-            this.props.patient.updateExistingEntry(found);
-            this.props.updateSelectedNote(found);
+        // Only update if there is a note in progress
+        if(!Lang.isEqual(entryId, -1)){
+            // List the notes to verify that they are being updated each invocation of this function:
+            // console.log(this.props.patient.getNotes());
+            var found = this.props.patient.getNotes().find(function(element){
+                return Lang.isEqual(element.entryInfo.entryId, entryId);
+            });
+            if(!Lang.isNull(found) && !Lang.isUndefined(found)){
+                found.content = this.props.documentText;
+                this.props.patient.updateExistingEntry(found);
+                this.props.updateSelectedNote(found);
+            }
         }
     }
 
@@ -131,8 +128,13 @@ export default class NoteAssistant extends Component {
 
     // save the note after every keypress. Invoked by FluxNotesEditor.
     saveNoteOnKeypress = () => {
+        /*console.log("saving");
+        console.log("is text null? " + Lang.isNull(this.props.documentText)); //still null after @patient then switch notes. Behind by 1
+        if(!Lang.isNull(this.props.documentText)){
+            console.log(this.props.documentText.length);
+        }*/
         // Don't start saving until there is content in the editor
-        if(!Lang.isNull(this.props.documentText) && !Lang.isUndefined(this.props.documentText)  && this.props.documentText.length > 0){
+        if(!Lang.isNull(this.props.documentText) && !Lang.isUndefined(this.props.documentText)){
             if(Lang.isEqual(this.state.currentlyEditingEntryId, -1)){
                 this.saveEditorContentsToNewNote();    
             } else {
@@ -143,6 +145,7 @@ export default class NoteAssistant extends Component {
 
     // Gets called when clicking on one of the notes in the clinical notes view
     openNote = (isInProgressNote, note) => {
+        //console.log(this.props.documentText);
         // Don't start saving until there is content in the editor
         if(!Lang.isNull(this.props.documentText) && !Lang.isUndefined(this.props.documentText)  && this.props.documentText.length > 0){
             if(Lang.isEqual(this.state.currentlyEditingEntryId, -1)){

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -128,11 +128,11 @@ export default class NoteAssistant extends Component {
 
     // save the note after every keypress. Invoked by FluxNotesEditor.
     saveNoteOnKeypress = () => {
-        /*console.log("saving");
+        console.log("saving");
         console.log("is text null? " + Lang.isNull(this.props.documentText)); //still null after @patient then switch notes. Behind by 1
         if(!Lang.isNull(this.props.documentText)){
             console.log(this.props.documentText.length);
-        }*/
+        }
         // Don't start saving until there is content in the editor
         if(!Lang.isNull(this.props.documentText) && !Lang.isUndefined(this.props.documentText)){
             if(Lang.isEqual(this.state.currentlyEditingEntryId, -1)){
@@ -145,7 +145,6 @@ export default class NoteAssistant extends Component {
 
     // Gets called when clicking on one of the notes in the clinical notes view
     openNote = (isInProgressNote, note) => {
-        //console.log(this.props.documentText);
         // Don't start saving until there is content in the editor
         if(!Lang.isNull(this.props.documentText) && !Lang.isUndefined(this.props.documentText)  && this.props.documentText.length > 0){
             if(Lang.isEqual(this.state.currentlyEditingEntryId, -1)){

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -21,7 +21,6 @@ export default class NoteAssistant extends Component {
             initialNote: true,
             currentlyEditingEntryId: -1
         };
-        //this.props.setFullAppStateWithCallback("updateOnKeypress", this.saveNoteUponKeypress);
     }
 
     notesNotDisplayed = null;
@@ -69,8 +68,6 @@ export default class NoteAssistant extends Component {
         this.setState({ sortIndex: sortIndex });
     }
 
-// TODO: somehow use the knowledge that saveEditorContents is now true to trigger an additional save before this Component goes away. For Workflow dropdown change. everything else works.
-
     // Gets called when clicking on the "new note" button
     handleOnNewNoteButtonClick  = () => {
         if(Lang.isEqual(this.state.currentlyEditingEntryId, -1)){
@@ -90,11 +87,8 @@ export default class NoteAssistant extends Component {
         });
         if(!Lang.isNull(found) && !Lang.isUndefined(found)){
             found.content = this.props.documentText;
-            console.log("Set Entry " + found.entryInfo.entryId + " to " + found.content + ". Calling Patient.update with " + found.entryInfo.entryId);
             this.props.patient.updateExistingEntry(found);
             this.props.updateSelectedNote(found);
-        } else {
-            console.log("Error: couldn't find a matching item to update: " + found + " " + this.state.currentlyEditingEntryId);
         }
     }
 
@@ -109,7 +103,6 @@ export default class NoteAssistant extends Component {
         // Add new unsigned note to patient record
         var currentlyEditingEntryId = this.props.patient.addClinicalNote(date, subject, hospital, clinician, this.props.documentText, signed);
         this.setState({currentlyEditingEntryId: currentlyEditingEntryId});
-        console.log("ADDING NOTE TO SHR, id="+ this.state.currentlyEditingEntryId + " aka " + currentlyEditingEntryId);
     }
 
     // creates blank new note and puts it on the screen
@@ -129,27 +122,15 @@ export default class NoteAssistant extends Component {
         // Add new unsigned note to patient record
         var currentlyEditingEntryId = this.props.patient.addClinicalNote(date, subject, hospital, clinician, content, signed);
         this.setState({currentlyEditingEntryId: currentlyEditingEntryId});
-        console.log("ADDING blank NOTE TO SHR, id="+ this.state.currentlyEditingEntryId +" aka " + currentlyEditingEntryId);
-
+        
         // Deselect note in the clinical notes view
         this.props.updateSelectedNote(null);
-    }
-
-    // invoked when the editor goes away
-    // either creates a new note or updates an existing one
-    // depending on whether the editor contents represent an existing note
-    saveNoteUponWorkflowChange = () => {
-        if(Lang.isEqual(this.state.currentlyEditingEntryId, -1)){
-            this.saveEditorContentsToNewNote();    
-        } else {
-            this.updateExistingNote();
-        }
     }
 
     // alternate approach to Workflow changes: don't make it a special case,
     // save the note after every keypress.
     saveNoteOnKeypress = () => {
-        console.log("key pressed NA " + this.props.documentText);
+        //console.log("key pressed NA " + this.props.documentText);
         // Don't start saving until there is content in the editor
         if(!Lang.isNull(this.props.documentText) && this.props.documentText.length > 0){
             if(Lang.isEqual(this.state.currentlyEditingEntryId, -1)){
@@ -166,11 +147,9 @@ export default class NoteAssistant extends Component {
         if(Lang.isEqual(this.state.currentlyEditingEntryId, -1)){
             this.saveEditorContentsToNewNote();    
         } else {
-            // need to only update notes that are inProgress, how? new note we have, but old one? uneditable so probably okay to overwrite with same content
-            //console.log("Updating existing note from openNote, id was " + this.state.currentlyEditingEntryId + " and macthing? content was " + this.props.documentText);
             this.updateExistingNote();
         }
-        this.setState({currentlyEditingEntryId: note.entryInfo.entryId}); // does note have entryId? no..
+        this.setState({currentlyEditingEntryId: note.entryInfo.entryId});
         // the lines below are duplicative
         this.props.updateSelectedNote(note);
         this.props.loadNote(note);
@@ -181,6 +160,7 @@ export default class NoteAssistant extends Component {
         } else {
             this.toggleView("clinical-notes");
         }
+        console.log(this.props.patient.getNotes());
     }
 
     // Render the content for the Note Assistant panel
@@ -400,5 +380,6 @@ NoteAssistant.propTypes = {
     contextManager: PropTypes.object,
     shortcutManager: PropTypes.object,
     isNoteViewerEditable: PropTypes.bool,
+    saveNote: PropTypes.func,
     handleSummaryItemSelected: PropTypes.func
 };

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -143,10 +143,13 @@ export default class NoteAssistant extends Component {
 
     // Gets called when clicking on one of the notes in the clinical notes view
     openNote = (isInProgressNote, note) => {
-        if(Lang.isEqual(this.state.currentlyEditingEntryId, -1)){
-            this.saveEditorContentsToNewNote();    
-        } else {
-            this.updateExistingNote();
+        // Don't start saving until there is content in the editor
+        if(!Lang.isNull(this.props.documentText) && !Lang.isUndefined(this.props.documentText)  && this.props.documentText.length > 0){
+            if(Lang.isEqual(this.state.currentlyEditingEntryId, -1)){
+                this.saveEditorContentsToNewNote();    
+            } else {
+                this.updateExistingNote();
+            }
         }
         this.setState({currentlyEditingEntryId: note.entryInfo.entryId});
         // the lines below are duplicative

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -153,7 +153,7 @@ function StructuredFieldPlugin(opts) {
             } else if (blk.kind === 'inline' && blk.type === 'structured_field') {
                 let shortcut = blk.data.get("shortcut");
                 if (shortcut instanceof InsertValue || (shortcut instanceof CreatorChild && Lang.isArray(shortcut.determineText(contextManager)))) {
-                    let text = shortcut.getText();
+                    let text = shortcut.getText(); // error upon copy, is this in master?
                     if (text.startsWith(shortcut.getPrefixCharacter())) {
                         text = text.substring(1);
                     }
@@ -166,7 +166,7 @@ function StructuredFieldPlugin(opts) {
         return result;
     }
 
-    function convertToText(state, selection) {
+    function convertToText(state, selection) { //Greg says call this
         //console.log(selection);
         const startBlock = state.document.getDescendant(selection.startKey);
         const startOffset = selection.startOffset;
@@ -221,6 +221,8 @@ function StructuredFieldPlugin(opts) {
         if (native.isCollapsed && !isVoid) return;
 
         //console.log(state.document);
+        console.log("onCopy, state is");
+        console.log(state);
         let fluxString = convertToText(state, selection);
         //console.log("copy: " + fluxString);
         const encoded = window.btoa(window.encodeURIComponent(fluxString));

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -153,8 +153,8 @@ function StructuredFieldPlugin(opts) {
             } else if (blk.kind === 'inline' && blk.type === 'structured_field') {
                 let shortcut = blk.data.get("shortcut");
                 if (shortcut instanceof InsertValue || (shortcut instanceof CreatorChild && Lang.isArray(shortcut.determineText(contextManager)))) {
-                    let text = shortcut.getText(); // error upon copy, is this in master?
-                    if (text.startsWith(shortcut.getPrefixCharacter())) {
+                    let text = shortcut.getText();
+                    if (typeof(text) === "string" && text.startsWith(shortcut.getPrefixCharacter())) {
                         text = text.substring(1);
                     }
                     result += `${shortcut.initiatingTrigger}[[${text}]]`;
@@ -166,8 +166,7 @@ function StructuredFieldPlugin(opts) {
         return result;
     }
 
-    function convertToText(state, selection) { //Greg says call this
-        //console.log(selection);
+    function convertToText(state, selection) {
         const startBlock = state.document.getDescendant(selection.startKey);
         const startOffset = selection.startOffset;
         const endOffset = selection.endOffset;
@@ -207,7 +206,6 @@ function StructuredFieldPlugin(opts) {
     }
 
     function onCopy(event, data, state, editor) {
-        //console.log("onCopy");
         let { selection } = state;
    
         const window = getWindow(event.target);
@@ -220,9 +218,6 @@ function StructuredFieldPlugin(opts) {
         // If the selection is collapsed, and it isn't inside a void node, abort.
         if (native.isCollapsed && !isVoid) return;
 
-        //console.log(state.document);
-        console.log("onCopy, state is");
-        console.log(state);
         let fluxString = convertToText(state, selection);
         //console.log("copy: " + fluxString);
         const encoded = window.btoa(window.encodeURIComponent(fluxString));
@@ -307,6 +302,7 @@ function StructuredFieldPlugin(opts) {
         onCopy,
         onPaste,
         schema,
+        convertToText,
 		
         utils: {
             //isSelectionInStructuredField

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -146,10 +146,6 @@ export default class NotesPanel extends Component {
                     updateSelectedNote={this.updateSelectedNote}
                     documentText={this.props.documentText}
                     saveEditorContents={this.props.saveEditorContents}
-                    // Pass this down one more layer
-                    setFullAppState={this.props.setFullAppState}
-                    setFullAppStateWithCallback={this.props.setFullAppStateWithCallback}
-                    saveNoteUponKeypress={this.saveNoteUponKeypress}
                     saveNote={click => this.saveNoteChild = click}
                 />
             </div>
@@ -170,7 +166,8 @@ NotesPanel.propTypes = {
     contextManager: PropTypes.object,
     shortcutManager: PropTypes.object,
     summaryItemToBeInserted: PropTypes.string,
-    //needed? was there documentText: PropTypes.string,
+    documentText: PropTypes.string,
+    saveNote: PropTypes.func,
     errors: PropTypes.array,
     isNoteViewerEditable: PropTypes.bool,
     newCurrentShortcut: PropTypes.func,

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Row, Col } from 'react-flexbox-grid';
 
 import FluxNotesEditor from '../notes/FluxNotesEditor';
+import Lang from 'lodash';
 import NoteAssistant from '../notes/NoteAssistant';
 import './NotesPanel.css';
 
@@ -21,6 +22,12 @@ export default class NotesPanel extends Component {
         this.updateSelectedNote = this.updateSelectedNote.bind(this);
     }
 
+    //added
+    getCurrentNote(){
+        
+        return this.updatedEditorNote;
+    }
+
     updateNoteAssistantMode(mode) {
         this.setState({noteAssistantMode: mode});
     }
@@ -31,7 +38,9 @@ export default class NotesPanel extends Component {
 
     // Handle when the editor needs to be updated with a note. The note can be a new blank note or a pre existing note
     handleUpdateEditorWithNote(note) {
-
+        if(!Lang.isNull(note)){
+            this.props.setFullAppState("documentText", note.content);
+        }
         // If in pre-encounter mode and the note editor doesn't exist, update the layout and add the editor
         // Set the note to be inserted into the editor and the selected note
         if (this.props.currentViewMode === 'pre-encounter' && !this.props.isNoteViewerVisible) {
@@ -97,6 +106,8 @@ export default class NotesPanel extends Component {
                     shortcutManager={this.props.shortcutManager}
                     updateErrors={this.props.updateErrors}
                     errors={this.props.errors}
+                    // Pass this down one more layer
+                    setFullAppState={this.props.setFullAppState}
 
                     // Pass in note that the editor is to be updated with
                     updatedEditorNote={this.state.updatedEditorNote}
@@ -123,6 +134,8 @@ export default class NotesPanel extends Component {
                     updateNoteAssistantMode={this.updateNoteAssistantMode}
                     selectedNote={this.state.selectedNote}
                     updateSelectedNote={this.updateSelectedNote}
+                    documentText={this.props.documentText}
+                    saveEditorContents={this.props.saveEditorContents}
                 />
             </div>
         );
@@ -142,6 +155,7 @@ NotesPanel.propTypes = {
     contextManager: PropTypes.object,
     shortcutManager: PropTypes.object,
     summaryItemToBeInserted: PropTypes.string,
+    //needed? was there documentText: PropTypes.string,
     errors: PropTypes.array,
     isNoteViewerEditable: PropTypes.bool,
     newCurrentShortcut: PropTypes.func,

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -23,12 +23,6 @@ export default class NotesPanel extends Component {
         this.saveNoteUponKeypress = this.saveNoteUponKeypress.bind(this);
     }
 
-    /*added
-    getCurrentNote(){
-        
-        return this.updatedEditorNote;
-    }*/
-
     updateNoteAssistantMode(mode) {
         this.setState({noteAssistantMode: mode});
     }
@@ -67,9 +61,7 @@ export default class NotesPanel extends Component {
         }
     }
 
-    // alternate approach to Workflow changes: don't make it a special case,
-    // save the note after every keypress.
-    // This function invokes the note saving logic in NoteAssistant
+    // Save the note after every keypress. This function invokes the note saving logic in NoteAssistant
     saveNoteUponKeypress(){
         this.saveNoteChild();
     }

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -20,13 +20,14 @@ export default class NotesPanel extends Component {
         this.handleUpdateEditorWithNote = this.handleUpdateEditorWithNote.bind(this);
         this.updateNoteAssistantMode = this.updateNoteAssistantMode.bind(this);
         this.updateSelectedNote = this.updateSelectedNote.bind(this);
+        this.saveNoteUponKeypress = this.saveNoteUponKeypress.bind(this);
     }
 
-    //added
+    /*added
     getCurrentNote(){
         
         return this.updatedEditorNote;
-    }
+    }*/
 
     updateNoteAssistantMode(mode) {
         this.setState({noteAssistantMode: mode});
@@ -64,6 +65,13 @@ export default class NotesPanel extends Component {
         if (this.props.isNoteViewerVisible) {
             this.setState({updatedEditorNote: note});
         }
+    }
+
+    // alternate approach to Workflow changes: don't make it a special case,
+    // save the note after every keypress.
+    // This function invokes the note saving logic in NoteAssistant
+    saveNoteUponKeypress(){
+        this.saveNoteChild();
     }
 
     renderNotesPanelContent() {
@@ -108,6 +116,8 @@ export default class NotesPanel extends Component {
                     errors={this.props.errors}
                     // Pass this down one more layer
                     setFullAppState={this.props.setFullAppState}
+                    setFullAppStateWithCallback={this.props.setFullAppStateWithCallback}
+                    saveNoteUponKeypress={this.saveNoteUponKeypress}
 
                     // Pass in note that the editor is to be updated with
                     updatedEditorNote={this.state.updatedEditorNote}
@@ -136,6 +146,11 @@ export default class NotesPanel extends Component {
                     updateSelectedNote={this.updateSelectedNote}
                     documentText={this.props.documentText}
                     saveEditorContents={this.props.saveEditorContents}
+                    // Pass this down one more layer
+                    setFullAppState={this.props.setFullAppState}
+                    setFullAppStateWithCallback={this.props.setFullAppStateWithCallback}
+                    saveNoteUponKeypress={this.saveNoteUponKeypress}
+                    saveNote={click => this.saveNoteChild = click}
                 />
             </div>
         );

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -109,6 +109,7 @@ export default class NotesPanel extends Component {
                     setFullAppState={this.props.setFullAppState}
                     setFullAppStateWithCallback={this.props.setFullAppStateWithCallback}
                     saveNoteUponKeypress={this.saveNoteUponKeypress}
+                    documentText={this.props.documentText}
 
                     // Pass in note that the editor is to be updated with
                     updatedEditorNote={this.state.updatedEditorNote}

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -106,7 +106,6 @@ export default class NotesPanel extends Component {
                     shortcutManager={this.props.shortcutManager}
                     updateErrors={this.props.updateErrors}
                     errors={this.props.errors}
-                    // Pass this down one more layer
                     setFullAppState={this.props.setFullAppState}
                     setFullAppStateWithCallback={this.props.setFullAppStateWithCallback}
                     saveNoteUponKeypress={this.saveNoteUponKeypress}
@@ -137,7 +136,6 @@ export default class NotesPanel extends Component {
                     selectedNote={this.state.selectedNote}
                     updateSelectedNote={this.updateSelectedNote}
                     documentText={this.props.documentText}
-                    saveEditorContents={this.props.saveEditorContents}
                     saveNote={click => this.saveNoteChild = click}
                 />
             </div>

--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -63,7 +63,18 @@ class PatientRecord {
 
         this.personOfRecord = this.getPersonOfRecord();
 		this.nextEntryId = Math.max.apply(Math, this.entries.map(function(o) { return o.entryInfo.entryId; })) + 1;
-	}
+    }
+    
+    // Finds an existing entry with the same entryId and replaces it with updatedEntry
+    updateExistingEntry(updatedEntry){
+        var found = this.entries.find(function(element){
+            return Lang.isEqual(element.entryInfo.entryId, updatedEntry.entryInfo.entryId);
+        });
+        if(!Lang.isUndefined(found)){
+            var index = this.entries.indexOf(found);
+            this.entries[index] = updatedEntry;
+        }
+    }
 
     addEntryToPatient(entry) {
         entry.entryInfo.shrId = this.shrId;
@@ -72,12 +83,15 @@ class PatientRecord {
         let today = new moment().format("D MMM YYYY");
         entry.entryInfo.originalCreationDate = today;
         entry.entryInfo.lastUpdateDate = today;
+        //entry.entryInfo.entryType = [ "http://standardhealthrecord.org/core/ClinicalNote" ]; probably not needed, uses instanceof
         this.entries.push(entry);
+        // TODO evaluate saving updated PatientRecord/entries to the database. Should it happen every time it changes, e.g. right here? or less frequently.
+        return entry.entryInfo.entryId;
     }
 
     addEntryToPatientWithPatientFocalSubject(entry) {
         entry.focalSubject = this.patientFocalSubject;
-        this.addEntryToPatient(entry);
+        return this.addEntryToPatient(entry);
     }
 
     setDeceased(deceased) {
@@ -220,7 +234,7 @@ class PatientRecord {
             }
         );
 
-        this.addEntryToPatientWithPatientFocalSubject(clinicalNote);
+        return this.addEntryToPatientWithPatientFocalSubject(clinicalNote);
     }
 
     getNotes() {

--- a/src/summary/ClinicalEventSelection.jsx
+++ b/src/summary/ClinicalEventSelection.jsx
@@ -16,6 +16,17 @@ class ClinicalEventSelection extends Component {
     selectClinicalEvent(clinicalEvent) {
         // need to save off contents of note here
         this.props.setFullAppState('saveEditorContents', true);
+       // console.log("selectClinicalEvent");
+       // console.log(this.props);
+
+        /*        no Patient on props here.
+        let date = "15 Jan 2018";
+        let subject = "New Note";
+        let hospital = "Dana Farber Cancer Institute";
+        let clinician = "Dr. X123";
+        let signed = false;
+        this.props.patient.addClinicalNote(date, subject, hospital, clinician, this.props.documentText, signed);
+        */
 
         this.props.setFullAppState('clinicalEvent', clinicalEvent.toLowerCase());
     }

--- a/src/summary/ClinicalEventSelection.jsx
+++ b/src/summary/ClinicalEventSelection.jsx
@@ -14,20 +14,6 @@ class ClinicalEventSelection extends Component {
     }
 
     selectClinicalEvent(clinicalEvent) {
-        // need to save off contents of note here
-       // this.props.setFullAppState('saveEditorContents', true);
-       // console.log("selectClinicalEvent");
-       // console.log(this.props);
-
-        /*        no Patient on props here.
-        let date = "15 Jan 2018";
-        let subject = "New Note";
-        let hospital = "Dana Farber Cancer Institute";
-        let clinician = "Dr. X123";
-        let signed = false;
-        this.props.patient.addClinicalNote(date, subject, hospital, clinician, this.props.documentText, signed);
-        */
-
         this.props.setFullAppState('clinicalEvent', clinicalEvent.toLowerCase());
     }
 

--- a/src/summary/ClinicalEventSelection.jsx
+++ b/src/summary/ClinicalEventSelection.jsx
@@ -15,7 +15,7 @@ class ClinicalEventSelection extends Component {
 
     selectClinicalEvent(clinicalEvent) {
         // need to save off contents of note here
-        this.props.setFullAppState('saveEditorContents', true);
+       // this.props.setFullAppState('saveEditorContents', true);
        // console.log("selectClinicalEvent");
        // console.log(this.props);
 

--- a/src/summary/ClinicalEventSelection.jsx
+++ b/src/summary/ClinicalEventSelection.jsx
@@ -14,6 +14,9 @@ class ClinicalEventSelection extends Component {
     }
 
     selectClinicalEvent(clinicalEvent) {
+        // need to save off contents of note here
+        this.props.setFullAppState('saveEditorContents', true);
+
         this.props.setFullAppState('clinicalEvent', clinicalEvent.toLowerCase());
     }
 

--- a/test/ui/FullApp.js
+++ b/test/ui/FullApp.js
@@ -556,6 +556,41 @@ test('Clicking on an in-progress note in post encounter mode loads the note in t
         .notEql("Enter your clinical note here or choose a template to start from...");
 })
 
+// Verifies automatic saving
+test('Contents of in-progress note saved when switching to a completed note and back', async t => {
+     const editor = Selector("div[data-slate-editor='true']");
+    const clinicalNotesButton = Selector('.clinical-notes-btn');
+    const newNoteButton = Selector('.note-new');
+    const inProgressNotes = Selector('.in-progress-note');
+        const note = Selector('.existing-note');
+    
+    // Enter some text in the editor
+    await t
+        .typeText(editor, "This is a note.");
+
+    // Click on the clinical notes button to switch to clinical notes view
+    await t
+        .click(clinicalNotesButton);
+
+    // click on a completed note to view it
+    await t
+        .click(note)
+
+    // Click on the in-progress note
+    await t
+        .click(inProgressNotes)
+
+    // Test that there is some text in the editor and that the editor is not in its initial cleared state
+    await t
+        .expect(editor.textContent)
+        .notEql("Enter your clinical note here or choose a template to start from...");
+    // Test that there is some text in the editor and that the editor is not in its initial cleared state
+    await t
+        .expect(editor.textContent)
+        .notEql("");
+});
+
+
 test('Clicking on an in-progress note in post encounter mode puts the NotesPanel in edit mode with the context tray displayed', async t => {
     const editor = Selector("div[data-slate-editor='true']");
     const clinicalNotesButton = Selector('.clinical-notes-btn');

--- a/test/ui/FullApp.js
+++ b/test/ui/FullApp.js
@@ -532,6 +532,10 @@ test('Clicking on an in-progress note in post encounter mode loads the note in t
     const clinicalNotesButton = Selector('.clinical-notes-btn');
     const newNoteButton = Selector('.note-new');
     const inProgressNotes = Selector('.in-progress-note');
+    
+    // Enter some text in the editor
+    await t
+        .typeText(editor, "This is a note.");
 
     // Click on the clinical notes button to switch to clinical notes view
     await t


### PR DESCRIPTION
This pull request adds the saving of notes to the in-memory PatientRecord. Notes are saved whenever the Slate editor is updated, including text and structured fields. The New Note button creates a new in-progress note which is automatically saved. When the editor is first loaded, it is not associated with a note. When you begin to type in the editor, a new note is created and saved. Several bugs related to empty notes and saving when switching to view another note were uncovered and resolved.

Please review and try to break this by finding a way to lose data. 

This will have to be rebased.

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [X] Manually tested in Chrome
- [X] Manually tested in IE

**Documentation**

- [X] This pull request describes why these changes were made
- [X] Recognizes any potential shortcomings/bugs in the description 
- [N/A] Cheat sheet is updated
- [N/A] Demo script is updated 
- [N/A] Documentation on Wiki has been updated 
- [N/A] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [N/A] Note parser has been updated if structured phrases change

**Code Quality**

- [X] 4-space indents - convert any tabs to spaces
- [X] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [X] Code is commented

**Tests**

- [X] Existing tests passed
- [N/A] Added UI tests for slim mode 
- [X] Added UI tests for full mode
- [N/A] Added backend tests for fluxNotes code
- [N/A] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
