### PR TITLE
Adjust resizing of RangeChart component

### DIFF
--- a/src/summary/MedicationRangeChartVisualizer.css
+++ b/src/summary/MedicationRangeChartVisualizer.css
@@ -1,11 +1,16 @@
 .medication-visualizer-wrapper {
     padding-top: 10px;
 }
+
+.medication-chart-item {
+    padding: 12px;
+}
+
 .medication-info-heading {
     font-size: 0.7em;
     color: #999;
-    margin-top: 20%;
 }
+
 .medication-info {
     font-size: 0.8em;
 }

--- a/src/summary/MedicationRangeChartVisualizer.css
+++ b/src/summary/MedicationRangeChartVisualizer.css
@@ -3,7 +3,7 @@
 }
 
 .medication-chart-item {
-    padding: 12px;
+    padding: 12px 0;
 }
 
 .medication-info-heading {

--- a/src/summary/MedicationRangeChartVisualizer.jsx
+++ b/src/summary/MedicationRangeChartVisualizer.jsx
@@ -9,6 +9,40 @@ import './MedicationRangeChartVisualizer.css';
  A MedicationRangeChart with additional information displayed to the right.
  */
 class MedicationRangeChartVisualizer extends Component {
+    constructor(props) {
+        super(props);
+
+        this.updateState = true;
+
+        this.state = { medicationVisWide: true };
+    }
+
+    componentDidMount() {
+        window.addEventListener("resize", this.checkMedicationWidth);
+        setTimeout(this.checkMedicationWidth, 450);
+    }
+
+    componentDidUpdate = () => {
+        if (this.updateState) {
+            this.updateState = false;
+        } else {
+            this.updateState = true;
+            setTimeout(this.checkMedicationWidth, 450);
+        }
+    }
+
+    componentWillUnmount() {
+        window.removeEventListener("resize", this.checkMedicationWidth);
+    }
+
+    checkMedicationWidth = () => {
+        if (this.parent.offsetWidth > 600) {
+            this.setState({ medicationVisWide: true });
+        } else {
+            this.setState({ medicationVisWide: false });
+        }
+    }
+
     getSubsections() {
         const {patient, condition, conditionSection} = this.props;
 
@@ -51,11 +85,14 @@ class MedicationRangeChartVisualizer extends Component {
         const unit = med[9];
         const name = med[0];
 
+        const numColsChart = this.state.medicationVisWide ? 5 : 12;
+        const numColsInfo = this.state.medicationVisWide ? 7 : 12;
+
         return (
-            <div key={i}>
+            <div key={i} className="medication-chart-item" ref={(parent) => {this.parent = parent}}>
                 <Grid className="FullApp-content" fluid>
-                    <Row center="xs">
-                        <Col sm={5}>
+                    <Row middle="xs">
+                        <Col sm={numColsChart}>
                             <div className="range-chart-container">
 
                                 <RangeChart
@@ -68,7 +105,7 @@ class MedicationRangeChartVisualizer extends Component {
                                 />
                             </div>
                         </Col>
-                        <Col sm={7}>
+                        <Col sm={numColsInfo}>
                             <Row center='xs'>
                                 <Col sm={3}>
                                     <div className='medication-info-heading'>

--- a/src/summary/RangeChart.jsx
+++ b/src/summary/RangeChart.jsx
@@ -54,7 +54,7 @@ class RangeChart extends Component {
         }
 
         return (
-            <svg width="100%" height="100%" viewBox="0 0 340 100">
+            <svg width="100%" height="6em" viewBox="0 0 340 100">
 
                 {/*Header*/}
                 <text x="40" y="20" fontFamily="sans-serif" fontSize="0.9em" fill="#333">{this.props.name} <tspan fill={valueColor}>{this.props.value}</tspan> <tspan fontSize="12px"> {this.props.unit}</tspan></text>


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

This limits the height of the RangeChart svg in order to stop the fonts and the chart from getting very large on large screens. I tried to keep this simple since it was just a one point task, but I also am not entirely sure if this is the expected behavior. All thoughts are appreciated!

## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
-  Cheat sheet is updated
-  Demo script is updated 
-  Documentation on Wiki has been updated 
-  Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

-  Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
-  Added UI tests for slim mode 
-  Added UI tests for full mode
-  Added backend tests for fluxNotes code
-  Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
