### PR TITLE
Fix noteparser test

### DIFF
--- a/src/model/condition/FluxDiseaseProgression.js
+++ b/src/model/condition/FluxDiseaseProgression.js
@@ -6,6 +6,8 @@ import ClinicallyRelevantTime from '../shr/finding/ClinicallyRelevantTime';
 import Entry from '../shr/base/Entry';
 import Reference from '../Reference';
 import EntryType from '../shr/base/EntryType';
+import moment from 'moment';
+import LastUpdated from '../shr/base/LastUpdated';
 
 // FluxDiseaseProgression class to hide codeableconcepts
 class FluxDiseaseProgression {
@@ -15,6 +17,9 @@ class FluxDiseaseProgression {
             let entry = new Entry();
             entry.entryType = new EntryType();
             entry.entryType.uri = 'http://standardhealthrecord.org/spec/shr/condition/DiseaseProgression';
+            let today = new moment().format("D MMM YYYY");
+            entry.lastUpdated = new LastUpdated();
+            entry.lastUpdated.instant = today;
             this._diseaseProgression.entryInfo = entry;
         }
     }
@@ -79,6 +84,7 @@ class FluxDiseaseProgression {
     }
 
     set referenceDate(date) {
+        if (!date) return;
         if (!this._diseaseProgression.clinicallyRelevantTime) {
             let clinicallyRelevantTime = new ClinicallyRelevantTime();
             clinicallyRelevantTime.value = date;

--- a/src/model/entity/FluxDeceased.js
+++ b/src/model/entity/FluxDeceased.js
@@ -13,9 +13,8 @@ class FluxDeceased {
      *  This will return the date value
      */
     get dateOfDeath() {
-        if (Lang.isUndefined(this._deceased.dateOfDeath)) this._deceased.dateOfDeath = new DateOfDeath();
-        if (Lang.isUndefined(this._deceased.dateOfDeath.generalizedDateTime)) this._deceased.dateOfDeath.generalizedDateTime = new GeneralizedDateTime();
-        return this._deceased.dateOfDeath.generalizedDateTime.value;
+        if (Lang.isUndefined(this._deceased.dateOfDeath) || Lang.isUndefined(this._deceased.dateOfDeath.dateTime)) return null; 
+        return this._deceased.dateOfDeath.dateTime.value;
     }
 
     /**
@@ -27,7 +26,7 @@ class FluxDeceased {
         let dateOfDeath = new DateOfDeath();
         let generalizedDateTime = new GeneralizedDateTime();
         generalizedDateTime.value = date;
-        dateOfDeath.generalizedDateTime = generalizedDateTime;
+        dateOfDeath.dateTime = generalizedDateTime;
         this._deceased.dateOfDeath = dateOfDeath;
         this._deceased.value = (!Lang.isNull(date));
     }

--- a/src/model/research/FluxStudy.js
+++ b/src/model/research/FluxStudy.js
@@ -6,6 +6,7 @@ import EntryType from '../shr/base/EntryType';
 import EffectiveTimePeriod from '../shr/core/EffectiveTimePeriod';
 import TimePeriodStart from '../shr/core/TimePeriodStart';
 import TimePeriodEnd from '../shr/core/TimePeriodEnd';
+import Lang from 'lodash';
 
 class FluxStudy {
     constructor(json) {
@@ -40,6 +41,7 @@ class FluxStudy {
      *  The method will create a Title object and set the value to the title string
      */
     set title(title) {
+        if (Lang.isNull(title)) return;
         let titleObj = new Title();
         titleObj.value = title; 
         this._study.title = titleObj;
@@ -70,6 +72,7 @@ class FluxStudy {
     }
   
     set enrollmentDate(val) {
+        if (Lang.isNull(val)) return;
         if (!this._study.effectiveTimePeriod) {
             this._study.effectiveTimePeriod = new EffectiveTimePeriod();
         }
@@ -84,6 +87,7 @@ class FluxStudy {
     }
   
     set endDate(val) {
+        if (Lang.isNull(val)) return;
         if (!this._study.effectiveTimePeriod) {
             this._study.effectiveTimePeriod = new EffectiveTimePeriod();
         }

--- a/test/backend/noteparser/NoteParser.test.js
+++ b/test/backend/noteparser/NoteParser.test.js
@@ -1,7 +1,7 @@
 import NoteParser from '../../../src/noteparser/NoteParser';
 import FluxDiseaseProgression from '../../../src/model/condition/FluxDiseaseProgression';
 import FluxTNMStage from '../../../src/model/oncology/FluxTNMStage';
-import FluxToxicReactionToTreatment from '../../../src/model/oncology/FluxToxicReactionToTreatment';
+import FluxToxicReaction from '../../../src/model/adverse/FluxToxicReaction';
 import FluxDeceased from '../../../src/model/actor/FluxDeceased';
 import FluxStudy from '../../../src/model/base/FluxStudy';
 import moment from 'moment';
@@ -27,55 +27,32 @@ const expectedOutputEmpty = [[], []];
 const expectedOutputPlain = [[], []];
 const expectedOutputNonsense = [[], [ sampleTextNonsense] ];
 const expectedOutputStaging = [[
-    new FluxTNMStage({ 
-        entryType: [ 
-            'http://standardhealthrecord.org/oncology/TNMStage',
-            'http://standardhealthrecord.org/observation/Observation',
-            'http://standardhealthrecord.org/base/Action' 
-        ],
-        value: { 
-            coding: [{
-                value: '',
-                codeSystem: { value: ''},
-                displayText: 'IIA'
-            }],
-            displayText: 'IIA'
-        },
-        specificType: {
-            value: { 
-                coding: [{ 
-                    value: '21908-9',
-                    codeSystem: { value: 'http://loinc.org'},
-                    displayText: 'Stage' 
-                }] 
-            }
-        },
-//        status: 'unknown',
-//        occurrenceTime: today,
-        originalCreationDate: today,
-        lastUpdateDate: today,
-        tStage: { 
-            coding: [{ 
-                  value: '369900003',
-                  codeSystem: { value: 'urn:oid:2.16.840.1.113883.6.96'},
-                  displayText: 'T2' 
-            }] 
-        },
-        nStage: { 
-            coding: [{ 
-                value: '436311000124105',
-                codeSystem: { value: 'urn:oid:2.16.840.1.113883.6.96'},
-                displayText: 'N0' 
-            }] 
-        },
-        mStage: { 
-            coding: [{ 
-                value: '433581000124101',
-                codeSystem: { value: 'urn:oid:2.16.840.1.113883.6.96'},
-                displayText: 'M0' 
-            }] 
-        } 
-    })
+    new FluxTNMStage(
+      {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/oncology/TNMStage" },
+            "Value": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "", "shr.core.CodeSystem": {"Value": ""}, "shr.core.DisplayText": {"Value": "IIA"}}]},
+            "shr.finding.ObservationComponent": [
+                {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/oncology/T_Stage" },
+                    "Value": {
+                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+                        "shr.core.Coding":[{ "Value": "369900003", "shr.core.CodeSystem": {"Value": "urn:oid:2.16.840.1.113883.6.96"}, "shr.core.DisplayText": {"Value": "T2"}}]}
+                },
+                {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/oncology/N_Stage" },
+                    "Value": {
+                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+                        "shr.core.Coding":[{ "Value": "436311000124105", "shr.core.CodeSystem": {"Value": "urn:oid:2.16.840.1.113883.6.96"}, "shr.core.DisplayText": {"Value": "N0"}}]}
+                },
+                {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/oncology/M_Stage" },
+                    "Value": {
+                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+                        "shr.core.Coding":[{ "Value": "433581000124101", "shr.core.CodeSystem": {"Value": "urn:oid:2.16.840.1.113883.6.96"}, "shr.core.DisplayText": {"Value": "M0"}}]}
+                }
+            ],
+        }
+    )
 ], []];
 const expectedOutputDiseaseStatus = [[
     new FluxDiseaseProgression({
@@ -107,46 +84,20 @@ const expectedOutputDiseaseStatus2 = [[
     })
 ], []];
 const expectedOutputToxicity = [[
-    new FluxToxicReaction({ 
-        shr.base.EntryType: {"Value": 'http://standardhealthrecord.org/spec/shr/adverse/ToxicReaction' },
-        
-        Value:  {   "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding": [
-                    {   "Value": "10028813", 
-                        "shr.core.CodeSystem": {"Value": "https://www.meddra.org/"}, 
-                        "shr.core.DisplayText": {"Value": "Nausea"}
-                    }]
-                },
-        shr.adverse.adverseEventGrade: {
-            Value:  {   "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                        "shr.core.Coding": [
-                        {   "Value": "10028813", 
-                            "shr.core.CodeSystem": {"Value": "https://www.meddra.org/"}, 
-                            "shr.core.DisplayText": {"Value": "Nausea"}
-                        }]
-                    },
-            Value: { 
-                coding: [{ 
-                    value: 'C1513374',
-                    codeSystem: { value:'http://ncimeta.nci.nih.gov'},
-                    displayText: 'Grade 2' 
-                }]
-            } 
-            causeCategory: {
-                value: { 
-                    coding: [{ 
-                        value: '#Treatment',
-                        codeSystem: { value:'https://www.meddra.org/'},
-                        displayText: 'Treatment' 
-                    }] 
-                }
+    new FluxToxicReaction(
+        {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/adverse/ToxicReaction"},
+            "Value": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "10028813", "shr.core.CodeSystem": {"Value": "https://www.meddra.org/"}, "shr.core.DisplayText": {"Value": "Nausea"}}], "shr.core.DisplayText": {"Value":"Nausea"}},
+            "shr.adverse.AdverseEventGrade": {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/adverse/AdverseEventGrade"},
+                "Value":{"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C1513374", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value": "Grade 2"}}], "shr.core.DisplayText": {"Value":"Grade 2"}},
             },
-            originalCreationDate: today,
-            lastUpdateDate: today 
-        },
-        originalCreationDate: today,
-        lastUpdateDate: today 
-    })
+            "shr.adverse.CauseCategory": {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/adverse/CauseCategory"},
+                "Value": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "#Treatment", "shr.core.CodeSystem": {"Value": "https://www.meddra.org/"}, "shr.core.DisplayText": {"Value": "Treatment"}}], "shr.core.DisplayText": {"Value":"Treatment"}},
+            }
+        }
+    )
 ], []];
 const expectedOutputDeceased = [[
     new FluxDeceased({
@@ -223,18 +174,12 @@ describe('parse', function() {
             .eql(expectedOutputStaging[0][0].stage);
         expect(record[0][0].entryInfo)
             .eql(expectedOutputStaging[0][0].entryInfo);
-        expect(record[0][0].occurrenceTime)
-            .eql(expectedOutputStaging[0][0].occurrenceTime);
-        expect(record[0][0].specificType)
-            .eql(expectedOutputStaging[0][0].specificType);
-        expect(record[0][0].status)
-            .eql(expectedOutputStaging[0][0].status);
-        expect(record[0][0].t_stage)
-            .eql(expectedOutputStaging[0][0].t_stage);
-        expect(record[0][0].n_stage)
-            .eql(expectedOutputStaging[0][0].n_stage);
-        expect(record[0][0].m_stage)
-            .eql(expectedOutputStaging[0][0].m_stage);
+        expect(record[0][0].t_Stage)
+            .eql(expectedOutputStaging[0][0].t_Stage);
+        expect(record[0][0].n_Stage)
+            .eql(expectedOutputStaging[0][0].n_Stage);
+        expect(record[0][0].m_Stage)
+            .eql(expectedOutputStaging[0][0].m_Stage);
     });
 
     it('should return a patient record with disease status data when parsing a note with disease status phrases', function () {

--- a/test/backend/noteparser/NoteParser.test.js
+++ b/test/backend/noteparser/NoteParser.test.js
@@ -2,11 +2,11 @@ import NoteParser from '../../../src/noteparser/NoteParser';
 import FluxDiseaseProgression from '../../../src/model/condition/FluxDiseaseProgression';
 import FluxTNMStage from '../../../src/model/oncology/FluxTNMStage';
 import FluxToxicReaction from '../../../src/model/adverse/FluxToxicReaction';
-import FluxDeceased from '../../../src/model/actor/FluxDeceased';
-import FluxStudy from '../../../src/model/base/FluxStudy';
+import FluxDeceased from '../../../src/model/entity/FluxDeceased';
+import FluxStudy from '../../../src/model/research/FluxStudy';
 import moment from 'moment';
 import {expect} from 'chai';
-// import util from 'util';
+import util from 'util';
 
 const noteParser = new NoteParser();
 
@@ -101,30 +101,29 @@ const expectedOutputToxicity = [[
 ], []];
 const expectedOutputDeceased = [[
     new FluxDeceased({
-        entryType: [ 'http://standardhealthrecord.org/shr/actor/Deceased' ],
-        value: true,
-        dateOfDeath: '1 Oct 2017'
+        "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Deceased"},
+        "Value": true,
+        "shr.entity.DateOfDeath": {
+            "Value": {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/GeneralizedDateTime"},
+                "Value": "1 Oct 2017"
+            }
+        }
     })
 ], []];
 const expectedOutputClinicalTrial = [[
     new FluxStudy({
-        entryType: [ 'http://standardhealthrecord.org/base/Study' ],
-        title: {value: 'PATINA' },
-        identifier: '',
-        enrollmentDate: '4 Sep 2017',
-        endDate: '6 Oct 2017',
-        originalCreationDate: today,
-        lastUpdateDate: today 
+        "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/research/Study"},
+        "shr.core.Title": {"Value": "PATINA"},
+        "shr.core.EffectiveTimePeriod": {
+            "shr.core.TimePeriodStart": {"Value": "4 Sep 2017"},
+            "shr.core.TimePeriodEnd": {"Value": "6 Oct 2017"}
+        }
     })
 ], []];
 const expectedOutputClinicalTrialMinimal = [[
     new FluxStudy({
-        entryType: [ 'http://standardhealthrecord.org/base/Study' ],
-        identifier: '',
-        enrollmentDate: null,
-        endDate: null,
-        originalCreationDate: today,
-        lastUpdateDate: today 
+        "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/research/Study"},
     })
 ], []];
 
@@ -208,8 +207,6 @@ describe('parse', function() {
     });
     it('should return a patient record with study enrollment data when parsing a note with clinical trial phases', function () {
         const record = noteParser.parse(sampleTextClinicalTrial);
-        //console.log(util.inspect(expectedOutputClinicalTrial[0][0]));
-        //console.log(util.inspect(record[0][0]));
         expect(record)
             .to.be.an('array')
             .and.to.eql(expectedOutputClinicalTrial);

--- a/test/backend/noteparser/NoteParser.test.js
+++ b/test/backend/noteparser/NoteParser.test.js
@@ -6,7 +6,7 @@ import FluxDeceased from '../../../src/model/entity/FluxDeceased';
 import FluxStudy from '../../../src/model/research/FluxStudy';
 import moment from 'moment';
 import {expect} from 'chai';
-import util from 'util';
+// import util from 'util';
 
 const noteParser = new NoteParser();
 

--- a/test/backend/noteparser/NoteParser.test.js
+++ b/test/backend/noteparser/NoteParser.test.js
@@ -1,12 +1,12 @@
 import NoteParser from '../../../src/noteparser/NoteParser';
-import FluxProgression from '../../../src/model/oncology/FluxProgression';
+import FluxDiseaseProgression from '../../../src/model/condition/FluxDiseaseProgression';
 import FluxTNMStage from '../../../src/model/oncology/FluxTNMStage';
 import FluxToxicReactionToTreatment from '../../../src/model/oncology/FluxToxicReactionToTreatment';
 import FluxDeceased from '../../../src/model/actor/FluxDeceased';
 import FluxStudy from '../../../src/model/base/FluxStudy';
 import moment from 'moment';
 import {expect} from 'chai';
-//import util from 'util';
+// import util from 'util';
 
 const noteParser = new NoteParser();
 
@@ -78,85 +78,32 @@ const expectedOutputStaging = [[
     })
 ], []];
 const expectedOutputDiseaseStatus = [[
-    new FluxProgression({
-        entryType: [ 
-            'http://standardhealthrecord.org/oncology/Progression',
-            'http://standardhealthrecord.org/assessment/Assessment',
-            'http://standardhealthrecord.org/base/Action' 
-        ],
-        value: { 
-            coding: [{ 
-                value: 'C0205360',
-                codeSystem: { value: 'http://ncimeta.nci.nih.gov'},
-                displayText: 'Stable' 
-            }]
+    new FluxDiseaseProgression({
+        "shr.base.EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/condition/DiseaseProgression"
         },
-        clinicallyRelevantTime: null,
-        evidence: [ 
-            { 
-                coding: [{ 
-                    value: 'C0011923',
-                    codeSystem: { value: 'http://ncimeta.nci.nih.gov'},
-                    displayText: 'Imaging' 
-                }] 
-            },
-            { 
-                coding: [{ 
-                    value: 'C0031809',
-                    codeSystem: { value: 'http://ncimeta.nci.nih.gov'},
-                    displayText: 'Physical exam' 
-                }] 
-            } 
+        "Value" : {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0205360", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value":"Stable"}}], "shr.core.DisplayText": {"Value":"Stable"}},
+        "shr.finding.Evidence": [   
+            {"Value": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0011923", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value":"Imaging"}}], "shr.core.DisplayText": {"Value":"Imaging"}}},
+            {"Value": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0031809", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value":"Physical exam"}}], "shr.core.DisplayText": {"Value":"Physical exam"}}}
         ],
