### PR TITLE
Update note header

### DIFF
--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -104,8 +104,6 @@ class FluxNotesEditor extends React.Component {
 
         this.noteParser = new NoteParser(this.props.shortcutManager, this.props.contextManager);
 
-        this.currentNote = null;
-
         // Set the initial state when the app is first constructed.
         this.resetEditorState();
 
@@ -208,7 +206,6 @@ class FluxNotesEditor extends React.Component {
         // This clears the contexts so that the tray starts back at the patient context
         this.contextManager.clearContexts();
     }
-
 
     suggestionFunction(initialChar, text) {
         if (Lang.isUndefined(text)) return [];
@@ -349,7 +346,7 @@ class FluxNotesEditor extends React.Component {
             endOfNoteOffset = state.toJSON().document.nodes["0"].nodes["0"].characters.length;
         } else{
             if(!Lang.isNull(this.props.documentText) && !Lang.isUndefined(this.props.documentText)){
-                endOfNoteOffset = this.props.documentText.length
+                endOfNoteOffset = this.props.documentText.length;
             }
         }
 
@@ -409,8 +406,6 @@ class FluxNotesEditor extends React.Component {
         this.contextManager.contextUpdated();
     }
 
-
-
     // This gets called before the component receives new properties
     componentWillReceiveProps = (nextProps) => {
 
@@ -421,9 +416,6 @@ class FluxNotesEditor extends React.Component {
                 this.props.itemInserted();
             }
         }
-
-        this.currentNote = nextProps.selectedNote;
-
 
         // Check if the updatedEditorNote property has been updated
         if (this.props.updatedEditorNote !== nextProps.updatedEditorNote && !Lang.isNull(nextProps.updatedEditorNote)) {
@@ -614,12 +606,12 @@ class FluxNotesEditor extends React.Component {
         let signedString = "not signed";
 
         // If a note is selected, update the note header with information from the selected note
-        if (this.currentNote) {
-            noteTitle = this.currentNote.subject;
-            date = this.currentNote.date;
+        if (this.props.selectedNote) {
+            noteTitle = this.props.selectedNote.subject;
+            date = this.props.selectedNote.date;
 
-            if(this.currentNote.signed) {
-                signedString = this.currentNote.clinician;
+            if(this.props.selectedNote.signed) {
+                signedString = this.props.selectedNote.clinician;
             } else {
                 signedString = "not signed";
             }

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -425,12 +425,6 @@ class FluxNotesEditor extends React.Component {
         this.currentNote = nextProps.selectedNote;
 
 
-        console.log("next props");
-        console.log(nextProps);
-
-
-
-
         // Check if the updatedEditorNote property has been updated
         if (this.props.updatedEditorNote !== nextProps.updatedEditorNote && !Lang.isNull(nextProps.updatedEditorNote)) {
 
@@ -614,8 +608,22 @@ class FluxNotesEditor extends React.Component {
         const CreatorsPortal = this.suggestionsPluginCreators.SuggestionPortal;
         const InsertersPortal = this.suggestionsPluginInserters.SuggestionPortal;
 
-        console.log("update selected note: ");
-        console.log(this.currentNote);
+        // Preset note header information
+        let noteTitle = "Pathology Assessment";
+        let date = "20 June 2017";
+        let signedString = "not signed";
+
+        // If a note is selected, update the note header with information from the selected note
+        if (this.currentNote) {
+            noteTitle = this.currentNote.subject;
+            date = this.currentNote.date;
+
+            if(this.currentNote.signed) {
+                signedString = this.currentNote.clinician;
+            } else {
+                signedString = "not signed";
+            }
+        }
 
         let noteDescriptionContent = null;
         if (this.props.patient == null) {
@@ -625,7 +633,7 @@ class FluxNotesEditor extends React.Component {
                 <div id="note-description">
                     <Row>
                         <Col xs={5}>
-                            <h1 id="note-title">Pathology Assessment</h1>
+                            <h1 id="note-title">{noteTitle}</h1>
                         </Col>
                         <Col xs={2}>
                             <p className="note-description-detail-name">Date</p>
@@ -637,7 +645,7 @@ class FluxNotesEditor extends React.Component {
                         </Col>
                         <Col xs={3}>
                             <p className="note-description-detail-name">Signed By</p>
-                            <p className="note-description-detail-value">not signed</p>
+                            <p className="note-description-detail-value">{signedString}</p>
                         </Col>
                     </Row>
 
@@ -726,7 +734,7 @@ FluxNotesEditor.proptypes = {
     resetEditorState: PropTypes.func.isRequired,
     resetEditorAndContext: PropTypes.func.isRequired,
     isNoteViewerEditable: PropTypes.bool.isRequired,
-    setFullAppState: PropTypes.func.isRequired, 
+    setFullAppState: PropTypes.func.isRequired,
 }
 
 export default FluxNotesEditor;

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -602,13 +602,15 @@ class FluxNotesEditor extends React.Component {
 
         // Preset note header information
         let noteTitle = "Pathology Assessment";
-        let date = "20 June 2017";
+        let date = Moment(new Date()).format('DD MMM YYYY');
         let signedString = "not signed";
+        let source = "Dana Farber";
 
         // If a note is selected, update the note header with information from the selected note
         if (this.props.selectedNote) {
             noteTitle = this.props.selectedNote.subject;
             date = this.props.selectedNote.date;
+            source = this.props.selectedNote.hospital;
 
             if(this.props.selectedNote.signed) {
                 signedString = this.props.selectedNote.clinician;
@@ -629,11 +631,11 @@ class FluxNotesEditor extends React.Component {
                         </Col>
                         <Col xs={2}>
                             <p className="note-description-detail-name">Date</p>
-                            <p className="note-description-detail-value">{Moment(new Date()).format('DD MMM YYYY')}</p>
+                            <p className="note-description-detail-value">{date}</p>
                         </Col>
                         <Col xs={2}>
                             <p className="note-description-detail-name">Source</p>
-                            <p className="note-description-detail-value">Pathology Report</p>
+                            <p className="note-description-detail-value">{source}</p>
                         </Col>
                         <Col xs={3}>
                             <p className="note-description-detail-name">Signed By</p>

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -104,6 +104,8 @@ class FluxNotesEditor extends React.Component {
 
         this.noteParser = new NoteParser(this.props.shortcutManager, this.props.contextManager);
 
+        this.currentNote = null;
+
         // Set the initial state when the app is first constructed.
         this.resetEditorState();
 
@@ -407,6 +409,8 @@ class FluxNotesEditor extends React.Component {
         this.contextManager.contextUpdated();
     }
 
+
+
     // This gets called before the component receives new properties
     componentWillReceiveProps = (nextProps) => {
 
@@ -418,8 +422,18 @@ class FluxNotesEditor extends React.Component {
             }
         }
 
+        this.currentNote = nextProps.selectedNote;
+
+
+        console.log("next props");
+        console.log(nextProps);
+
+
+
+
         // Check if the updatedEditorNote property has been updated
         if (this.props.updatedEditorNote !== nextProps.updatedEditorNote && !Lang.isNull(nextProps.updatedEditorNote)) {
+
 
             // If the updated editor note is an empty string, then add a new blank note. Call method to
             // re initialize editor state and reset updatedEditorNote state in parent to be null
@@ -599,6 +613,9 @@ class FluxNotesEditor extends React.Component {
     render = () => {
         const CreatorsPortal = this.suggestionsPluginCreators.SuggestionPortal;
         const InsertersPortal = this.suggestionsPluginInserters.SuggestionPortal;
+
+        console.log("update selected note: ");
+        console.log(this.currentNote);
 
         let noteDescriptionContent = null;
         if (this.props.patient == null) {

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -601,10 +601,10 @@ class FluxNotesEditor extends React.Component {
         const InsertersPortal = this.suggestionsPluginInserters.SuggestionPortal;
 
         // Preset note header information
-        let noteTitle = "Pathology Assessment";
+        let noteTitle = "New Note";
         let date = Moment(new Date()).format('DD MMM YYYY');
         let signedString = "not signed";
-        let source = "Dana Farber";
+        let source = "Dana Farber Cancer Institute";
 
         // If a note is selected, update the note header with information from the selected note
         if (this.props.selectedNote) {
@@ -626,14 +626,14 @@ class FluxNotesEditor extends React.Component {
             noteDescriptionContent = (
                 <div id="note-description">
                     <Row>
-                        <Col xs={5}>
+                        <Col xs={4}>
                             <h1 id="note-title">{noteTitle}</h1>
                         </Col>
                         <Col xs={2}>
                             <p className="note-description-detail-name">Date</p>
                             <p className="note-description-detail-value">{date}</p>
                         </Col>
-                        <Col xs={2}>
+                        <Col xs={3}>
                             <p className="note-description-detail-name">Source</p>
                             <p className="note-description-detail-value">{source}</p>
                         </Col>

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -102,6 +102,12 @@ export default class NoteAssistant extends Component {
         // Add new unsigned note to patient record
         var currentlyEditingEntryId = this.props.patient.addClinicalNote(date, subject, hospital, clinician, this.props.documentText, signed);
         this.setState({currentlyEditingEntryId: currentlyEditingEntryId});
+
+        var found = this.props.patient.getNotes().find(function(element){
+            return Lang.isEqual(element.entryInfo.entryId, currentlyEditingEntryId);
+        });
+
+        this.props.updateSelectedNote(found); //TODO; pass in the note
     }
 
     // creates blank new note and puts it on the screen
@@ -121,9 +127,13 @@ export default class NoteAssistant extends Component {
         // Add new unsigned note to patient record
         var currentlyEditingEntryId = this.props.patient.addClinicalNote(date, subject, hospital, clinician, content, signed);
         this.setState({currentlyEditingEntryId: currentlyEditingEntryId});
-        
+
+        var found = this.props.patient.getNotes().find(function(element){
+            return Lang.isEqual(element.entryInfo.entryId, currentlyEditingEntryId);
+        });
+
         // Deselect note in the clinical notes view
-        this.props.updateSelectedNote(null);
+        this.props.updateSelectedNote(found); //used to be null
     }
 
     // save the note after every keypress. Invoked by FluxNotesEditor.

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -4,7 +4,6 @@ import Select from 'material-ui/Select';
 import MenuItem from 'material-ui/Menu/MenuItem';
 import Lang from 'lodash';
 import FontAwesome from 'react-fontawesome';
-
 import ContextTray from '../context/ContextTray';
 import Button from '../elements/Button';
 import iconArrowLeft from '../../public/icons/icon_arrow_left.svg';
@@ -18,7 +17,6 @@ export default class NoteAssistant extends Component {
         this.state = {
             sortIndex: null,
             maxNotesToDisplay: 3,
-            currentlyEditingEntryId: -1
         };
     }
 
@@ -75,7 +73,7 @@ export default class NoteAssistant extends Component {
     }
 
     updateExistingNote = () => {
-        var entryId = this.state.currentlyEditingEntryId;
+        var entryId = this.props.currentlyEditingEntryId;
         // Only update if there is a note in progress
         if(!Lang.isEqual(entryId, -1)){
             // List the notes to verify that they are being updated each invocation of this function:
@@ -101,7 +99,8 @@ export default class NoteAssistant extends Component {
         
         // Add new unsigned note to patient record
         var currentlyEditingEntryId = this.props.patient.addClinicalNote(date, subject, hospital, clinician, this.props.documentText, signed);
-        this.setState({currentlyEditingEntryId: currentlyEditingEntryId});
+        // this.setState({currentlyEditingEntryId: currentlyEditingEntryId});
+        this.props.updateCurrentlyEditingEntryId(currentlyEditingEntryId);
 
         var found = this.props.patient.getNotes().find(function(element){
             return Lang.isEqual(element.entryInfo.entryId, currentlyEditingEntryId);
@@ -126,21 +125,24 @@ export default class NoteAssistant extends Component {
 
         // Add new unsigned note to patient record
         var currentlyEditingEntryId = this.props.patient.addClinicalNote(date, subject, hospital, clinician, content, signed);
-        this.setState({currentlyEditingEntryId: currentlyEditingEntryId});
+        // this.setState({currentlyEditingEntryId: currentlyEditingEntryId});
+        this.props.updateCurrentlyEditingEntryId(currentlyEditingEntryId);
 
         var found = this.props.patient.getNotes().find(function(element){
             return Lang.isEqual(element.entryInfo.entryId, currentlyEditingEntryId);
         });
 
         // Select note in the clinical notes view
-        this.props.updateSelectedNote(found); //used to be null
+        this.props.updateSelectedNote(found);
+        this.props.loadNote(found);
+        this.toggleView("context-tray");
     }
 
     // save the note after every keypress. Invoked by FluxNotesEditor.
     saveNoteOnKeypress = () => {
         // Don't start saving until there is content in the editor
         if(!Lang.isNull(this.props.documentText) && !Lang.isUndefined(this.props.documentText)){
-            if(Lang.isEqual(this.state.currentlyEditingEntryId, -1)){
+            if(Lang.isEqual(this.props.currentlyEditingEntryId, -1)){
                 this.saveEditorContentsToNewNote();    
             } else {
                 this.updateExistingNote();
@@ -152,13 +154,13 @@ export default class NoteAssistant extends Component {
     openNote = (isInProgressNote, note) => {
         // Don't start saving until there is content in the editor
         if(!Lang.isNull(this.props.documentText) && !Lang.isUndefined(this.props.documentText)  && this.props.documentText.length > 0){
-            if(Lang.isEqual(this.state.currentlyEditingEntryId, -1)){
+            if(Lang.isEqual(this.props.currentlyEditingEntryId, -1)){
                 this.saveEditorContentsToNewNote();    
             } else {
                 this.updateExistingNote();
             }
         }
-        this.setState({currentlyEditingEntryId: note.entryInfo.entryId});
+        this.props.updateCurrentlyEditingEntryId(note.entryInfo.entryId);
         // the lines below are duplicative
         this.props.updateSelectedNote(note);
         this.props.loadNote(note);
@@ -389,5 +391,6 @@ NoteAssistant.propTypes = {
     shortcutManager: PropTypes.object,
     isNoteViewerEditable: PropTypes.bool,
     saveNote: PropTypes.func,
-    handleSummaryItemSelected: PropTypes.func
+    handleSummaryItemSelected: PropTypes.func,
+    updateCurrentlyEditingEntryId: PropTypes.func
 };

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -107,7 +107,7 @@ export default class NoteAssistant extends Component {
             return Lang.isEqual(element.entryInfo.entryId, currentlyEditingEntryId);
         });
 
-        this.props.updateSelectedNote(found); //TODO; pass in the note
+        this.props.updateSelectedNote(found);
     }
 
     // creates blank new note and puts it on the screen
@@ -132,7 +132,7 @@ export default class NoteAssistant extends Component {
             return Lang.isEqual(element.entryInfo.entryId, currentlyEditingEntryId);
         });
 
-        // Deselect note in the clinical notes view
+        // Select note in the clinical notes view
         this.props.updateSelectedNote(found); //used to be null
     }
 

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -12,8 +12,10 @@ export default class NotesPanel extends Component {
         super(props);
 
         this.state = {
+            // updatedEditorNote is the note to be loaded in the editor
             updatedEditorNote: null,
             noteAssistantMode: "context-tray",
+            // selectedNote is the note that is selected in the clinical notes view in the NoteAssistant
             selectedNote: null
         };
 
@@ -29,8 +31,6 @@ export default class NotesPanel extends Component {
 
     updateSelectedNote(note) {
         this.setState({selectedNote: note});
-        console.log("updateSelectedNote--------");
-
     }
 
     // Handle when the editor needs to be updated with a note. The note can be a new blank note or a pre existing note

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -1,7 +1,6 @@
-import React, { Component } from 'react';
+import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import { Row, Col } from 'react-flexbox-grid';
-
+import {Row, Col} from 'react-flexbox-grid';
 import FluxNotesEditor from '../notes/FluxNotesEditor';
 import Lang from 'lodash';
 import NoteAssistant from '../notes/NoteAssistant';
@@ -16,13 +15,15 @@ export default class NotesPanel extends Component {
             updatedEditorNote: null,
             noteAssistantMode: "context-tray",
             // selectedNote is the note that is selected in the clinical notes view in the NoteAssistant
-            selectedNote: null
+            selectedNote: null,
+            currentlyEditingEntryId: -1
         };
 
         this.handleUpdateEditorWithNote = this.handleUpdateEditorWithNote.bind(this);
         this.updateNoteAssistantMode = this.updateNoteAssistantMode.bind(this);
         this.updateSelectedNote = this.updateSelectedNote.bind(this);
         this.saveNoteUponKeypress = this.saveNoteUponKeypress.bind(this);
+        this.handleUpdateCurrentlyEditingEntryId = this.handleUpdateCurrentlyEditingEntryId.bind(this);
     }
 
     updateNoteAssistantMode(mode) {
@@ -35,7 +36,7 @@ export default class NotesPanel extends Component {
 
     // Handle when the editor needs to be updated with a note. The note can be a new blank note or a pre existing note
     handleUpdateEditorWithNote(note) {
-        if(!Lang.isNull(note)){
+        if (!Lang.isNull(note)) {
             this.props.setFullAppState("documentText", note.content);
         }
         // If in pre-encounter mode and the note editor doesn't exist, update the layout and add the editor
@@ -52,6 +53,11 @@ export default class NotesPanel extends Component {
                 if (this.props.isNoteViewerVisible) {
                     this.setState({updatedEditorNote: note});
                     this.setState({selectedNote: note});
+                    if (!note) {
+                        this.setState({currentlyEditingEntryId: -1});
+                    } else {
+                        this.setState({currentlyEditingEntryId: note.entryInfo.entryId});
+                    }
                 }
             });
         }
@@ -63,8 +69,12 @@ export default class NotesPanel extends Component {
         }
     }
 
+    handleUpdateCurrentlyEditingEntryId(id) {
+        this.setState({currentlyEditingEntryId: id});
+    }
+
     // Save the note after every keypress. This function invokes the note saving logic in NoteAssistant
-    saveNoteUponKeypress(){
+    saveNoteUponKeypress() {
         this.saveNoteChild();
     }
 
@@ -142,6 +152,8 @@ export default class NotesPanel extends Component {
                     updateSelectedNote={this.updateSelectedNote}
                     documentText={this.props.documentText}
                     saveNote={click => this.saveNoteChild = click}
+                    updateCurrentlyEditingEntryId={this.handleUpdateCurrentlyEditingEntryId}
+                    currentlyEditingEntryId={this.state.currentlyEditingEntryId}
                 />
             </div>
         );

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -29,6 +29,8 @@ export default class NotesPanel extends Component {
 
     updateSelectedNote(note) {
         this.setState({selectedNote: note});
+        console.log("updateSelectedNote--------");
+
     }
 
     // Handle when the editor needs to be updated with a note. The note can be a new blank note or a pre existing note
@@ -114,6 +116,7 @@ export default class NotesPanel extends Component {
 
                     // Pass in note that the editor is to be updated with
                     updatedEditorNote={this.state.updatedEditorNote}
+                    selectedNote={this.state.selectedNote}
                     handleUpdateEditorWithNote={this.handleUpdateEditorWithNote}
 
                     currentViewMode={this.props.currentViewMode}

--- a/test/ui/FullApp.js
+++ b/test/ui/FullApp.js
@@ -499,6 +499,26 @@ test('Clicking on an existing note in post encounter mode loads the note in the 
         .notEql("Enter your clinical note here or choose a template to start from...");
 })
 
+test('Clicking on a note in the clinical notes view updates the information in the note header', async t =>  {
+    const clinicalNotesButton = Selector('.clinical-notes-btn');
+    const note = Selector('.existing-note');
+    const noteHeaderName = Selector('#note-title').textContent;
+
+    // Click on the clinical notes button to switch to clinical notes view
+    await t
+        .click(clinicalNotesButton);
+
+    // Click on one of the existing notes
+    await t
+        .click(note);
+
+    // Test that the note header name has been updated (that it doesn't equal the default text on app start)
+    await t
+        .expect(noteHeaderName)
+        .notEql("Pathology Assessment");
+})
+
+
 test('Clicking on an existing note in post encounter mode puts the NotesPanel in a read only mode with the clinical notes view displayed', async t => {
     const editor = Selector("div[data-slate-editor='true']");
     const clinicalNotesButton = Selector('.clinical-notes-btn');
@@ -555,6 +575,7 @@ test('Clicking on an in-progress note in post encounter mode loads the note in t
         .expect(editor.textContent)
         .notEql("Enter your clinical note here or choose a template to start from...");
 })
+
 
 // Verifies automatic saving
 test('Contents of in-progress note saved when switching to a completed note and back', async t => {


### PR DESCRIPTION
This PR addresses jira 828 (https://jira.mitre.org/browse/ASCODCP-828). 

- When a note is selected, the note header information is updated in the editor (name, date, source, signed by)
- On app start, the note header shows default hard coded info. When the user clicks on a note in the clinical notes view or starts typing in the editor, the note header is updated with the selected note information
- When selecting a signed note, the header is updated to show the doctor's name under "signed by". When selecting an in-progress note, "signed by" is set to "not signed"
- Added a UI test to verify that the note header is updated when a note is selected
- This PR focuses on updating the note header when a note is selected, not updating the information in the in-progress note image or being able to manually edit the note header. That is covered in jira 208 (https://jira.mitre.org/browse/ASCODCP-208) 

Fixed some bugs with saving and selecting notes which impacted working on this task (thanks @mtorchio for your help!):
- On app start, typing in the editor now properly selects the note (not just highlighting the note image but also updates the state with the current note being viewed)
- In pre encounter mode, fixed issue where adding a new note or selecting existing note created an extra in-progress note




_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- N/A Cheat sheet is updated
- N/A Demo script is updated 
- N/A Documentation on Wiki has been updated 
- N/A Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- N/A Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- N/A Added UI tests for slim mode 
- [x] Added UI tests for full mode
- N/A Added backend tests for fluxNotes code
- N/A Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
