### PR TITLE
Added toggle buttons to switch between clinical notes and context tray

### DIFF
--- a/src/notes/NoteAssistant.css
+++ b/src/notes/NoteAssistant.css
@@ -7,6 +7,7 @@ span.button-hover {
     min-width: 70px !important;
     min-height: 20px !important;
     display: inline-block !important;
+    box-shadow: 0px 1px 5px 0px rgba(0, 0, 0, 0.2), 0px 2px 2px 0px rgba(0, 0, 0, 0.14), 0px 3px 1px -2px rgba(0, 0, 0, 0.12) !important;
 }
 
 .toggle-buttons-container {

--- a/src/notes/NoteAssistant.css
+++ b/src/notes/NoteAssistant.css
@@ -2,15 +2,6 @@ span.button-hover {
     cursor: pointer;
 }
 
-/*.clinical-notes-btn {*/
-    /*padding: 0 20px;*/
-    /*display: inline-block;*/
-    /*white-space: nowrap;*/
-    /*transform: perspective(1px) translateZ(0);*/
-    /*transition-duration: 0.3s;*/
-    /*transition-property: transform;*/
-/*}*/
-
 .toggle-button {
     background-color: #FFFFFF !important;
     min-width: 70px !important;
@@ -20,16 +11,14 @@ span.button-hover {
 
 .toggle-buttons-container {
     display: flex !important;
-    align-items: center !important;
-    justify-content: center !important;
 }
 
 #notes-btn {
-    /*float:right;*/
+    width: 50%
 }
 
 #context-btn {
-    /*float:right;*/
+    width: 50%;
 }
 .toggle-button-selected {
     background-color: #3399FF !important;
@@ -106,19 +95,6 @@ li.sort-item:hover {
 
 .clinical-notes-btn:hover {
     transform: scale(1.1);
-}
-
-.resume-note-btn {
-    background-color: white !important;
-    padding: 10px !important;
-    margin-bottom: 20px;
-    height: auto !important;
-    width: 9vw !important;
-    min-width: 180px !important;
-}
-
-.resume-note-btn:hover {
-    background: #e6e6e6 !important;
 }
 
 .more-notes-btn {

--- a/src/notes/NoteAssistant.css
+++ b/src/notes/NoteAssistant.css
@@ -13,6 +13,23 @@ span.button-hover {
 
 .toggle-button {
     background-color: #FFFFFF !important;
+    min-width: 70px !important;
+    min-height: 20px !important;
+    display: inline-block !important;
+}
+
+.toggle-button-selected {
+    background-color: #3399FF !important;
+    min-width: 70px !important;
+    min-height: 20px !important;
+    display: inline-block !important;
+}
+
+.toggle-button-disabled {
+    background-color: #FFFFFF !important;
+    min-width: 70px !important;
+    min-height: 20px !important;
+    display: inline-block !important;
 }
 
 

--- a/src/notes/NoteAssistant.css
+++ b/src/notes/NoteAssistant.css
@@ -27,14 +27,6 @@ span.button-hover {
     display: inline-block !important;
 }
 
-.toggle-button-disabled {
-    background-color: #FFFFFF !important;
-    min-width: 70px !important;
-    min-height: 20px !important;
-    display: inline-block !important;
-}
-
-
 .clinical-notes-panel { 
     float: right;
 }

--- a/src/notes/NoteAssistant.css
+++ b/src/notes/NoteAssistant.css
@@ -11,6 +11,11 @@ span.button-hover {
     transition-property: transform;
 }
 
+.toggle-button {
+    background-color: #FFFFFF !important;
+}
+
+
 .clinical-notes-panel { 
     float: right;
 }

--- a/src/notes/NoteAssistant.css
+++ b/src/notes/NoteAssistant.css
@@ -10,6 +10,9 @@ span.button-hover {
 
 .toggle-buttons-container {
     display: flex !important;
+    margin-left: auto;
+    max-width: 222px;
+    margin-right: 0;
 }
 
 #notes-btn {

--- a/src/notes/NoteAssistant.css
+++ b/src/notes/NoteAssistant.css
@@ -2,14 +2,14 @@ span.button-hover {
     cursor: pointer;
 }
 
-.clinical-notes-btn {
-    padding: 0 20px;
-    display: inline-block;
-    white-space: nowrap;
-    transform: perspective(1px) translateZ(0);
-    transition-duration: 0.3s;
-    transition-property: transform;
-}
+/*.clinical-notes-btn {*/
+    /*padding: 0 20px;*/
+    /*display: inline-block;*/
+    /*white-space: nowrap;*/
+    /*transform: perspective(1px) translateZ(0);*/
+    /*transition-duration: 0.3s;*/
+    /*transition-property: transform;*/
+/*}*/
 
 .toggle-button {
     background-color: #FFFFFF !important;
@@ -18,6 +18,19 @@ span.button-hover {
     display: inline-block !important;
 }
 
+.toggle-buttons-container {
+    display: flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+}
+
+#notes-btn {
+    /*float:right;*/
+}
+
+#context-btn {
+    /*float:right;*/
+}
 .toggle-button-selected {
     background-color: #3399FF !important;
     min-width: 70px !important;

--- a/src/notes/NoteAssistant.css
+++ b/src/notes/NoteAssistant.css
@@ -6,6 +6,7 @@ span.button-hover {
     min-width: 70px !important;
     min-height: 20px !important;
     display: inline-block !important;
+    background-color: #FFFFFF !important;
 }
 
 .toggle-buttons-container {
@@ -24,6 +25,13 @@ span.button-hover {
 }
 .toggle-button-selected {
     background-color: #3399FF !important;
+    min-width: 70px !important;
+    min-height: 20px !important;
+    display: inline-block !important;
+}
+
+.toggle-button-disabled {
+    background-color: #e6e6e6 !important;
     min-width: 70px !important;
     min-height: 20px !important;
     display: inline-block !important;

--- a/src/notes/NoteAssistant.css
+++ b/src/notes/NoteAssistant.css
@@ -3,11 +3,9 @@ span.button-hover {
 }
 
 .toggle-button {
-    background-color: #FFFFFF !important;
     min-width: 70px !important;
     min-height: 20px !important;
     display: inline-block !important;
-    box-shadow: 0px 1px 5px 0px rgba(0, 0, 0, 0.2), 0px 2px 2px 0px rgba(0, 0, 0, 0.14), 0px 3px 1px -2px rgba(0, 0, 0, 0.12) !important;
 }
 
 .toggle-buttons-container {

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -1,7 +1,9 @@
-import React, { Component } from 'react';
+import React, {Component} from 'react';
 import PropTypes from 'prop-types';
+import {Row, Col} from 'react-flexbox-grid';
 import Select from 'material-ui/Select';
 import MenuItem from 'material-ui/Menu/MenuItem';
+import MaterialButton from 'material-ui/Button';
 import Lang from 'lodash';
 import FontAwesome from 'react-fontawesome';
 import ContextTray from '../context/ContextTray';
@@ -33,7 +35,7 @@ export default class NoteAssistant extends Component {
         this.selectSort(0);
         this.getNotesFromPatient(this.props);
     }
-    
+
     componentDidMount() {
         // set callback so the editor can signal a change and this class can save the note
         this.props.saveNote(this.saveNoteOnKeypress);
@@ -67,7 +69,7 @@ export default class NoteAssistant extends Component {
     }
 
     // Gets called when clicking on the "new note" button
-    handleOnNewNoteButtonClick  = () => {
+    handleOnNewNoteButtonClick = () => {
         this.updateExistingNote();
         this.createBlankNewNote();
     }
@@ -75,13 +77,13 @@ export default class NoteAssistant extends Component {
     updateExistingNote = () => {
         var entryId = this.props.currentlyEditingEntryId;
         // Only update if there is a note in progress
-        if(!Lang.isEqual(entryId, -1)){
+        if (!Lang.isEqual(entryId, -1)) {
             // List the notes to verify that they are being updated each invocation of this function:
             // console.log(this.props.patient.getNotes());
             var found = this.props.patient.getNotes().find(function(element){
                 return Lang.isEqual(element.entryInfo.entryId, entryId);
             });
-            if(!Lang.isNull(found) && !Lang.isUndefined(found)){
+            if (!Lang.isNull(found) && !Lang.isUndefined(found)) {
                 found.content = this.props.documentText;
                 this.props.patient.updateExistingEntry(found);
                 this.props.updateSelectedNote(found);
@@ -96,7 +98,7 @@ export default class NoteAssistant extends Component {
         let hospital = "Dana Farber Cancer Institute";
         let clinician = "Dr. X123";
         let signed = false;
-        
+
         // Add new unsigned note to patient record
         var currentlyEditingEntryId = this.props.patient.addClinicalNote(date, subject, hospital, clinician, this.props.documentText, signed);
         // this.setState({currentlyEditingEntryId: currentlyEditingEntryId});
@@ -226,7 +228,7 @@ export default class NoteAssistant extends Component {
         return (
             <div className="note note-new" onClick={() => this.handleOnNewNoteButtonClick()}>
                 <div className="note-new-text">
-                    <FontAwesome name="plus" />
+                    <FontAwesome name="plus"/>
                     <span>New note</span>
                 </div>
             </div>
@@ -259,7 +261,7 @@ export default class NoteAssistant extends Component {
     renderSortSelection() {
         return (
             <div className="sort-selection">
-                <div className="sort-label">Sort by </div>
+                <div className="sort-label">Sort by</div>
 
                 <Select
                     className="sort-select"
@@ -370,6 +372,38 @@ export default class NoteAssistant extends Component {
         if (this.props.isNoteViewerEditable) {
             return (
                 <div>
+                    <Row center="xs">
+                        <Col sm={6}>
+                            <MaterialButton raised className="toggle-button">
+                                <svg width="19px" height="17px" viewBox="0 0 19 17">
+                                    <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
+                                        <g id="Group-Copy" transform="translate(0.003906, 0.007812)" stroke="#666666"
+                                           strokeWidth="1.62">
+                                            <path
+                                                d="M1.1248514,1.1248514 L1.1248514,9.91423446 L6.40096349,15.2473495 L17.6880469,15.2473495 L17.6880469,1.1248514 L1.1248514,1.1248514 Z"
+                                                id="Rectangle-12-Copy-4"
+                                                transform="translate(9.406449, 8.186100) rotate(-180.000000) translate(-9.406449, -8.186100) "></path>
+                                            <polyline id="Path-2"
+                                                      points="12.3745117 0.874511719 12.3745117 6.63727788 17.8869466 6.63727788"></polyline>
+                                        </g>
+                                    </g>
+                                </svg>
+                            </MaterialButton>
+                        </Col>
+                        <Col sm={6}>
+                            <MaterialButton raised className="toggle-button">
+                                <svg width="15px" height="20px" viewBox="0 0 15 16">
+                                    <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd"
+                                       fontFamily="OpenSans-Semibold, Open Sans" fontSize="19" fontWeight="500"
+                                       letterSpacing="0.172221214">
+                                        <text id="@-copy" fill="#666666">
+                                            <tspan x="-0.844039108" y="16.2245462">@</tspan>
+                                        </text>
+                                    </g>
+                                </svg>
+                            </MaterialButton>
+                        </Col>
+                    </Row>
                     {this.renderNoteAssistantContent(this.props.noteAssistantMode)}
                 </div>
             );

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -107,7 +107,7 @@ export default class NoteAssistant extends Component {
     }
 
     disableContextToggleButton() {
-        this.context_btn_classname = "toggle-button";
+        this.context_btn_classname = "toggle-button-disabled";
         this.context_disabled = true;
         this.context_fill = "#FFFFFF";
     }

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -19,31 +19,21 @@ export default class NoteAssistant extends Component {
             maxNotesToDisplay: 3,
         };
 
+        // On creating of NoteAssistant, check if the note viewer is editable
         if (this.props.isNoteViewerEditable) {
+            // Check if the clinical notes view mode is active and if it is, set the notes button to selected, otherwise select the context button
             if (this.props.noteAssistantMode === "clinical-notes") {
-                this.notes_btn_classname = "toggle-button-selected";
-                this.notes_stroke = "#FFFFFF";
-                this.notes_disabled = false;
-                this.context_btn_classname = "toggle-button";
-                this.context_fill = "#666666";
-                this.context_disabled = false;
-            } else {
-                this.notes_btn_classname = "toggle-button";
-                this.notes_stroke = "#666666";
-                this.notes_disabled = false;
-                this.context_btn_classname = "toggle-button-selected"
-                this.context_fill = "#FFFFFF";
-                this.context_disabled = false;
+                this.onNotesToggleButtonClicked();
             }
-        } else {
-            this.notes_btn_classname = "toggle-button-selected";
-            this.notes_stroke = "#FFFFFF";
-            this.notes_disabled = false;
+            else {
+                this.onContextToggleButtonClicked();
+            }
+        }
 
-            // disable context button
-            this.context_btn_classname = "toggle-button-disabled";
-            this.context_disabled = true;
-            this.context_fill = "#e6e6e6";
+        // If the note editor is note editable, set the notes button to selected and disable the context button
+        else {
+            this.onNotesToggleButtonClicked();
+            this.disableContextToggleButton();
         }
     }
 
@@ -53,26 +43,15 @@ export default class NoteAssistant extends Component {
 
     componentWillUpdate(nextProps, nextState) {
         this.getNotesFromPatient(nextProps);
-        
+
         if (nextProps.noteAssistantMode === "context-tray") {
-            this.context_btn_classname = "toggle-button-selected";
-            this.context_fill = "#ffffff";
-            this.notes_btn_classname = "toggle-button";
-            this.notes_stroke = "#666666";
+            this.onContextToggleButtonClicked();
         } else {
-            this.context_btn_classname = "toggle-button";
-            this.context_fill = "#666666";
-            this.notes_btn_classname = "toggle-button-selected";
-            this.notes_stroke = "#ffffff";
+            this.onNotesToggleButtonClicked();
         }
 
-        if(!nextProps.isNoteViewerEditable) {
-            // disable context button
-            this.context_btn_classname = "toggle-button-disabled";
-            this.context_disabled = true;
-            this.context_fill = "#e6e6e6";
-        } else {
-            this.context_disabled = false;
+        if (!nextProps.isNoteViewerEditable) {
+            this.disableContextToggleButton();
         }
     }
 
@@ -107,31 +86,32 @@ export default class NoteAssistant extends Component {
     // Switch view (i.e clinical notes view or context tray)
     toggleView(mode) {
         this.props.updateNoteAssistantMode(mode);
-
-        // if(!this.props.isNoteViewerEditable) {
-        //     // disable context button
-        //     this.context_btn_classname = "toggle-button-disabled";
-        //     this.context_disabled = true;
-        //     this.context_fill = "#e6e6e6";
-        // } else {
-        //     this.context_disabled = false;
-        // }
-        //
-        // if (mode === "context-tray") {
-        //     this.context_btn_classname = "toggle-button-selected";
-        //     this.context_fill = "#ffffff";
-        //     this.notes_btn_classname = "toggle-button";
-        //     this.notes_stroke = "#666666";
-        //
-        //
-        // } else {
-        //         this.context_btn_classname = "toggle-button";
-        //         this.context_fill = "#666666";
-        //         this.notes_btn_classname = "toggle-button-selected";
-        //         this.notes_stroke = "#ffffff";
-        //
-        // }
     }
+
+    onNotesToggleButtonClicked() {
+        this.notes_btn_classname = "toggle-button-selected";
+        this.notes_stroke = "#FFFFFF";
+        this.notes_disabled = false;
+        this.context_btn_classname = "toggle-button";
+        this.context_fill = "#666666";
+        this.context_disabled = false;
+    }
+
+    onContextToggleButtonClicked() {
+        this.notes_btn_classname = "toggle-button";
+        this.notes_stroke = "#666666";
+        this.notes_disabled = false;
+        this.context_btn_classname = "toggle-button-selected"
+        this.context_fill = "#FFFFFF";
+        this.context_disabled = false;
+    }
+
+    disableContextToggleButton() {
+        this.context_btn_classname = "toggle-button";
+        this.context_disabled = true;
+        this.context_fill = "#e6e6e6";
+    }
+
 
     // Update the selected index for the sort drop down
     selectSort(sortIndex) {
@@ -197,7 +177,6 @@ export default class NoteAssistant extends Component {
 
         // Add new unsigned note to patient record
         var currentlyEditingEntryId = this.props.patient.addClinicalNote(date, subject, hospital, clinician, content, signed);
-        // this.setState({currentlyEditingEntryId: currentlyEditingEntryId});
         this.props.updateCurrentlyEditingEntryId(currentlyEditingEntryId);
 
         var found = this.props.patient.getNotes().find(function (element) {
@@ -226,8 +205,6 @@ export default class NoteAssistant extends Component {
     // Gets called when clicking on one of the notes in the clinical notes view
     openNote = (isInProgressNote, note) => {
 
-        console.log("is editor editable");
-        console.log(this.props.isNoteViewerEditable);
         // Don't start saving until there is content in the editor
         if (!Lang.isNull(this.props.documentText) && !Lang.isUndefined(this.props.documentText) && this.props.documentText.length > 0) {
             if (Lang.isEqual(this.props.currentlyEditingEntryId, -1)) {
@@ -245,8 +222,6 @@ export default class NoteAssistant extends Component {
         if (isInProgressNote) {
             this.props.setFullAppState('isNoteViewerEditable', true);
             this.toggleView("context-tray");
-
-
         } else {
             this.props.setFullAppState('isNoteViewerEditable', false);
             this.toggleView("clinical-notes");
@@ -311,9 +286,6 @@ export default class NoteAssistant extends Component {
 
     renderInProgressNote(note, i) {
         const selected = this.props.selectedNote === note;
-        /*  console.log("in renderInProgressNoteSVG");
-         console.log(note);
-         console.log(selected);*/
 
         return (
             <div className={`note in-progress-note${selected ? " selected" : ""}`} key={i} onClick={() => {
@@ -440,6 +412,53 @@ export default class NoteAssistant extends Component {
         }
     }
 
+    renderToggleButtons() {
+        return (
+            <div>
+                <MaterialButton
+                    raised
+                    id="notes-btn"
+                    className={this.notes_btn_classname}
+                    disabled={this.notes_disabled}
+                    onClick={() => {
+                        this.toggleView("clinical-notes")
+                    }}>
+                    <svg width="19px" height="20px" viewBox="0 0 19 17">
+                        <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
+                            <g id="Group-Copy" transform="translate(0.003906, 0.007812)" stroke={this.notes_stroke}
+                               strokeWidth="1.62">
+                                <path
+                                    d="M1.1248514,1.1248514 L1.1248514,9.91423446 L6.40096349,15.2473495 L17.6880469,15.2473495 L17.6880469,1.1248514 L1.1248514,1.1248514 Z"
+                                    id="Rectangle-12-Copy-4"
+                                    transform="translate(9.406449, 8.186100) rotate(-180.000000) translate(-9.406449, -8.186100) "></path>
+                                <polyline id="Path-2"
+                                          points="12.3745117 0.874511719 12.3745117 6.63727788 17.8869466 6.63727788"></polyline>
+                            </g>
+                        </g>
+                    </svg>
+                </MaterialButton>
+                <MaterialButton
+                    raised
+                    id="context-btn"
+                    className={this.context_btn_classname}
+                    disabled={this.context_disabled}
+                    onClick={() => {
+                    this.toggleView("context-tray")
+                }}>
+                    <svg width="15px" height="20px" viewBox="0 0 15 16">
+                        <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd"
+                           fontFamily="OpenSans-Semibold, Open Sans" fontSize="19" fontWeight="500"
+                           letterSpacing="0.172221214">
+                            <text id="@-copy" fill={this.context_fill}>
+                                <tspan x="-0.844039108" y="16.2245462">@</tspan>
+                            </text>
+                        </g>
+                    </svg>
+                </MaterialButton>
+            </div>
+        );
+    }
+
     // Main render method
     render() {
 
@@ -447,37 +466,7 @@ export default class NoteAssistant extends Component {
         if (this.props.isNoteViewerEditable) {
             return (
                 <div>
-                    <MaterialButton raised id="notes-btn" className={this.notes_btn_classname} disabled={this.notes_disabled} onClick={() => {
-                        this.toggleView("clinical-notes")
-                    }}>
-                        <svg width="19px" height="20px" viewBox="0 0 19 17">
-                            <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
-                                <g id="Group-Copy" transform="translate(0.003906, 0.007812)" stroke={this.notes_stroke}
-                                   strokeWidth="1.62">
-                                    <path
-                                        d="M1.1248514,1.1248514 L1.1248514,9.91423446 L6.40096349,15.2473495 L17.6880469,15.2473495 L17.6880469,1.1248514 L1.1248514,1.1248514 Z"
-                                        id="Rectangle-12-Copy-4"
-                                        transform="translate(9.406449, 8.186100) rotate(-180.000000) translate(-9.406449, -8.186100) "></path>
-                                    <polyline id="Path-2"
-                                              points="12.3745117 0.874511719 12.3745117 6.63727788 17.8869466 6.63727788"></polyline>
-                                </g>
-                            </g>
-                        </svg>
-                    </MaterialButton>
-                    <MaterialButton raised id="context-btn" className={this.context_btn_classname} disabled={this.context_disabled} onClick={() => {
-                        this.toggleView("context-tray")
-                    }}>
-                        <svg width="15px" height="20px" viewBox="0 0 15 16">
-                            <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd"
-                               fontFamily="OpenSans-Semibold, Open Sans" fontSize="19" fontWeight="500"
-                               letterSpacing="0.172221214">
-                                <text id="@-copy" fill={this.context_fill}>
-                                    <tspan x="-0.844039108" y="16.2245462">@</tspan>
-                                </text>
-                            </g>
-                        </svg>
-                    </MaterialButton>
-
+                    {this.renderToggleButtons()}
                     {this.renderNoteAssistantContent(this.props.noteAssistantMode)}
                 </div>
             );
@@ -485,38 +474,8 @@ export default class NoteAssistant extends Component {
             // If the note viewer is read only the we want to be able to view the clinical notes
         } else {
             return (
-
                 <div>
-                    <MaterialButton raised id="notes-btn" className={this.notes_btn_classname} disabled={this.notes_disabled} onClick={() => {
-                        this.toggleView("clinical-notes")
-                    }}>
-                        <svg width="19px" height="20px" viewBox="0 0 19 17">
-                            <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
-                                <g id="Group-Copy" transform="translate(0.003906, 0.007812)" stroke={this.notes_stroke}
-                                   strokeWidth="1.62">
-                                    <path
-                                        d="M1.1248514,1.1248514 L1.1248514,9.91423446 L6.40096349,15.2473495 L17.6880469,15.2473495 L17.6880469,1.1248514 L1.1248514,1.1248514 Z"
-                                        id="Rectangle-12-Copy-4"
-                                        transform="translate(9.406449, 8.186100) rotate(-180.000000) translate(-9.406449, -8.186100) "></path>
-                                    <polyline id="Path-2"
-                                              points="12.3745117 0.874511719 12.3745117 6.63727788 17.8869466 6.63727788"></polyline>
-                                </g>
-                            </g>
-                        </svg>
-                    </MaterialButton>
-                    <MaterialButton raised id="context-btn" className={this.context_btn_classname} disabled={this.context_disabled} onClick={() => {
-                        this.toggleView("context-tray")
-                    }}>
-                        <svg width="15px" height="20px" viewBox="0 0 15 16">
-                            <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd"
-                               fontFamily="OpenSans-Semibold, Open Sans" fontSize="19" fontWeight="500"
-                               letterSpacing="0.172221214">
-                                <text id="@-copy" fill={this.context_fill}>
-                                    <tspan x="-0.844039108" y="16.2245462">@</tspan>
-                                </text>
-                            </g>
-                        </svg>
-                    </MaterialButton>
+                    {this.renderToggleButtons()}
                     {this.renderNoteAssistantContent("clinical-notes")}
                 </div>
             );

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -414,7 +414,7 @@ export default class NoteAssistant extends Component {
 
     renderToggleButtons() {
         return (
-            <div>
+            <div className="toggle-buttons-container">
                 <MaterialButton
                     raised
                     id="notes-btn"
@@ -443,8 +443,8 @@ export default class NoteAssistant extends Component {
                     className={this.context_btn_classname}
                     disabled={this.context_disabled}
                     onClick={() => {
-                    this.toggleView("context-tray")
-                }}>
+                        this.toggleView("context-tray")
+                    }}>
                     <svg width="15px" height="20px" viewBox="0 0 15 16">
                         <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd"
                            fontFamily="OpenSans-Semibold, Open Sans" fontSize="19" fontWeight="500"
@@ -455,6 +455,7 @@ export default class NoteAssistant extends Component {
                         </g>
                     </svg>
                 </MaterialButton>
+
             </div>
         );
     }

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -109,7 +109,7 @@ export default class NoteAssistant extends Component {
     disableContextToggleButton() {
         this.context_btn_classname = "toggle-button";
         this.context_disabled = true;
-        this.context_fill = "#e6e6e6";
+        this.context_fill = "#FFFFFF";
     }
 
 

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -141,6 +141,7 @@ export default class NotesPanel extends Component {
             <div className="fitted-panel panel-content dashboard-panel">
                 <NoteAssistant
                     isNoteViewerEditable={this.props.isNoteViewerEditable}
+                    setFullAppState={this.props.setFullAppState}
                     patient={this.props.patient}
                     contextManager={this.props.contextManager}
                     shortcutManager={this.props.shortcutManager}

--- a/test/ui/FullApp.js
+++ b/test/ui/FullApp.js
@@ -95,7 +95,7 @@ fixture('Patient Mode - Editor')
 
 test('Clicking clinical notes in Note Assistance switches view to clinical notes', async t => {
 
-    const clinicalNotesButton = Selector('.clinical-notes-btn');
+    const clinicalNotesButton = Selector('#notes-btn');
     const newNoteButton = Selector('.note-new');
 
     // clinical notes button is selected
@@ -111,7 +111,7 @@ test('Clicking clinical notes in Note Assistance switches view to clinical notes
 
 test('In post-encounter mode, clicking the "New Note" button clears the editor content', async t => {
     const editor = Selector("div[data-slate-editor='true']");
-    const clinicalNotesButton = Selector('.clinical-notes-btn');
+    const clinicalNotesButton = Selector('#notes-btn');
     const newNoteButton = Selector('.note-new');
 
     // Enter some text in the editor
@@ -134,7 +134,7 @@ test('In post-encounter mode, clicking the "New Note" button clears the editor c
 test('In pre-encounter mode, clicking the "New Note" button clears the editor content', async t => {
     const clinicalEventSelector = Selector('.clinical-event-select');
     const editor = Selector("div[data-slate-editor='true']");
-    const clinicalNotesButton = Selector('.clinical-notes-btn');
+    const clinicalNotesButton = Selector('#notes-btn');
     const newNoteButton = Selector('.note-new');
 
     // Select pre-encounter mode
@@ -456,7 +456,7 @@ fixture('Patient Mode - Clinical Notes list')
     .page(startPage);
 
 test('Clicking New Note button adds a new in progress note to the list', async t => {
-    const clinicalNotesButton = Selector('.clinical-notes-btn');
+    const clinicalNotesButton = Selector('#notes-btn');
     const newNoteButton = Selector('.note-new');
     const inProgressNotes = Selector('.in-progress-note');
 
@@ -482,7 +482,7 @@ test('Clicking New Note button adds a new in progress note to the list', async t
 
 test('Clicking on an existing note in post encounter mode loads the note in the editor', async t => {
     const editor = Selector("div[data-slate-editor='true']");
-    const clinicalNotesButton = Selector('.clinical-notes-btn');
+    const clinicalNotesButton = Selector('#notes-btn');
     const note = Selector('.existing-note');
 
     // Click on the clinical notes button to switch to clinical notes view
@@ -500,7 +500,7 @@ test('Clicking on an existing note in post encounter mode loads the note in the 
 })
 
 test('Clicking on a note in the clinical notes view updates the information in the note header', async t =>  {
-    const clinicalNotesButton = Selector('.clinical-notes-btn');
+    const clinicalNotesButton = Selector('#notes-btn');
     const note = Selector('.existing-note');
     const noteHeaderName = Selector('#note-title').textContent;
 
@@ -521,7 +521,7 @@ test('Clicking on a note in the clinical notes view updates the information in t
 
 test('Clicking on an existing note in post encounter mode puts the NotesPanel in a read only mode with the clinical notes view displayed', async t => {
     const editor = Selector("div[data-slate-editor='true']");
-    const clinicalNotesButton = Selector('.clinical-notes-btn');
+    const clinicalNotesButton = Selector('#notes-btn');
     const clinicalNotesPanel = Selector('.clinical-notes-panel');
     const note = Selector('.existing-note');
 
@@ -549,7 +549,7 @@ test('Clicking on an existing note in post encounter mode puts the NotesPanel in
 
 test('Clicking on an in-progress note in post encounter mode loads the note in the editor', async t => {
     const editor = Selector("div[data-slate-editor='true']");
-    const clinicalNotesButton = Selector('.clinical-notes-btn');
+    const clinicalNotesButton = Selector('#notes-btn');
     const newNoteButton = Selector('.note-new');
     const inProgressNotes = Selector('.in-progress-note');
     
@@ -580,7 +580,7 @@ test('Clicking on an in-progress note in post encounter mode loads the note in t
 // Verifies automatic saving
 test('Contents of in-progress note saved when switching to a completed note and back', async t => {
      const editor = Selector("div[data-slate-editor='true']");
-    const clinicalNotesButton = Selector('.clinical-notes-btn');
+    const clinicalNotesButton = Selector('#notes-btn');
     const newNoteButton = Selector('.note-new');
     const inProgressNotes = Selector('.in-progress-note');
         const note = Selector('.existing-note');
@@ -614,7 +614,7 @@ test('Contents of in-progress note saved when switching to a completed note and 
 
 test('Clicking on an in-progress note in post encounter mode puts the NotesPanel in edit mode with the context tray displayed', async t => {
     const editor = Selector("div[data-slate-editor='true']");
-    const clinicalNotesButton = Selector('.clinical-notes-btn');
+    const clinicalNotesButton = Selector('#notes-btn');
     const newNoteButton = Selector('.note-new');
     const inProgressNotes = Selector('.in-progress-note');
     const contextTray = Selector('.context-tray');

--- a/test/ui/FullApp.js
+++ b/test/ui/FullApp.js
@@ -93,8 +93,7 @@ test('Clicking "New Note" button in pre-encounter mode changes layout and displa
 fixture('Patient Mode - Editor')
     .page(startPage);
 
-test('Clicking clinical notes in Note Assistance switches view to clinical notes', async t => {
-
+test('Clicking clinical notes toggle button in Note Assistance switches view to clinical notes', async t => {
     const clinicalNotesButton = Selector('#notes-btn');
     const newNoteButton = Selector('.note-new');
 
@@ -108,6 +107,25 @@ test('Clicking clinical notes in Note Assistance switches view to clinical notes
         .expect(buttonText.toString().toLowerCase())
         .eql("new note");
 });
+
+test('Clicking context toggle button in Note Assistance switches view to context tray', async t=> {
+    const clinicalNotesButton = Selector('#notes-btn');
+    const contextButton = Selector('#context-btn');
+    const contextTray = Selector('.context-tray');
+
+    // Select clinical notes
+    await t
+        .click(clinicalNotesButton)
+
+    // Select context button
+    await t
+        .click(contextButton)
+
+    await t
+        .expect(contextTray.exists)
+        .ok()
+});
+
 
 test('In post-encounter mode, clicking the "New Note" button clears the editor content', async t => {
     const editor = Selector("div[data-slate-editor='true']");
@@ -184,7 +202,7 @@ test('Typing a date in the editor results in a structured data insertion ', asyn
 });
 
 test('Typing "#clinical" and selecting "clinical trial" from the portal in the editor results \
-in a structured data insertion and the conext panel updates', async t => {
+in a structured data insertion and the context panel updates', async t => {
     const editor = Selector("div[data-slate-editor='true']");
     await t
         .typeText(editor, "#clinical");
@@ -519,11 +537,12 @@ test('Clicking on a note in the clinical notes view updates the information in t
 })
 
 
-test('Clicking on an existing note in post encounter mode puts the NotesPanel in a read only mode with the clinical notes view displayed', async t => {
+test('Clicking on an existing note in post encounter mode puts the NotesPanel in a read only mode with the clinical notes view displayed and the context toggle button disabled', async t => {
     const editor = Selector("div[data-slate-editor='true']");
     const clinicalNotesButton = Selector('#notes-btn');
     const clinicalNotesPanel = Selector('.clinical-notes-panel');
     const note = Selector('.existing-note');
+    const contextToggleButton = Selector('#context-btn');
 
     // Click on the clinical notes button to switch to clinical notes view
     await t
@@ -542,6 +561,14 @@ test('Clicking on an existing note in post encounter mode puts the NotesPanel in
         .expect(editor.textContent).notContains('random_text', 'Editor content does not contain the text "random_text"');
 
     // Expect to see the clinical notes view (not the context tray)
+    await t
+        .expect(clinicalNotesPanel.exists)
+        .ok()
+
+    // Click the context button and expect to still see the clinical notes view (not the context tray)
+    await t
+        .click(contextToggleButton);
+
     await t
         .expect(clinicalNotesPanel.exists)
         .ok()


### PR DESCRIPTION
This PR addresses 842. Added toggle buttons to switch between the clinical notes view and the context tray in the note assistant panel using designs for Edwin (version 12.4).

- Clicking clinical notes button switches to the clinical notes view and clicking the context tray button switches to the context tray
- Selected buttons change color and font color, as shown in the mockups
- The context tray button is disabled (with the appropriate styling) when the editor is in read only mode
- Removed previous clinical notes button
- Styled toggle buttons to look like the mockups (thanks @Dtphelan1 for your help)
- Fixed UI tests and added new ones

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- N/A Cheat sheet is updated
- N/A Demo script is updated 
- N/A Documentation on Wiki has been updated 
- N/A Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- N/A Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- N/A Added UI tests for slim mode 
- [x] Added UI tests for full mode
- N/A Added backend tests for fluxNotes code
- N/A Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