-        assessmentType: { 
-            coding: { 
-                value: '#disease status' 
-            } 
-        },
-        originalCreationDate: today,
-        asOfDate: today,
-        lastUpdateDate: today 
+        "shr.core.CreationTime": {"Value": today},
+        "shr.base.LastUpdated": {"Value": today}
     })
 ], []];
 const expectedOutputDiseaseStatus2 = [[
-    new FluxProgression({
-        entryType: [ 
-            'http://standardhealthrecord.org/oncology/Progression',
-            'http://standardhealthrecord.org/assessment/Assessment',
-            'http://standardhealthrecord.org/base/Action'  
-        ],
-        value: { 
-            coding: [{ 
-                value: 'C0205360',
-                codeSystem: { value: 'http://ncimeta.nci.nih.gov'},
-                displayText: 'Stable' 
-            }] 
+    new FluxDiseaseProgression({
+        "shr.base.EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/condition/DiseaseProgression"
         },
-        clinicallyRelevantTime: '7 Jun 2017',
-        evidence: [ 
-            { 
-                coding: [{ 
-                    value: 'C0011923',
-                    codeSystem: { value: 'http://ncimeta.nci.nih.gov'},
-                    displayText: 'Imaging' 
-                }] 
-            },
-            { 
-                coding: [{ 
-                    value: 'C0031809',
-                    codeSystem: { value: 'http://ncimeta.nci.nih.gov'},
-                    displayText: 'Physical exam' 
-                }] 
-            } 
+        "Value" : {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0205360", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value":"Stable"}}], "shr.core.DisplayText": {"Value":"Stable"}},
+        "shr.finding.Evidence": [   
+            {"Value": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0011923", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value":"Imaging"}}], "shr.core.DisplayText": {"Value":"Imaging"}}},
+            {"Value": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0031809", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value":"Physical exam"}}], "shr.core.DisplayText": {"Value":"Physical exam"}}}
         ],
-        assessmentType: { 
-            coding: { 
-                value: '#disease status' 
-            } 
-        },
-        originalCreationDate: today,
-        asOfDate: '5 Oct 2017',
-        lastUpdateDate: today 
+        "shr.finding.ClinicallyRelevantTime": {"Value": "7 Jun 2017"},
+        "shr.core.CreationTime": {"Value": "5 Oct 2017"},
+        "shr.base.LastUpdated": {"Value": today}
     })
 ], []];
 const expectedOutputToxicity = [[


### PR DESCRIPTION
Pull Request to fix remaining note parser tests that were breaking when we merged the shr-json branch.

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
-  Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
-  Recognizes any potential shortcomings/bugs in the description 
-  Cheat sheet is updated
-  Demo script is updated 
-  Documentation on Wiki has been updated 
-  Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [x] Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
-  Added UI tests for slim mode 
-  Added UI tests for full mode
- [x] Added backend tests for fluxNotes code
-  Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
