### PR TITLE
Tabular viz new inserter

### DIFF
--- a/src/containers/FullApp.jsx
+++ b/src/containers/FullApp.jsx
@@ -56,7 +56,7 @@ export default class FullApp extends Component {
             selectedText: null,
             documentText: null,
             superRole: 'Clinician',
-            SummaryItemToInsert: '',
+            summaryItemToInsert: '',
             summaryMetadata: this.summaryMetadata.getMetadata(),
         };
     }
@@ -83,7 +83,7 @@ export default class FullApp extends Component {
 
     // Determines the item to be inserted
     itemInserted = () => {
-        this.setState({SummaryItemToInsert: ''});
+        this.setState({summaryItemToInsert: ''});
     }
 
     // Given a shortcutClass, a type and an object, create a new shortcut and change errors is needed.
@@ -129,18 +129,18 @@ export default class FullApp extends Component {
         })
     }
 
-    // Update the summaryitemtoinsert based on the item given
+    // Update the summaryItemToInsert based on the item given
     handleSummaryItemSelected = (item, arrayIndex = -1) => {
         if (item) {
             // calls to this method from the buttons on a ListType pass in 'item' as an array.
             if (Lang.isArray(item) && arrayIndex >= 0) {
-                this.setState({SummaryItemToInsert: item[arrayIndex]});
+                this.setState({summaryItemToInsert: item[arrayIndex]});
             } else if (item.shortcut) {
-                this.setState({SummaryItemToInsert: `${item.shortcut}[[${item.value}]]`});
+                this.setState({summaryItemToInsert: `${item.shortcut}[[${item.value}]]`});
             } else if (item.value) {
-                this.setState({SummaryItemToInsert: item.value});
+                this.setState({summaryItemToInsert: item.value});
             } else {
-                this.setState({SummaryItemToInsert: item});
+                this.setState({summaryItemToInsert: item});
             }
         }
     }

