### PR TITLE
Added Selected Condition to Targeted Data Section Headers

### DIFF
--- a/src/summary/TargetedDataSection.css
+++ b/src/summary/TargetedDataSection.css
@@ -3,6 +3,17 @@
     color: #333;
 }
 
+.section-header__condition {
+  margin-left: 20px;
+  color: #ccc;
+  font-weight: normal;
+}
+
+.section-header__condition.encounter {
+  display: block;
+  margin: 0;
+}
+
 .small-btn {
     min-width: 0 !important;
     min-height: 0 !important;

--- a/src/summary/TargetedDataSection.css
+++ b/src/summary/TargetedDataSection.css
@@ -1,17 +1,30 @@
-#targeted-data-section h2.section-header{
+#targeted-data-section h2.section-header {
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: center;
+    justify-content: space-between;
     font-weight: bold;
     color: #333;
 }
 
+.section-header__name {
+    margin-right: 20px;
+}
+
 .section-header__condition {
-  margin-left: 20px;
-  color: #ccc;
-  font-weight: normal;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+    color: #ccc;
+    font-weight: normal;
+    flex: 1;
+    padding-right: 10px;
 }
 
 .section-header__condition.encounter {
-  display: block;
-  margin: 0;
+    text-overflow: inherit;
+    overflow: inherit;
+    white-space: normal;
 }
 
 .small-btn {
@@ -20,7 +33,6 @@
 }
 
 .right-icons {
-    float: right;
-    padding-right: 10px;
+    margin-right: 10px;
     display: flex;
 }

--- a/src/summary/TargetedDataSection.jsx
+++ b/src/summary/TargetedDataSection.jsx
@@ -1,5 +1,6 @@
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+
 import Button from '../elements/Button';
 import TabularListVisualizer from './TabularListVisualizer'; //ordering of these lines matters
 import TabularNameValuePairsVisualizer from './TabularNameValuePairsVisualizer';
@@ -10,7 +11,7 @@ import TimelineEventsVisualizer from '../timeline/TimelineEventsVisualizer';
 import MedicationRangeChartVisualizer from './MedicationRangeChartVisualizer';
 import './TargetedDataSection.css';
 
-class TargetedDataSection extends Component {
+export default class TargetedDataSection extends Component {
     constructor(props) {
         super(props);
 
@@ -189,7 +190,7 @@ class TargetedDataSection extends Component {
     // TODO: Add a List type and a tabular renderer for it for Procedures section. case where left column is data
     //       and not just a label
     renderSection = (section) => {
-        const {patient, condition, onItemClicked, allowItemClick, isWide, type} = this.props;
+        const { patient, condition, onItemClicked, allowItemClick, isWide, type } = this.props;
         const visualization = this.checkVisualization();
 
         switch (type) {
@@ -299,21 +300,25 @@ class TargetedDataSection extends Component {
     }
 
     render() {
-        const visualizationOptions = this.getOptions(this.props.section);
+        const { section, condition, clinicalEvent } = this.props;
+        const visualizationOptions = this.getOptions(section);
+        const selectedCondition = condition && condition.specificType.codeableConcept.displayText.string;
+        const encounterView = clinicalEvent === "encounter";
 
         return (
             <div id="targeted-data-section">
                 <h2 className="section-header">
-                    {this.props.section.name}
+                    {section.name}
+                    {!encounterView && <span className="section-header__condition">{selectedCondition}</span>}
                     {this.renderVisualizationOptions(visualizationOptions)}
+                    {encounterView && <span className="section-header__condition encounter">{selectedCondition}</span>}
                 </h2>
-                {this.renderSection(this.props.section)}
+
+                {this.renderSection(section)}
             </div>
         );
     }
 }
-
-export default TargetedDataSection;
 
 TargetedDataSection.propTypes = {
     type: PropTypes.string,
@@ -323,4 +328,5 @@ TargetedDataSection.propTypes = {
     onItemClicked: PropTypes.func,
     allowItemClick: PropTypes.bool,
     isWide: PropTypes.bool.isRequired,
+    clinicalEvent: PropTypes.string.isRequired
 }

--- a/src/summary/TargetedDataSection.jsx
+++ b/src/summary/TargetedDataSection.jsx
@@ -177,9 +177,9 @@ export default class TargetedDataSection extends Component {
     renderVisualizationOptions = (options) => {
         if (options.length > 1) {
             return (
-                <span className="right-icons">
+                <div className="right-icons">
                     {this.getVisualizationsIcons(options)}
-                </span>
+                </div>
             );
         } else {
             return null;
@@ -308,11 +308,12 @@ export default class TargetedDataSection extends Component {
         return (
             <div id="targeted-data-section">
                 <h2 className="section-header">
-                    {section.name}
+                    <span className="section-header__name">{section.name}</span>
                     {!encounterView && <span className="section-header__condition">{selectedCondition}</span>}
                     {this.renderVisualizationOptions(visualizationOptions)}
-                    {encounterView && <span className="section-header__condition encounter">{selectedCondition}</span>}
                 </h2>
+
+                {encounterView && <div className="section-header__condition encounter">{selectedCondition}</div>}
 
                 {this.renderSection(section)}
             </div>


### PR DESCRIPTION
# Added Selected Condition to Targeted Data Section Headers
Selected conditions now display next to (pre- and post-encounter) and under (encounter) the section title for each section in the Targeted Data Panel. For pre- and post-encounters, conditions with long names will be truncated. For encounters, they will wrap. Tested in Chrome and IE.

#### Pre-encounter:
<img width="1110" alt="screen shot 2018-01-25 at 4 58 49 pm" src="https://user-images.githubusercontent.com/5418735/35414696-33f68190-01f1-11e8-9f76-c76cd36a6da8.png">

#### Encounter:
<img width="311" alt="screen shot 2018-01-25 at 4 58 35 pm" src="https://user-images.githubusercontent.com/5418735/35414727-5072b618-01f1-11e8-9ecd-6fd54d5b6aeb.png">

#### Post-encounter:
<img width="557" alt="screen shot 2018-01-25 at 4 58 23 pm" src="https://user-images.githubusercontent.com/5418735/35414734-55472052-01f1-11e8-9a66-0343176a5edf.png">


_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- Cheat sheet is updated
- Demo script is updated 
- Documentation on Wiki has been updated 
- Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- Added UI tests for slim mode 
- Added UI tests for full mode
- Added backend tests for fluxNotes code
- Added note parser examples to test new functionality

## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
