### PR TITLE
Added Trademarks to Flux Notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Flux Notes Prototype
+# Flux Notes&trade; Prototype
 
 
 ## Features
-This prototype is designed to demonstrate the concept of a clinician entering or dictating a clinical note that includes structured data embedded within it. A patient summary is shown for reference during the authoring of new clinical notes and provide incentive to identifying structured data during note authoring and review. The clinican can leverage templates for note creation. When authoring a note and within a structured field, Flux Notes displays a simple "point-of-sale" inspired "form" for choosing values that are part of the current structured field.
+This prototype is designed to demonstrate the concept of a clinician entering or dictating a clinical note that includes structured data embedded within it. A patient summary is shown for reference during the authoring of new clinical notes and provide incentive to identifying structured data during note authoring and review. The clinican can leverage templates for note creation. When authoring a note and within a structured field, Flux Notes&trade; displays a simple "point-of-sale" inspired "form" for choosing values that are part of the current structured field.
 
 In addition, a no-patient version of the above concept has been created for situations where EHR integration is not possible and to facilitate use at hospitals without requiring installation. In no-patient mode, the clinican choosing the type of data being authored and then uses the point-of-sale form from above to author the content which produces the equivalent structured field text that can be pasted into their EHR's note entry area as part of authoring a clinical note.
 
@@ -40,21 +40,21 @@ If a directory is specified, every file in that directory will be treated as a n
 
 ## Testing
 