--- a/src/dashboard/ClinicianDashboard.jsx
+++ b/src/dashboard/ClinicianDashboard.jsx
@@ -188,7 +188,7 @@ class ClinicianDashboard extends Component {
                         patient={this.props.appState.patient}
                         documentText={this.props.appState.documentText}
                         shortcutManager={this.props.shortcutManager}
-                        summaryItemToBeInserted={this.props.appState.SummaryItemToInsert}
+                        summaryItemToInsert={this.props.appState.summaryItemToInsert}
                         updateErrors={this.props.updateErrors}
                         updateLayoutOnNewNoteClicked={this.updateLayoutOnNewNoteClicked}
                         currentViewMode={this.props.appState.clinicalEvent}

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -411,9 +411,9 @@ class FluxNotesEditor extends React.Component {
     componentWillReceiveProps = (nextProps) => {
 
         // Check if the item to be inserted is updated
-        if (this.props.itemToBeInserted !== nextProps.itemToBeInserted && nextProps.itemToBeInserted.length > 0) {
+        if (this.props.summaryItemToInsert !== nextProps.summaryItemToInsert && nextProps.summaryItemToInsert.length > 0) {
             if (this.props.isNoteViewerEditable) {
-                this.insertTextWithStructuredPhrases(nextProps.itemToBeInserted);
+                this.insertTextWithStructuredPhrases(nextProps.summaryItemToInsert);
                 this.props.itemInserted();
             }
         }
@@ -700,7 +700,7 @@ FluxNotesEditor.proptypes = {
     onSelectionChange: PropTypes.func.isRequired,
     newCurrentShortcut: PropTypes.func.isRequired,
     itemInserted: PropTypes.object,
-    itemToBeInserted: PropTypes.object,
+    summaryItemToInsert: PropTypes.object,
     patient: PropTypes.object.isRequired,
     shortcutManager: PropTypes.object.isRequired,
     contextManager: PropTypes.object.isRequired,

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -700,7 +700,7 @@ FluxNotesEditor.proptypes = {
     onSelectionChange: PropTypes.func.isRequired,
     newCurrentShortcut: PropTypes.func.isRequired,
     itemInserted: PropTypes.object,
-    summaryItemToInsert: PropTypes.object,
+    summaryItemToInsert: PropTypes.string,
     patient: PropTypes.object.isRequired,
     shortcutManager: PropTypes.object.isRequired,
     contextManager: PropTypes.object.isRequired,

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -100,7 +100,7 @@ export default class NotesPanel extends Component {
                     onSelectionChange={this.props.handleSelectionChange}
                     newCurrentShortcut={this.props.newCurrentShortcut}
                     itemInserted={this.props.itemInserted}
-                    itemToBeInserted={this.props.summaryItemToBeInserted}
+                    summaryItemToInsert={this.props.summaryItemToInsert}
                     patient={this.props.patient}
                     contextManager={this.props.contextManager}
                     shortcutManager={this.props.shortcutManager}
@@ -168,4 +168,5 @@ NotesPanel.propTypes = {
     handleSummaryItemSelected: PropTypes.func,
     handleSelectionChange: PropTypes.func,
     setFullAppState: PropTypes.func,
+    summaryItemToInsert: PropTypes.bool,
 };

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -168,5 +168,5 @@ NotesPanel.propTypes = {
     handleSummaryItemSelected: PropTypes.func,
     handleSelectionChange: PropTypes.func,
     setFullAppState: PropTypes.func,
-    summaryItemToInsert: PropTypes.bool,
+    summaryItemToInsert: PropTypes.string,
 };

--- a/src/summary/NarrativeNameValuePairsVisualizer.css
+++ b/src/summary/NarrativeNameValuePairsVisualizer.css
@@ -49,6 +49,7 @@ span.missing-data {
 }
 
 span.structured-data {
+    cursor: pointer;
     text-decoration: underline;
     text-decoration-color: blue;
 }

--- a/src/summary/NarrativeNameValuePairsVisualizer.css
+++ b/src/summary/NarrativeNameValuePairsVisualizer.css
@@ -44,11 +44,13 @@ span.plain {
 }
 
 span.missing-data {
-    border-bottom: 1px solid red;
+    text-decoration: underline;
+    text-decoration-color: red;
 }
 
 span.structured-data {
-    border-bottom: 1px solid blue;
+    text-decoration: underline;
+    text-decoration-color: blue;
 }
 
 .menu-item {

--- a/src/summary/NarrativeNameValuePairsVisualizer.jsx
+++ b/src/summary/NarrativeNameValuePairsVisualizer.jsx
@@ -195,9 +195,9 @@ class NarrativeNameValuePairsVisualizer extends Component {
     openInsertionMenu = (event, snippetId) => { 
         // Get menu coordinates
         let x = event.clientX;  // Get the horizontal coordinate of mouse
-        x += 20;                // push menu a little to the right
+        x += 4;                // push menu a little to the right
         let y = event.clientY;  // Get the vertical coordinate of mouse
-        y += 10;                // push a little to the bottom of cursor
+        y += 7;                // push a little to the bottom of cursor
 
         this.setState({ 
             snippetDisplayingMenu: snippetId,
@@ -223,8 +223,8 @@ class NarrativeNameValuePairsVisualizer extends Component {
         } = this.state;
         
         const insertItem = (item, snippetId) => {
-            this.props.onItemClicked(item);
             this.closeInsertionMenu(snippetId);
+            this.props.onItemClicked(item);
         };
         
         // now go through each snippet and build up HTML to render

--- a/src/summary/NarrativeNameValuePairsVisualizer.jsx
+++ b/src/summary/NarrativeNameValuePairsVisualizer.jsx
@@ -191,57 +191,26 @@ class NarrativeNameValuePairsVisualizer extends Component {
         return this.buildNarrativeSnippetList(narrativeTemplate, subsections);
     }
 
-    // Number of milliseconds to wait
-    waitTimeOpen = 400
-    waitTimeClose = 400
-    openTimer = null
-    closeTimer = null
-
-    // Sets a timer to set the anchor element at this index to be the target div
-    timedPopoverOpen = (event, snippetId) => {
-        // Get popover coordinates
+    // Opens the insertion menu for the given snippet id, based on cursor location
+    openInsertionMenu = (event, snippetId) => { 
+        // Get menu coordinates
         let x = event.clientX;  // Get the horizontal coordinate of mouse
-        x += 10;                // push popover a little to the right
+        x += 20;                // push menu a little to the right
         let y = event.clientY;  // Get the vertical coordinate of mouse
         y += 10;                // push a little to the bottom of cursor
-        
-        // Set timer for opening
-        this.openTimer = setTimeout(() => {
-            this.setState({ 
-                snippetDisplayingMenu: snippetId,
-                positionTop: y,
-                positionLeft: x,
-            });
-            this.openTimer = null;
-        }, this.waitTimeOpen);
+
+        this.setState({ 
+            snippetDisplayingMenu: snippetId,
+            positionLeft: x,
+            positionTop: y,
+        });
     }
 
-    // Clear timeout for opening menus
-    cancelPopoverOpen = () => { 
-        clearTimeout(this.openTimer);
-        this.openTimer = null;
-    }
-
-    // Set timer to close 
-    timedPopoverClose = (event, snippetId) => { 
-        this.closeTimer = setTimeout(() => { 
-            this.closePopover()
-            this.closeTimer = null;
-        }, this.waitTimeClose);        
-    }
-
-    // Clear timeout for closing menus
-    cancelPopoverClose = () => { 
-        clearTimeout(this.closeTimer);
-        this.closeTimer = null;
-    }
-
-    // Make the anchor element for this snippetId null
-    closePopover = () => { 
+    // Closes the insertion menu
+    closeInsertionMenu = () => { 
         this.setState({ snippetDisplayingMenu: null });
     }
 
-    
     // Gets called for each section in SummaryMetaData.jsx that will be rendered by this component
     render() {
         // build list of snippets that are part of narrative to support typing each snippet so each
@@ -255,7 +224,7 @@ class NarrativeNameValuePairsVisualizer extends Component {
         
         const insertItem = (item, snippetId) => {
             this.props.onItemClicked(item);
-            this.closePopover(snippetId);
+            this.closeInsertionMenu(snippetId);
         };
         
         // now go through each snippet and build up HTML to render
@@ -267,8 +236,7 @@ class NarrativeNameValuePairsVisualizer extends Component {
                     <span key={snippetId}>
                         <span 
                             className={snippet.type} 
-                            onMouseOver={(event) =>  this.timedPopoverOpen(event, snippetId)}
-                            onMouseLeave={(event) => this.cancelPopoverOpen()}
+                            onClick={(event) => this.openInsertionMenu(event, snippetId)}
                         >
                             {snippet.text}
                         </span>
@@ -276,13 +244,11 @@ class NarrativeNameValuePairsVisualizer extends Component {
                             open={snippetDisplayingMenu === snippetId}
                             anchorReference="anchorPosition"
                             anchorPosition={{ top: positionTop, left: positionLeft }}
-                            onClose={(event) => this.closePopover(snippetId)}
+                            onClose={(event) => this.closeInsertionMenu(snippetId)}
                             className="narrative-inserter-tooltip"
                         >
                             <MenuItem   
                                 onClick={() => insertItem(snippet.item, snippetId)}
-                                onMouseOver={(event) => this.cancelPopoverClose()}
-                                onMouseLeave={(event) => this.timedPopoverClose(event, snippetId)}
                                 className="narrative-inserter-box"
                             >
                                 <ListItemIcon>

--- a/src/summary/NarrativeNameValuePairsVisualizer.jsx
+++ b/src/summary/NarrativeNameValuePairsVisualizer.jsx
@@ -207,8 +207,12 @@ class NarrativeNameValuePairsVisualizer extends Component {
     }
 
     // Closes the insertion menu
-    closeInsertionMenu = () => { 
-        this.setState({ snippetDisplayingMenu: null });
+    closeInsertionMenu = (callback) => { 
+        if (callback) { 
+            this.setState({ snippetDisplayingMenu: null }, callback);
+        } else { 
+            this.setState({ snippetDisplayingMenu: null });
+        }
     }
 
     // Gets called for each section in SummaryMetaData.jsx that will be rendered by this component
@@ -222,9 +226,11 @@ class NarrativeNameValuePairsVisualizer extends Component {
           positionTop,
         } = this.state;
         
-        const insertItem = (item, snippetId) => {
-            this.closeInsertionMenu(snippetId);
-            this.props.onItemClicked(item);
+        const insertItem = (item) => {
+            const callback = () => { 
+                this.props.onItemClicked(item);
+            };
+            this.closeInsertionMenu(callback);
         };
         
         // now go through each snippet and build up HTML to render
@@ -244,11 +250,11 @@ class NarrativeNameValuePairsVisualizer extends Component {
                             open={snippetDisplayingMenu === snippetId}
                             anchorReference="anchorPosition"
                             anchorPosition={{ top: positionTop, left: positionLeft }}
-                            onClose={(event) => this.closeInsertionMenu(snippetId)}
+                            onClose={(event) => this.closeInsertionMenu()}
                             className="narrative-inserter-tooltip"
                         >
                             <MenuItem   
-                                onClick={() => insertItem(snippet.item, snippetId)}
+                                onClick={() => insertItem(snippet.item)}
                                 className="narrative-inserter-box"
                             >
                                 <ListItemIcon>

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -474,7 +474,6 @@ class SummaryMetadata {
             if (typeof p.occurrenceTime !== 'string') {
                 return [
                     {
-                        name: "Procedure",
                         value: p.specificType.value.coding[0].displayText.value,
                         shortcut: "@procedure",
                     },
@@ -483,7 +482,6 @@ class SummaryMetadata {
             } else {
                 return [
                     {
-                        name: "Procedure",
                         value: p.specificType.value.coding[0].displayText.value,
                         shortcut: "@procedure",
                     },

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -470,14 +470,26 @@ class SummaryMetadata {
         const procedures = patient.getProceduresForConditionChronologicalOrder(currentConditionEntry);
         return procedures.map((p, i) => {
             // Ensure that each array for a given data type (e.g. Procedures in this case) contains the same number of elements (e.g. here it is 2 elements).
-            // Or add to the end of the array, that looks okay too.
+            // Or add to the end of the array, that looks okay too
             if (typeof p.occurrenceTime !== 'string') {
-                return [p.specificType.value.coding[0].displayText.value, p.occurrenceTime.timePeriodStart + " to " + p.occurrenceTime.timePeriodEnd];
+                return [
+                    {
+                        name: "Procedure",
+                        value: p.specificType.value.coding[0].displayText.value,
+                        shortcut: "@procedure",
+                    },
+                    p.occurrenceTime.timePeriodStart + " to " + p.occurrenceTime.timePeriodEnd
+                ];
             } else {
-                return [p.specificType.value.coding[0].displayText.value, p.occurrenceTime];
+                return [
+                    {
+                        name: "Procedure",
+                        value: p.specificType.value.coding[0].displayText.value,
+                        shortcut: "@procedure",
+                    },
+                    p.occurrenceTime
+                ];
             }
-
-
         });
     }
 

--- a/src/summary/TabularListVisualizer.css
+++ b/src/summary/TabularListVisualizer.css
@@ -29,13 +29,11 @@
 
 /* Most table elements only have a top border */
 .tabular-list td {
-    border-top: 1px solid #ccc;
     padding: 8px 10px;
 }
 
 /* Include the bottom border on the last row of the table */
 .tabular-list tr:last-child td {
-    border-bottom: 1px solid #ccc;
 }
 
 /* Missing element styling*/
@@ -55,8 +53,6 @@
 
 /* Heading of column*/
 .tabular-list .list-column-heading {
-    border-top: 1px solid #ccc;
-    border-bottom: 1px solid #ccc;
     color: #000;
     background-color: #ffffff;
     padding: 8px 10px;

--- a/src/summary/TabularListVisualizer.css
+++ b/src/summary/TabularListVisualizer.css
@@ -19,9 +19,12 @@
     border-top: 0;
 }
 
-/* Include the bottom border on the last row of the table */
-.tabular-list tr:last-child td {
-    border-bottom: 1px solid #ccc;
+.tabular-list tr:nth-child(even) { 
+    background-color: #f1f1f1;
+}
+
+.tabular-list tr:nth-child(odd) { 
+    background-color: #fff;
 }
 
 /* Most table elements only have a top border */
@@ -30,42 +33,27 @@
     padding: 8px 10px;
 }
 
-/* Omit the borders from the icon column in the table */
-.tabular-list td.list-enabled {
-    border-top: 0;
-    border-bottom: 0;
-    color: #fefefe;
-}
-.tabular-list td.list-disabled {
-    border-top: 0;
-    border-bottom: 0;
-    color: #fefefe;
+/* Include the bottom border on the last row of the table */
+.tabular-list tr:last-child td {
+    border-bottom: 1px solid #ccc;
 }
 
-
-.tabular-list tr.list-captured td.list-disabled  {
-    color: #DDD;
-    border-bottom: 0;
-}
-.tabular-list tr.list-captured td.list-enabled {
-    color: #888;
-    border-bottom: 0;
+/* Missing element styling*/
+.tabular-list td.list-missing span {
+    text-decoration: underline;
+    text-decoration-color: red;
+    /*background-color: #fa9f8f;*/
 }
 
-.tabular-list td.list-missing {
-    color: #fff;
-    background-color: #fa9f8f;
-}
-
-.tabular-list td.list-captured {
-    color: #333;
-    background-color: #d9ebf9;
-}
-
-.tabular-list span.list-button-hover {
+/*Captured element styling */
+.tabular-list td.list-captured span {
+    text-decoration: underline;
+    text-decoration-color: blue;
     cursor: pointer;
+    /*background-color: #d9ebf9;*/
 }
 
+/* Heading of column*/
 .tabular-list .list-column-heading {
     border-top: 1px solid #ccc;
     border-bottom: 1px solid #ccc;

--- a/src/summary/TabularListVisualizer.jsx
+++ b/src/summary/TabularListVisualizer.jsx
@@ -136,8 +136,8 @@ class TabularListVisualizer extends Component {
               positionTop,
             } = this.state;
 
-            const insertItem = (elementList, elementId, arrayIndex) => {
-                this.props.onItemClicked(elementList, arrayIndex)
+            const insertItem = (element) => {
+                this.props.onItemClicked(element)
                 this.closeInsertionMenu();
             };
             
@@ -156,6 +156,11 @@ class TabularListVisualizer extends Component {
                         </td>
                     );
                 } else if (this.props.allowItemClick) {
+                    // Get value off of element given two cases: 
+                    // 1. Element type is shortcut, value is returned by element.value()
+                    // 2. Element type is string, the value is just the string
+                    const elementText = (element.shortcut) ? element.value : element;
+                    // Make unique id for each value
                     const elementId = `${index}-item-${arrayIndex}`
                     columnItem = (
                         <td 
@@ -166,7 +171,7 @@ class TabularListVisualizer extends Component {
                                 data-test-summary-item={item[0]} 
                                 onClick={(event) => this.openInsertionMenu(event, elementId)}
                             >
-                                {element}
+                                {elementText}
                             </span>
                             <Menu
                                 open={elementToDisplayMenu === elementId}
@@ -176,13 +181,13 @@ class TabularListVisualizer extends Component {
                                 className="narrative-inserter-tooltip"
                             >
                                 <MenuItem   
-                                    onClick={() => insertItem(element, elementId, arrayIndex)}
+                                    onClick={() => insertItem(element, elementId)}
                                     className="narrative-inserter-box"
                                 >
                                     <ListItemIcon>
                                         <FontAwesome name="plus"/>
                                     </ListItemIcon>
-                                    <ListItemText className='narrative-inserter-menu-item' inset primary={`Insert "${element}"`} />
+                                    <ListItemText className='narrative-inserter-menu-item' inset primary={`Insert "${elementText}"`} />
                                 </MenuItem>
                             </Menu>
                         </td>

--- a/src/summary/TabularListVisualizer.jsx
+++ b/src/summary/TabularListVisualizer.jsx
@@ -38,10 +38,13 @@ class TabularListVisualizer extends Component {
     }
 
     // Closes the insertion menu
-    closeInsertionMenu = () => { 
-        this.setState({ elementToDisplayMenu: null });
+    closeInsertionMenu = (callback) => { 
+        if (callback) { 
+            this.setState({ elementToDisplayMenu: null }, callback);
+        } else { 
+            this.setState({ elementToDisplayMenu: null });
+        }
     }
-
     // Get a list of subsections to display given the current condition section
     getSubsections() {
         const {patient, condition, conditionSection} = this.props;
@@ -125,8 +128,10 @@ class TabularListVisualizer extends Component {
             } = this.state;
 
             const insertItem = (element) => {
-                this.props.onItemClicked(element)
-                this.closeInsertionMenu();
+                const callback = () => { 
+                    this.props.onItemClicked(element);
+                };
+                this.closeInsertionMenu(callback);
             };
             
             item.forEach((element, arrayIndex) => {
@@ -169,7 +174,7 @@ class TabularListVisualizer extends Component {
                                 className="narrative-inserter-tooltip"
                             >
                                 <MenuItem   
-                                    onClick={() => insertItem(element, elementId)}
+                                    onClick={() => insertItem(element)}
                                     className="narrative-inserter-box"
                                 >
                                     <ListItemIcon>

--- a/src/summary/TabularListVisualizer.jsx
+++ b/src/summary/TabularListVisualizer.jsx
@@ -26,9 +26,9 @@ class TabularListVisualizer extends Component {
     openInsertionMenu = (event, elementId) => { 
         // Get menu coordinates
         let x = event.clientX;  // Get the horizontal coordinate of mouse
-        x += 20;                // push menu a little to the right
+        x += 4;                // push menu a little to the right
         let y = event.clientY;  // Get the vertical coordinate of mouse
-        y += 10;                // push a little to the bottom of cursor
+        y += 7;                // push a little to the bottom of cursor
 
         this.setState({ 
             elementToDisplayMenu: elementId,

--- a/src/summary/TabularListVisualizer.jsx
+++ b/src/summary/TabularListVisualizer.jsx
@@ -150,9 +150,9 @@ class TabularListVisualizer extends Component {
                             data-test-summary-item={item[0]} 
                             key={index + "-item-" + arrayIndex}
                         >   
-                            <p>
+                            <span>
                                 Missing Data
-                            </p>
+                            </span>
                         </td>
                     );
                 } else if (this.props.allowItemClick) {
@@ -194,9 +194,9 @@ class TabularListVisualizer extends Component {
                             data-test-summary-item={item[0]} 
                             key={index + "-item-" + arrayIndex}
                         >
-                            <p>
+                            <span>
                                 {element}
-                            </p>
+                            </span>
                         </td>
                     );
                 }

--- a/src/summary/TabularListVisualizer.jsx
+++ b/src/summary/TabularListVisualizer.jsx
@@ -65,22 +65,10 @@ class TabularListVisualizer extends Component {
             return [];
         }
 
-        const items = subsection.items;
         const itemsFunction = subsection.itemsFunction;
 
-        let list = null;
+        const list = itemsFunction(patient, condition, subsection);
 
-        if (Lang.isUndefined(items)) {
-            list = itemsFunction(patient, condition, subsection);
-        } else {
-            list = items.map((item, i) => {
-                if (Lang.isNull(item.value)) {
-                    return {name: item.name, value: null};
-                } else {
-                    return {name: item.name, value: item.value(patient, condition), shortcut: item.shortcut};
-                }
-            });
-        }
         return list;
     }
 
@@ -193,6 +181,8 @@ class TabularListVisualizer extends Component {
                         </td>
                     );
                 } else { 
+                    const elementText = (element.shortcut) ? element.value : element;
+
                     columnItem = (
                         <td 
                             className={itemClass} 
@@ -200,7 +190,7 @@ class TabularListVisualizer extends Component {
                             key={index + "-item-" + arrayIndex}
                         >
                             <span>
-                                {element}
+                                {elementText}
                             </span>
                         </td>
                     );
@@ -219,7 +209,7 @@ class TabularListVisualizer extends Component {
     }
     
     // Render all list items 
-    renderedListItems(list, numberofHeadings) {
+    renderedListItems(list, numberOfHeadings) {
         let onClick, hoverClass, rowClass, itemClass = "";
         return list.map((item, index) => {
             // Handles case where this method is passed a NameValuePair or other type accidentally, or null
@@ -233,7 +223,7 @@ class TabularListVisualizer extends Component {
                 itemClass = "list-captured";
                 hoverClass = "list-button-hover";
             }
-            return this.renderedListItem(item.slice(0,numberofHeadings), index, rowClass, itemClass, onClick, hoverClass);
+            return this.renderedListItem(item.slice(0,numberOfHeadings), index, rowClass, itemClass, onClick, hoverClass);
         });
     }
 


### PR DESCRIPTION
Addresses ASCODCP-885: Integrate new insertion methodology into Tabular visualizer

Removes pluses from the tabular visualizer with the new insertion methodology. Based on conversations with @gregquinn2001  and @edwinychoi we've replaced the hover menu-trigger with a click menu-trigger. This change is made in both this new instance of the inserter and the original instance. 

Known issues: 
- A change made in my previous PR disabled scrolling on home page for flux notes. @noranda discussed a way to revert this with me and pushed that change out to master as discussed; sadly this makes the application buggy to use in IE, bringing back the issue I was trying to fix in my previous PR. I spent considerable time trying to find a combination of overflow definitions in CSS files that would remedy this bug and had no luck. I present the feature as-is for feedback and criticism. 
- No UI tests were made for reasons discussed in my previous PR.


_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- **N/A** Cheat sheet is updated
- **N/A** Demo script is updated 
- **N/A** Documentation on Wiki has been updated 
- **N/A** Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- **N/A** Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- **N/A** Added UI tests for slim mode 
- **N/A** Added UI tests for full mode
- **N/A** Added backend tests for fluxNotes code
- **N/A** Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