-For docs on writing new tests, [see here in our wiki](https://github.com/standardhealth/flux/wiki/Testing#writing-tests). To run tests, go into the central project directory and run: 
+For docs on writing new tests, [see here in our wiki](https://github.com/standardhealth/flux/wiki/Testing#writing-tests). To run tests, go into the central project directory and run:
 
 ```
 yarn test
 ```
 
-This command will determine your machine's OS and run all possible tests. When in development, individuals can run front end tests with `yarn test-ui` and backend tests with `yarn test-backend`. 
+This command will determine your machine's OS and run all possible tests. When in development, individuals can run front end tests with `yarn test-ui` and backend tests with `yarn test-backend`.
 
-**Required Extra Steps**: Due to quirks in the libraries we're using, there are few things to do in order for all tests to pass: 
+**Required Extra Steps**: Due to quirks in the libraries we're using, there are few things to do in order for all tests to pass:
 
 1. Run `yarn start` in another terminal before running `yarn test`. Some ui-tests will fail because it takes longer for the site instance to spin up than it takes for the tests to start.
-2. Ensure that all browsers' testing windows are open while the tests are running. TestCafe has been known to have some issues if those windows are minimized, possibly causing some tests to fail when they shouldn't. 
-3. Zoom out ridiculously far out on the ui-test's browser windows once they open. There are currently some issues we have with the our fixed copy-button that cause some tests to fail if the 
+2. Ensure that all browsers' testing windows are open while the tests are running. TestCafe has been known to have some issues if those windows are minimized, possibly causing some tests to fail when they shouldn't.
+3. Zoom out ridiculously far out on the ui-test's browser windows once they open. There are currently some issues we have with the our fixed copy-button that cause some tests to fail if the
 
-**Other Known Issues:** 
+**Other Known Issues:**
 
 - *Using Git Bash on Windows?* It may look like the test aren't working on your machine. Hit enter a second time after running your yarn test command. The specifics of why this happens are still unknown, but this should help when running your tests.
 

--- a/src/apps/AppManager.jsx
+++ b/src/apps/AppManager.jsx
@@ -2,25 +2,25 @@ import FullApp from '../containers/FullApp';
 import SlimApp from '../containers/SlimApp';
 import LandingPage from '../components/LandingPage';
 
-class AppManager {
+export default class AppManager {
     constructor() {
         this.apps = [{
                 path: '/',
-                display: 'Flux Notes',
+                display: 'Flux Notes™',
                 app: LandingPage,
                 isExact: true
             },
             {
                 path: '/patina',
                 shortcuts: ['Disease Status', 'Toxicity', 'Clinical Trial', 'Deceased'],
-                display: 'Flux Notes Lite (for PATINA endpoints)',
+                display: 'Flux Notes™ Lite (for PATINA endpoints)',
                 app: SlimApp,
                 isExact: true,
                 shortcutConfigurations: {
                     'Disease Status': {
                         referenceDateEnabled: false
                     },
-                    'Toxicity': {   
+                    'Toxicity': {
                         gradesToDisplay: [3,4,5],
                         gradesPrompt: ' PATINA only calculates its endpoint based on adverse events of grades 2 through 5; therefore, only those are shown below. ',
                         topAdverseEvents: [
@@ -51,7 +51,7 @@ class AppManager {
             {
                 path: '/merkelcell',
                 shortcuts: ['Disease Status', 'Toxicity', 'Deceased'],
-                display: 'Flux Notes Lite (for Merkel Cell endpoints)',
+                display: 'Flux Notes™ Lite (for Merkel Cell endpoints)',
                 app: SlimApp,
                 isExact: true,
                 shortcutConfigurations: {
@@ -85,21 +85,21 @@ class AppManager {
             },
             {
                 path: '/patient',
-                display: 'Flux Notes',
+                display: 'Flux Notes™',
                 app: FullApp,
                 isExact: true,
                 dataSource: 'HardCodedReadOnlyDataSource',
                 shortcuts: []
             },  {
                 path: '/p2',
-                display: 'Flux Notes',
+                display: 'Flux Notes™',
                 app: FullApp,
                 isExact: false,
                 dataSource: 'RestApiDataSource',
                 shortcuts: []
             }, {
                 path: '/p3',
-                display: 'Flux Notes',
+                display: 'Flux Notes™',
                 app: FullApp,
                 isExact: false,
                 dataSource: 'FHIRApiDataSource',
@@ -112,5 +112,3 @@ class AppManager {
         return this.apps;
     }
 }
-
-export default AppManager;

--- a/src/components/LandingPage.jsx
+++ b/src/components/LandingPage.jsx
@@ -12,6 +12,7 @@ export default class LandingPage extends Component {
                     <div className="landing-header-logo">
                         <img src="./fluxnotes_logo_color.png" alt="Flux Notes" className="landing-header-logo-image" />
                         <span className="landing-header-title">Flux Notes</span>
+                        <span className="landing-header-trademark">™</span>
                     </div>
                 </div>
 
@@ -21,7 +22,7 @@ export default class LandingPage extends Component {
                     </div>
 
                     <div className="landing-tagline-text">
-                        Flux Notes is an open source, standard health record based application that will expand the
+                        Flux Notes™ is an open source, standard health record based application that will expand the
                         availability of structured high quality, longitudinal and computable health records data to
                         support clinical oncology research.
                     </div>
@@ -147,7 +148,7 @@ export default class LandingPage extends Component {
                                 </div>
 
                                 <div className="landing-products-link">
-                                    <span>Flux Notes Lite</span>
+                                    <span>Flux Notes™ Lite</span>
                                     <FontAwesome name="arrow-right" />
                                 </div>
                             </a>
@@ -155,12 +156,12 @@ export default class LandingPage extends Component {
 
                         <div className="landing-products-description">
                             <div className="landing-products-title-mobile">
-                                Flux Notes Lite
+                                Flux Notes™ Lite
                                 <span>Viewable on desktop</span>
                             </div>
 
                             <div className="landing-products-summary">
-                                Flux Notes Lite helps clinicians capture data to drive clinical endpoints, such as
+                                Flux Notes™ Lite helps clinicians capture data to drive clinical endpoints, such as
                                 disease status and toxicity. This information is stored in a structured data format
                                 that can be easily analyzed and shared across multiple clinical care sites.
 
@@ -189,7 +190,7 @@ export default class LandingPage extends Component {
                                 </div>
 
                                 <div className="landing-products-link">
-                                    <span>Flux Notes Full</span>
+                                    <span>Flux Notes™ Full</span>
                                     <FontAwesome name="arrow-right" />
                                 </div>
                             </a>
@@ -197,12 +198,12 @@ export default class LandingPage extends Component {
 
                         <div className="landing-products-description">
                             <div className="landing-products-title-mobile">
-                                Flux Notes Full
+                                Flux Notes™ Full
                                 <span>Viewable on desktop</span>
                             </div>
 
                             <div className="landing-products-summary">
-                                Flux Notes Full allows information capture via extensible structured phrases driven by
+                                Flux Notes™ Full allows information capture via extensible structured phrases driven by
                                 the Standard Health Record (SHR).
 
                                 <div className="landing-products-summary-divider"></div>
@@ -219,7 +220,7 @@ export default class LandingPage extends Component {
                                 </p>
 
                                 <p>
-                                    The approach of Flux Notes Full will be to deploy it at hospitals and integrate
+                                    The approach of Flux Notes™ Full will be to deploy it at hospitals and integrate
                                     bi-directionally with existing EHRs.
                                 </p>
                             </div>
@@ -241,7 +242,7 @@ export default class LandingPage extends Component {
                 <div className="landing-clinical-trials">
                     <div className="landing-clinical-trials-section patina">
                         <Button raised href="/patina" className="landing-clinical-trials-button" id="link-to-patina">
-                            Flux Notes for PATINA
+                            Flux Notes™ for PATINA
                         </Button>
 
                         <div className="landing-clinical-trials-description">
@@ -259,8 +260,8 @@ export default class LandingPage extends Component {
 
                         <div className="landing-get-involved-info-description">
                             Support the collection of high quality real-world data (RWD) to enable clinical oncology
-                            research. Contact us to learn more about the project, or about piloting Flux Notes in a
-                            clinical setting. Help grow Flux Notes by committing to
+                            research. Contact us to learn more about the project, or about piloting Flux Notes™ in a
+                            clinical setting. Help grow Flux Notes™ by committing to
                             the <a href="https://github.com/standardhealth/flux" alt="Flux Notes Repository">repository</a> today.
                         </div>
                     </div>
@@ -309,7 +310,7 @@ export default class LandingPage extends Component {
 
                         <div className="landing-initiatives-description">
                             <p>
-                                Flux Notes supports the ICAREdata study capture of treatment data during the authoring
+                                Flux Notes™ supports the ICAREdata study capture of treatment data during the authoring
                                 of clinical notes. The goal of the ICAREdata study is to support the collection of high
                                 quality real-world data (RWD) in a way that enables clinical oncology research.
                             </p>

--- a/src/containers/FullApp.jsx
+++ b/src/containers/FullApp.jsx
@@ -23,7 +23,7 @@ const theme = createMuiTheme({
     }
 });
 
-class FullApp extends Component {
+export default class FullApp extends Component {
     constructor(props) {
         super(props);
         this.possibleClinicalEvents = [
@@ -206,5 +206,3 @@ FullApp.proptypes = {
     shortcuts: PropTypes.array.isRequired,
     display: PropTypes.string.isRequired
 }
-
-export default FullApp;

--- a/src/containers/SlimApp.jsx
+++ b/src/containers/SlimApp.jsx
@@ -1,14 +1,15 @@
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import {Grid, Row, Col} from 'react-flexbox-grid';
+import { Grid, Row, Col } from 'react-flexbox-grid';
+import Lang from 'lodash';
+
 import NavBar from '../nav/NavBar';
 import FormList from '../forms/FormList';
 import ShortcutViewer from '../viewer/ShortcutViewer';
 import ShortcutManager from '../shortcuts/ShortcutManager';
-import Lang from 'lodash'
 import '../styles/SlimApp.css';
 
-class SlimApp extends Component {
+export default class SlimApp extends Component {
     constructor(props) {
         super(props);
 
@@ -43,30 +44,32 @@ class SlimApp extends Component {
 
     render() {
         return (
-                <div className="SlimApp">
-                    <NavBar title={this.props.display} supportLogin={false}/>
-                    <Grid className="SlimApp-content" fluid>
-                        <div id="forms-panel">
-                            <Row center="xs">
-                                <Col className="no-padding" xs={3}>
-                                    {/*No need for formsearch right now*/}
-                                    {/*<FormSearch />*/}
-                                    <FormList
-                                        shortcuts={['About Flux Notes Lite'].concat(this.props.shortcuts)} //, 'Disease Status', 'Toxicity'
-                                        currentShortcut={this.state.currentShortcut}
-                                        changeShortcut={this.changeShortcut}
-                                    />
-                                </Col>
-                                <Col className="no-padding" xs={9}>
-                                    <ShortcutViewer
-                                        currentShortcut={this.state.currentShortcut}
-                                        onShortcutUpdate={this.handleShortcutUpdate}
-                                    />
-                                </Col>
-                            </Row>
-                        </div>
-                    </Grid>
-                </div>
+            <div className="SlimApp">
+                <NavBar title={this.props.display} supportLogin={false} />
+
+                <Grid className="SlimApp-content" fluid>
+                    <div id="forms-panel">
+                        <Row center="xs">
+                            <Col className="no-padding" xs={3}>
+                                {/*No need for formsearch right now*/}
+                                {/*<FormSearch />*/}
+                                <FormList
+                                    shortcuts={['About Flux Notes™ Lite'].concat(this.props.shortcuts)} //, 'Disease Status', 'Toxicity'
+                                    currentShortcut={this.state.currentShortcut}
+                                    changeShortcut={this.changeShortcut}
+                                />
+                            </Col>
+
+                            <Col className="no-padding" xs={9}>
+                                <ShortcutViewer
+                                    currentShortcut={this.state.currentShortcut}
+                                    onShortcutUpdate={this.handleShortcutUpdate}
+                                />
+                            </Col>
+                        </Row>
+                    </div>
+                </Grid>
+            </div>
         );
     }
 }
@@ -76,5 +79,3 @@ SlimApp.proptypes = {
     shortcuts: PropTypes.array.isRequired,
     display: PropTypes.string.isRequired
 }
-
-export default SlimApp;

--- a/src/forms/FormList.jsx
+++ b/src/forms/FormList.jsx
@@ -9,14 +9,14 @@ class FormList extends Component {
         super(props);
         this._newShortcut = this._newShortcut.bind(this);
         this.state = {
-            disabledElement: "About Flux Notes Lite"
+            disabledElement: "About Flux Notes™ Lite"
         }
     }
 
     _newShortcut(e, index, shortcutName) {
         e.preventDefault();
 
-        if (shortcutName !== "About Flux Notes Lite") {
+        if (shortcutName !== "About Flux Notes™ Lite") {
             this.props.changeShortcut(this.props.shortcuts[index]);
         }
         else {
@@ -37,7 +37,7 @@ class FormList extends Component {
                         let classValue = "list-element";
                         let primaryText = shortcutName;
 
-                        if (shortcutName === "About Flux Notes Lite") {
+                        if (shortcutName === "About Flux Notes™ Lite") {
                             classValue += " overview";
                         }
                         if (this.state.disabledElement === shortcutName) {
@@ -68,8 +68,8 @@ class FormList extends Component {
     }
 }
 
-FormList.proptypes = { 
-    shortcuts: PropTypes.array.isRequired, 
+FormList.proptypes = {
+    shortcuts: PropTypes.array.isRequired,
     currentShortcut: PropTypes.object,
     changeShortcut: PropTypes.func.isRequired
 }

--- a/src/forms/LandingPageForm.css
+++ b/src/forms/LandingPageForm.css
@@ -1,10 +1,20 @@
 .landing-page-title {
     color: steelblue;
 }
-ol, ol li { 
-    margin-left: 0; 
-    padding-left: 0; 
+
+ol, ol li {
+    margin-left: 0;
+    padding-left: 0;
 }
-ol { 
-    margin-left: 1.3em; 
+
+ol {
+    margin-left: 1.3em;
+}
+
+.landing-page-about {
+  margin-bottom: 40px;
+}
+
+.landing-page-using li {
+  margin: 10px 0;
 }

--- a/src/forms/LandingPageForm.jsx
+++ b/src/forms/LandingPageForm.jsx
@@ -1,56 +1,63 @@
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 import './LandingPageForm.css';
 
-class LandingPageForm extends Component {
-
+export default class LandingPageForm extends Component {
     render() {
         return (
             <div id="landing-page-container">
-                <h1 className="landing-page-title">About Flux Notes Lite</h1>
-                <p>
-                    Flux Notes Lite supports the ICARE data study capture of disease status and toxicity during the
-                    authoring of clinical notes. The purpose of Flux Notes Lite is to help clinicians capture disease
-                    status and
-                    toxicity information in a structured data format that can be easily analyzed and shared across
-                    multiple clinical care sites.
-                </p>
-                <p>
-                    This application provides an easy mechanism for clinicians to generate disease status and toxicity
-                    information via an interface and allow them to copy the resulting structured shorthand phrase and
-                    paste it
-                    into their EHR notes entry.
-                </p>
-                <p>
-                    This tool is one of multiple prototypes in development by MITRE with the end goal of providing
-                    complete, accurate, and computable records to inform the best care for each individual.
-                </p>
-                <p>
-                    This application leverages the <a href="http://standardhealthrecord.org/" target="_blank">SHR (Standard Health Record)</a> format for capturing data.
-                </p>
-                <p>&nbsp;</p>
-                <h4>Using Flux Notes Lite</h4>
-                <ol>
-                    <li>
-                        From the left panel, select the type of data that you would like to capture
-                    </li>
-                    <br/>
-                    <li>
-                        A form will be displayed on the right for the selected data type. On this form, choose values
-                        related to the data. As values are selected, the copy button on the bottom of the form will show
-                        the structured shorthand phrase as it is being built
-                    </li>
-                    <br/>
-                    <li>
-                        Once you finish entering data, click the copy button to copy the shorthand phrase
-                    </li>
-                    <br/>
-                    <li>
-                        Paste the phrase into your EHR notes entry
-                    </li>
-                </ol>
+                <div className="landing-page-about">
+                    <h1 className="landing-page-title">About Flux Notes™ Lite</h1>
+
+                    <p>
+                        Flux Notes™ Lite supports the ICARE data study capture of disease status and toxicity during the
+                        authoring of clinical notes. The purpose of Flux Notes™ Lite is to help clinicians capture disease
+                        status and
+                        toxicity information in a structured data format that can be easily analyzed and shared across
+                        multiple clinical care sites.
+                    </p>
+
+                    <p>
+                        This application provides an easy mechanism for clinicians to generate disease status and toxicity
+                        information via an interface and allow them to copy the resulting structured shorthand phrase and
+                        paste it
+                        into their EHR notes entry.
+                    </p>
+
+                    <p>
+                        This tool is one of multiple prototypes in development by MITRE with the end goal of providing
+                        complete, accurate, and computable records to inform the best care for each individual.
+                    </p>
+
+                    <p>
+                        This application leverages the <a href="http://standardhealthrecord.org/" target="_blank">
+                        SHR (Standard Health Record)</a> format for capturing data.
+                    </p>
+                </div>
+
+                <div className="landing-page-using">
+                    <h4>Using Flux Notes™ Lite</h4>
+
+                    <ol>
+                        <li>
+                            From the left panel, select the type of data that you would like to capture
+                        </li>
+
+                        <li>
+                            A form will be displayed on the right for the selected data type. On this form, choose values
+                            related to the data. As values are selected, the copy button on the bottom of the form will show
+                            the structured shorthand phrase as it is being built
+                        </li>
+
+                        <li>
+                            Once you finish entering data, click the copy button to copy the shorthand phrase
+                        </li>
+
+                        <li>
+                            Paste the phrase into your EHR notes entry
+                        </li>
+                    </ol>
+                </div>
             </div>
         )
     }
 }
-
-export default LandingPageForm;

--- a/src/nav/NavBar.jsx
+++ b/src/nav/NavBar.jsx
@@ -49,14 +49,21 @@ class NavBar extends Component {
             <div className={classes.root}>
                 <AppBar position="static" className="navbar-custom">
                     <Toolbar>
-                        {showMenu ?
+                        {showMenu &&
                             <IconButton style={{margin: '0px 8px 0px -16px' }} aria-label="Menu" onClick={this.toggleDrawer.bind(this)}>
                                 <MenuIcon/>
-                            </IconButton> : null}
+                            </IconButton>
+                        }
+
                         <img src="fluxnotes_logo_color.png" height="40px" width="30px" alt="Flux Notes logo" />&nbsp;&nbsp;
-                        <Typography type="title" style={{color:"#17263f", fontFamily: '"Open Sans", Arial, sans-serif'}} className={classes.flex}>
+
+                        <Typography
+                            type="title"
+                            style={{color:"#17263f", fontFamily: '"Open Sans", Arial, sans-serif'}}
+                            className={classes.flex}>
                             {this.props.title}
                         </Typography>
+
                         {login}
                     </Toolbar>
                 </AppBar>

--- a/src/styles/LandingPage.css
+++ b/src/styles/LandingPage.css
@@ -22,6 +22,10 @@
     font-size: calc(36px + 1.5vw);
     font-weight: 600;
     white-space: nowrap; }
+  .landing-header-trademark {
+    font-size: calc(15px + 1vw);
+    color: #2E5C7C;
+    margin-top: -15px; }
 
 /* ------------------------- TAGLINE --------------------------------------- */
 .landing-tagline {

--- a/src/styles/LandingPage.scss
+++ b/src/styles/LandingPage.scss
@@ -56,6 +56,12 @@ $landing-panel-shadow: rgba(0, 0, 0, 0.3) 0 6px 6px;
         font-weight: 600;
         white-space: nowrap;
     }
+
+    &-trademark {
+        font-size: calc(15px + 1vw);
+        color: $landing-blue;
+        margin-top: -15px;
+    }
 }
 
 /* ------------------------- TAGLINE --------------------------------------- */

--- a/test/ui/SlimApp.js
+++ b/test/ui/SlimApp.js
@@ -35,9 +35,9 @@ test('Clicking deceased button puts us in deceased mode', async t => {
 test('Clicking about button puts us back on landing page', async t => {
     await t
         .click("#Toxicity")
-        .click("#About\\ Flux\\ Notes\\ Lite")
+        .click("#About\\ Flux\\ Notes™\\ Lite")
         .expect(Selector("#shortcut-viewer").find('h1').innerText)
-        .eql("About Flux Notes Lite", `Current header doesn't reflect expected landing page header`);
+        .eql("About Flux Notes™ Lite", `Current header doesn't reflect expected landing page header`);
 })
 
 


### PR DESCRIPTION
# Added Trademarks to Flux Notes
Added the &trade; symbol to Flux Notes on landing page, full app, slim app, and readme. Tested on Chrome and IE. Other minor changes due to code cleanup and editor whitespace removal.

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter: Noranda

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- Cheat sheet is updated
- Demo script is updated 
- Documentation on Wiki has been updated 
- Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- Added UI tests for slim mode 
- Added UI tests for full mode
- Added backend tests for fluxNotes code
- Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
