### PR TITLE
Two more lab results: Neutrophil and Hemoglobin

### DIFF
--- a/src/dataaccess/HardCodedPatient.json
+++ b/src/dataaccess/HardCodedPatient.json
@@ -324,6 +324,26 @@
                     "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
                 }
             },
+            {                
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
+                "shr.finding.ClinicallyRelevantTime": { "Value": "02 JAN 2018" },
+                "Value": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
+                    "Value": 6.2, 
+                    "shr.core.Units": {
+                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
+                        "Value": {
+                            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+                            "Value": "10^9/L"
+                        }
+                    }
+                },
+                "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0027950", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value": "Neutrophil"}}]},
+                "shr.finding.FindingStatus": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
+                }
+            },
             {
                 "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/oncology/HistologicGrade"},
                 "Value":  {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "369792005", "shr.core.CodeSystem": {"Value": "http://snomed.info/sct"}, "shr.core.DisplayText": {"Value": "High grade or poorly differentiated"}}]},

--- a/src/dataaccess/HardCodedPatient.json
+++ b/src/dataaccess/HardCodedPatient.json
@@ -298,7 +298,7 @@
                         }
                     }
                 },
-                "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0023508", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": "White blood cell"}]},
+                "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0023508", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText":  {"Value": "White blood cell"}}]},
                 "shr.finding.FindingStatus": {
                     "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
                     "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": "Final"}]
@@ -326,10 +326,110 @@
             },
             {                
                 "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
+                "shr.finding.ClinicallyRelevantTime": { "Value": "25 NOV 2017" },
+                "Value": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
+                    "Value": 4.2, 
+                    "shr.core.Units": {
+                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
+                        "Value": {
+                            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+                            "Value": "10^9/L"
+                        }
+                    }
+                },
+                "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0027950", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value": "Neutrophil"}}]},
+                "shr.finding.FindingStatus": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
+                }
+            },
+            {                
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
+                "shr.finding.ClinicallyRelevantTime": { "Value": "5 DEC 2017" },
+                "Value": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
+                    "Value": 2.3, 
+                    "shr.core.Units": {
+                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
+                        "Value": {
+                            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+                            "Value": "10^9/L"
+                        }
+                    }
+                },
+                "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0027950", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value": "Neutrophil"}}]},
+                "shr.finding.FindingStatus": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
+                }
+            },
+            {                
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
+                "shr.finding.ClinicallyRelevantTime": { "Value": "12 DEC 2017" },
+                "Value": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
+                    "Value": 1.2, 
+                    "shr.core.Units": {
+                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
+                        "Value": {
+                            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+                            "Value": "10^9/L"
+                        }
+                    }
+                },
+                "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0027950", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value": "Neutrophil"}}]},
+                "shr.finding.FindingStatus": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
+                }
+            },
+            {                
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
+                "shr.finding.ClinicallyRelevantTime": { "Value": "19 DEC 2017" },
+                "Value": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
+                    "Value": 1.9, 
+                    "shr.core.Units": {
+                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
+                        "Value": {
+                            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+                            "Value": "10^9/L"
+                        }
+                    }
+                },
+                "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0027950", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value": "Neutrophil"}}]},
+                "shr.finding.FindingStatus": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
+                }
+            },
+            {                
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
+                "shr.finding.ClinicallyRelevantTime": { "Value": "27 DEC 2017" },
+                "Value": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
+                    "Value": 2.6, 
+                    "shr.core.Units": {
+                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
+                        "Value": {
+                            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+                            "Value": "10^9/L"
+                        }
+                    }
+                },
+                "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0027950", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value": "Neutrophil"}}]},
+                "shr.finding.FindingStatus": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
+                }
+            },
+            {                
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
                 "shr.finding.ClinicallyRelevantTime": { "Value": "02 JAN 2018" },
                 "Value": {
                     "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
-                    "Value": 6.2, 
+                    "Value": 4.3, 
                     "shr.core.Units": {
                         "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
                         "Value": {

--- a/src/dataaccess/HardCodedPatient.json
+++ b/src/dataaccess/HardCodedPatient.json
@@ -149,7 +149,47 @@
                 "shr.finding.ClinicallyRelevantTime": { "Value": "01 JAN 2018" },
                 "Value": {
                     "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
-                    "Value": 6.30, 
+                    "Value": 15, 
+                    "shr.core.Units": {
+                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
+                        "Value": {
+                            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+                            "Value": "%"
+                        }
+                    }
+                },
+                "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0019046", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value": "Hemoglobin"}}]},
+                "shr.finding.FindingStatus": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
+                },
+            }
+            {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
+                "shr.finding.ClinicallyRelevantTime": { "Value": "19 DEC 2017" },
+                "Value": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
+                    "Value": 10.30, 
+                    "shr.core.Units": {
+                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
+                        "Value": {
+                            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+                            "Value": "%"
+                        }
+                    }
+                },
+                "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0019046", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value": "Hemoglobin"}}]},
+                "shr.finding.FindingStatus": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
+                },
+            }
+            {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
+                "shr.finding.ClinicallyRelevantTime": { "Value": "10 JAN 2018" },
+                "Value": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
+                    "Value": 14.50, 
                     "shr.core.Units": {
                         "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
                         "Value": {

--- a/src/dataaccess/HardCodedPatient.json
+++ b/src/dataaccess/HardCodedPatient.json
@@ -162,8 +162,8 @@
                 "shr.finding.FindingStatus": {
                     "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
                     "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
-                },
-            }
+                }
+            },
             {
                 "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
                 "shr.finding.ClinicallyRelevantTime": { "Value": "19 DEC 2017" },
@@ -182,8 +182,8 @@
                 "shr.finding.FindingStatus": {
                     "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
                     "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
-                },
-            }
+                }
+            },
             {
                 "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
                 "shr.finding.ClinicallyRelevantTime": { "Value": "10 JAN 2018" },

--- a/src/summary/BandedLineChartVisualizer.css
+++ b/src/summary/BandedLineChartVisualizer.css
@@ -10,3 +10,8 @@
 .recharts-text { 
     font-size: 14px;
 }
+
+.current-value-label {
+    font-size: 20px;
+    margin-top: 50px;
+}

--- a/src/summary/BandedLineChartVisualizer.css
+++ b/src/summary/BandedLineChartVisualizer.css
@@ -11,3 +11,7 @@
     font-size: 14px;
 }
 
+.current-value-label {
+    font-size: 20px;
+    margin-top: 50px;
+}

--- a/src/summary/BandedLineChartVisualizer.css
+++ b/src/summary/BandedLineChartVisualizer.css
@@ -11,7 +11,3 @@
     font-size: 14px;
 }
 
-.current-value-label {
-    font-size: 20px;
-    margin-top: 50px;
-}

--- a/src/summary/BandedLineChartVisualizer.jsx
+++ b/src/summary/BandedLineChartVisualizer.jsx
@@ -1,5 +1,4 @@
 import React, {Component} from 'react';
-import {Grid, Row, Col} from 'react-flexbox-grid';
 import {LineChart, Line, XAxis, YAxis, Tooltip, ReferenceArea} from 'recharts';
 import moment from 'moment';
 import {scaleLinear} from "d3-scale";
@@ -118,9 +117,6 @@ class BandedLineChartVisualizer extends Component {
         if (Lang.isUndefined(processedData) || processedData.length === 0) return <h2 key='0' style={{paddingTop: '10px'}}>None</h2>;
         const yUnit = processedData[0].unit;
 
-        // Grab most current y (should be the last value in array because it's sorted chronologically)
-        const mostRecentY = data[data.length-1];
-
         let renderedBands = null;
 
         // Check if the subsection contains "bands" attribute. If it does, draw them, if not don't draw them
@@ -165,51 +161,39 @@ class BandedLineChartVisualizer extends Component {
 
         return (
             <div
-
-                key={subsection}
+                ref={(chartParentDiv) => {
+                    this.chartParentDiv = chartParentDiv;
+                }}
+                key={yVar}
             >
                 <div className="sub-section-heading">
                     <h2 className="sub-section-name">
                         {`${yVar} (${yUnit})`}
                     </h2>
                 </div>
-                <Row center="xs">
-                    <Col sm={2}>
-                        <div className="current-value-label">
-                            {mostRecentY["White blood cell count"]} <span style={{fontSize: '10px'}}>{mostRecentY["unit"]}</span>
-                        </div>
-                    </Col>
-                    <Col sm={10} >
-                        <div ref={(chartParentDiv) => {
-                            this.chartParentDiv = chartParentDiv;
-                        }}>
-                        <LineChart
-                            width={this.state.chartWidth}
-                            height={this.state.chartHeight}
-                            data={processedData}
-                            margin={{top: 5, right: 20, left: 10, bottom: 5}}
-                        >
-                            <XAxis
-                                dataKey={xVarNumber}
-                                type="number"
-                                domain={[]}
-                                ticks={this.getTicks(processedData, xVarNumber)}
-                                tickFormatter={this.dateFormat}
-                            />
-                            <YAxis
-                                dataKey={yVar}
-                            />
-                            <Tooltip
-                                labelFormatter={this.xVarFormatFunction}
-                                formatter={this.createYVarFormatFunctionWithUnit(yUnit)}
-                            />
-                            <Line type="monotone" dataKey={yVar} stroke="#295677" yAxisId={0}/>
-                            {renderedBands}
-                        </LineChart>
-                            </div>
-                    </Col>
-                </Row>
-
+                <LineChart
+                    width={this.state.chartWidth}
+                    height={this.state.chartHeight}
+                    data={processedData}
+                    margin={{top: 5, right: 20, left: 10, bottom: 5}}
+                >
+                    <XAxis
+                        dataKey={xVarNumber}
+                        type="number"
+                        domain={[]}
+                        ticks={this.getTicks(processedData, xVarNumber)}
+                        tickFormatter={this.dateFormat}
+                    />
+                    <YAxis
+                        dataKey={yVar}
+                    />
+                    <Tooltip
+                        labelFormatter={this.xVarFormatFunction}
+                        formatter={this.createYVarFormatFunctionWithUnit(yUnit)}
+                    />
+                    <Line type="monotone" dataKey={yVar} stroke="#295677" yAxisId={0}/>
+                    {renderedBands}
+                </LineChart>
             </div>
         );
     }

--- a/src/summary/BandedLineChartVisualizer.jsx
+++ b/src/summary/BandedLineChartVisualizer.jsx
@@ -186,6 +186,7 @@ class BandedLineChartVisualizer extends Component {
                     />
                     <YAxis
                         dataKey={yVar}
+                        domain={[0, 'dataMax']}
                     />
                     <Tooltip
                         labelFormatter={this.xVarFormatFunction}

--- a/src/summary/BandedLineChartVisualizer.jsx
+++ b/src/summary/BandedLineChartVisualizer.jsx
@@ -117,7 +117,7 @@ class BandedLineChartVisualizer extends Component {
         if (Lang.isUndefined(processedData) || processedData.length === 0) return <h2 key='0' style={{paddingTop: '10px'}}>None</h2>;
         const yUnit = processedData[0].unit;
         // Min/Max for rendering 
-        const [yMin, yMax] = this.getMinMax(processedData, yVar)
+        const [, yMax] = this.getMinMax(processedData, yVar)
 
         let renderedBands = null;
 

--- a/src/summary/BandedLineChartVisualizer.jsx
+++ b/src/summary/BandedLineChartVisualizer.jsx
@@ -1,4 +1,5 @@
 import React, {Component} from 'react';
+import {Grid, Row, Col} from 'react-flexbox-grid';
 import {LineChart, Line, XAxis, YAxis, Tooltip, ReferenceArea} from 'recharts';
 import moment from 'moment';
 import {scaleLinear} from "d3-scale";
@@ -116,6 +117,9 @@ class BandedLineChartVisualizer extends Component {
         const processedData = this.processForGraphing(data, xVar, xVarNumber);
         if (Lang.isUndefined(processedData) || processedData.length === 0) return <h2 key='0' style={{paddingTop: '10px'}}>None</h2>;
         const yUnit = processedData[0].unit;
+
+        // Grab most current y (should be the last value in array because it's sorted chronologically)
+        const mostRecentY = data[data.length-1];
 
         let renderedBands = null;
 

--- a/src/summary/BandedLineChartVisualizer.jsx
+++ b/src/summary/BandedLineChartVisualizer.jsx
@@ -1,4 +1,5 @@
 import React, {Component} from 'react';
+import {Grid, Row, Col} from 'react-flexbox-grid';
 import {LineChart, Line, XAxis, YAxis, Tooltip, ReferenceArea} from 'recharts';
 import moment from 'moment';
 import {scaleLinear} from "d3-scale";
@@ -117,12 +118,15 @@ class BandedLineChartVisualizer extends Component {
         if (Lang.isUndefined(processedData) || processedData.length === 0) return <h2 key='0' style={{paddingTop: '10px'}}>None</h2>;
         const yUnit = processedData[0].unit;
 
+        // Grab most current y (should be the last value in array because it's sorted chronologically)
+        const mostRecentY = data[data.length-1];
+
         let renderedBands = null;
 
         // Check if the subsection contains "bands" attribute. If it does, draw them, if not don't draw them
         if (subsection.bands) {
             let bands = [];
-            
+
             // Grab the values from the summary metadata and set the bands low and high values
             subsection.bands.forEach((band) => {
                 let color = null;
@@ -153,7 +157,7 @@ class BandedLineChartVisualizer extends Component {
 
             renderedBands = bands.map((band, i) => {
                 return this.renderBand(band.y1, band.y2, band.color, i);
-            });            
+            });
 
         } else {
             renderedBands = null;
@@ -161,41 +165,50 @@ class BandedLineChartVisualizer extends Component {
 
         return (
             <div
-                ref={(chartParentDiv) => {
-                    this.chartParentDiv = chartParentDiv;
-                }}
+
                 key={subsection}
             >
                 <div className="sub-section-heading">
                     <h2 className="sub-section-name">
                         {`${yVar} (${yUnit})`}
                     </h2>
-
                 </div>
-
-                <LineChart
-                    width={this.state.chartWidth}
-                    height={this.state.chartHeight}
-                    data={processedData}
-                    margin={{top: 5, right: 20, left: 10, bottom: 5}}
-                >
-                    <XAxis
-                        dataKey={xVarNumber}
-                        type="number"
-                        domain={[]}
-                        ticks={this.getTicks(processedData, xVarNumber)}
-                        tickFormatter={this.dateFormat}
-                    />
-                    <YAxis
-                        dataKey={yVar}
-                    />
-                    <Tooltip
-                        labelFormatter={this.xVarFormatFunction}
-                        formatter={this.createYVarFormatFunctionWithUnit(yUnit)}
-                    />
-                    <Line type="monotone" dataKey={yVar} stroke="#295677" yAxisId={0}/>
-                    {renderedBands}
-                </LineChart>
+                <Row center="xs">
+                    <Col sm={2}>
+                        <div className="current-value-label">
+                            {mostRecentY["White blood cell count"]} <span style={{fontSize: '10px'}}>{mostRecentY["unit"]}</span>
+                        </div>
+                    </Col>
+                    <Col sm={10} >
+                        <div ref={(chartParentDiv) => {
+                            this.chartParentDiv = chartParentDiv;
+                        }}>
+                        <LineChart
+                            width={this.state.chartWidth}
+                            height={this.state.chartHeight}
+                            data={processedData}
+                            margin={{top: 5, right: 20, left: 10, bottom: 5}}
+                        >
+                            <XAxis
+                                dataKey={xVarNumber}
+                                type="number"
+                                domain={[]}
+                                ticks={this.getTicks(processedData, xVarNumber)}
+                                tickFormatter={this.dateFormat}
+                            />
+                            <YAxis
+                                dataKey={yVar}
+                            />
+                            <Tooltip
+                                labelFormatter={this.xVarFormatFunction}
+                                formatter={this.createYVarFormatFunctionWithUnit(yUnit)}
+                            />
+                            <Line type="monotone" dataKey={yVar} stroke="#295677" yAxisId={0}/>
+                            {renderedBands}
+                        </LineChart>
+                            </div>
+                    </Col>
+                </Row>
 
             </div>
         );

--- a/src/summary/BandedLineChartVisualizer.jsx
+++ b/src/summary/BandedLineChartVisualizer.jsx
@@ -1,5 +1,4 @@
 import React, {Component} from 'react';
-import {Grid, Row, Col} from 'react-flexbox-grid';
 import {LineChart, Line, XAxis, YAxis, Tooltip, ReferenceArea} from 'recharts';
 import moment from 'moment';
 import {scaleLinear} from "d3-scale";
@@ -117,9 +116,6 @@ class BandedLineChartVisualizer extends Component {
         const processedData = this.processForGraphing(data, xVar, xVarNumber);
         if (Lang.isUndefined(processedData) || processedData.length === 0) return <h2 key='0' style={{paddingTop: '10px'}}>None</h2>;
         const yUnit = processedData[0].unit;
-
-        // Grab most current y (should be the last value in array because it's sorted chronologically)
-        const mostRecentY = data[data.length-1];
 
         let renderedBands = null;
 

--- a/src/summary/BandedLineChartVisualizer.jsx
+++ b/src/summary/BandedLineChartVisualizer.jsx
@@ -116,6 +116,8 @@ class BandedLineChartVisualizer extends Component {
         const processedData = this.processForGraphing(data, xVar, xVarNumber);
         if (Lang.isUndefined(processedData) || processedData.length === 0) return <h2 key='0' style={{paddingTop: '10px'}}>None</h2>;
         const yUnit = processedData[0].unit;
+        // Min/Max for rendering 
+        const [yMin, yMax] = this.getMinMax(processedData, yVar)
 
         let renderedBands = null;
 
@@ -152,7 +154,7 @@ class BandedLineChartVisualizer extends Component {
             });
 
             renderedBands = bands.map((band, i) => {
-                return this.renderBand(band.y1, band.y2, band.color, i);
+                return this.renderBand(band.y1, band.y2, yMax, band.color, i);
             });
 
         } else {
@@ -200,10 +202,23 @@ class BandedLineChartVisualizer extends Component {
     }
 
     // Given the range and the color, render the band
-    renderBand(y1, y2, color, key) {
-        return (
-            <ReferenceArea key={key} y1={y1} y2={y2} fill={color} fillOpacity="0.1" alwaysShow/>
-        );
+    renderBand(y1, y2, yMax, color, key) {
+        if (y2 === "max") { 
+            // If reference area has no upper limit, draw it only if patient data would be captured by it
+            if (yMax > y1) { 
+                // Draw refence area large enough to capture max dataelement if it's greater than the y1 (bottom of referenceArea)
+                return (
+                    <ReferenceArea key={key} y1={y1} y2={yMax} fill={color} fillOpacity="0.1" alwaysShow/>
+                );
+            } else { 
+                // Else  draw nothing -- no relevant values would be captured by that rectangle
+            }
+        } else { 
+            // Otherwise, draw as usual
+            return (
+                <ReferenceArea key={key} y1={y1} y2={y2} fill={color} fillOpacity="0.1" alwaysShow/>
+            );
+        }
     }
 
     // Gets called for each section in SummaryMetaData.jsx

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -169,7 +169,6 @@ class SummaryMetadata {
 
                                 // Source: https://www.cancer.org/treatment/understanding-your-diagnosis/tests/understanding-your-lab-test-results.html
                                 // Source: https://www.mayoclinic.org/symptoms/low-white-blood-cell-count/basics/definition/sym-20050615
-
                                 bands: [
                                     {
                                         low: 0,
@@ -184,6 +183,31 @@ class SummaryMetadata {
                                     {
                                         low: 5,
                                         high: 10,
+                                        assessment: 'good'
+                                    }
+                                ]
+                            },
+                            {
+                                name: "Hemoglobin",
+                                code: "C0019046",
+                                itemsFunction: this.getTestsForSubSection,
+
+                                // Source: https://www.emedicinehealth.com/hemoglobin_levels/page2_em.htm
+                                // Source: https://www.quora.com/What-is-the-percentage-of-haemoglobin-in-blood
+                                bands: [
+                                    {
+                                        low: 0,
+                                        high: 12,
+                                        assessment: 'bad'
+                                    },
+                                    {
+                                        low: 16,
+                                        high: 20,
+                                        assessment: 'bad'
+                            },
+                                    {
+                                        low: 12,
+                                        high: 16,
                                         assessment: 'good'
                                     }
                                 ]

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -159,6 +159,7 @@ class SummaryMetadata {
                     },
                     {
                         name: "Labs",
+                        clinicalEvents: ["pre-encounter"],
                         type: "ValueOverTime",
                         data: [
                             {
@@ -170,9 +171,21 @@ class SummaryMetadata {
                                 // Source: https://www.mayoclinic.org/symptoms/low-white-blood-cell-count/basics/definition/sym-20050615
 
                                 bands: [
-                                    {low: 0, high: 3, assessment: 'bad'},
-                                    {low: 3, high: 5, assessment: 'average'},
-                                    {low: 5, high: 10, assessment: 'good'}
+                                    {
+                                        low: 0,
+                                        high: 3,
+                                        assessment: 'bad'
+                                    },
+                                    {
+                                        low: 3,
+                                        high: 5,
+                                        assessment: 'average'
+                                    },
+                                    {
+                                        low: 5,
+                                        high: 10,
+                                        assessment: 'good'
+                                    }
                                 ]
                             }
                         ]
@@ -514,6 +527,7 @@ class SummaryMetadata {
     getTestsForSubSection = (patient, currentConditionEntry, subsection) => { 
         if (Lang.isNull(patient) || Lang.isNull(currentConditionEntry)) return [];
         const labResults = currentConditionEntry.getTests();
+        labResults.sort(currentConditionEntry._labResultsTimeSorter);
 
         const labs = labResults.filter((lab, i) => {
             return lab.codeableConceptCode === subsection.code;
@@ -525,6 +539,7 @@ class SummaryMetadata {
 
             return processedLab
         });
+
         return labs
     }
 

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -188,6 +188,36 @@ class SummaryMetadata {
                                 ]
                             },
                             {
+                                name: "Neutrophil count",
+                                code: "C0027950",
+                                itemsFunction: this.getTestsForSubSection,
+
+                                // Source: https://www.healthline.com/health/neutrophils#anc
+                                // Source: https://evs.nci.nih.gov/ftp1/CTCAE/CTCAE_4.03_2010-06-14_QuickReference_8.5x11.pdf page 42
+                                bands: [
+                                    {
+                                        low: 0,
+                                        high: 1,
+                                        assessment: 'bad'
+                                    },
+                                    {
+                                        low: 1,
+                                        high: 1.5,
+                                        assessment: 'average'
+                                    },
+                                    {
+                                        low: 1.5,
+                                        high: 8,
+                                        assessment: 'good'
+                                    }
+                                    // {
+                                    //     low: 8,
+                                    //     high: highest,
+                                    //     assessment: 'bad'
+                                    // },
+                                ]
+                            },
+                            {
                                 name: "Hemoglobin",
                                 code: "C0019046",
                                 itemsFunction: this.getTestsForSubSection,
@@ -204,7 +234,7 @@ class SummaryMetadata {
                                         low: 16,
                                         high: 20,
                                         assessment: 'bad'
-                            },
+                                    },
                                     {
                                         low: 12,
                                         high: 16,

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -184,6 +184,11 @@ class SummaryMetadata {
                                         low: 5,
                                         high: 10,
                                         assessment: 'good'
+                                    },
+                                    {
+                                        low: 10,
+                                        high: 'max',
+                                        assessment: 'bad'
                                     }
                                 ]
                             },
@@ -209,12 +214,13 @@ class SummaryMetadata {
                                         low: 1.5,
                                         high: 8,
                                         assessment: 'good'
+                                    },
+                                    {
+                                        low: 8,
+                                        // Only draws if an element is captured in this range
+                                        high: 'max',
+                                        assessment: 'bad'
                                     }
-                                    // {
-                                    //     low: 8,
-                                    //     high: highest,
-                                    //     assessment: 'bad'
-                                    // },
                                 ]
                             },
                             {
@@ -230,15 +236,16 @@ class SummaryMetadata {
                                         high: 12,
                                         assessment: 'bad'
                                     },
-                                    {
-                                        low: 16,
-                                        high: 20,
-                                        assessment: 'bad'
-                                    },
+
                                     {
                                         low: 12,
                                         high: 16,
                                         assessment: 'good'
+                                    },
+                                    {
+                                        low: 16,
+                                        high: 20,
+                                        assessment: 'bad'
                                     }
                                 ]
                             }


### PR DESCRIPTION
ASCODCP-826: Support 2 additional lab results to pre encounter mode only. Support line graphs per lab result. add test data for more than WBC so we have multiple line graphs. Update patient JSON to include another lab result, and update summary metadata to display it.

Make lab result sections pre encounter mode only

*NOTE: After discussing with Quinn, Greg, not adding most recent value to be rendered (like the mockups have) because graph has hover over functionality to read the data values.

Additional Fixes: Addresses ASCODCP-884, Specify and render a band in the line chart that is the entire area above or below a set y value. This area is only drawn when values exist outside that boundary, otherwise we don't take up space with it. 

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- [ ] Cheat sheet is updated
- [ ] Demo script is updated 
- [ ] Documentation on Wiki has been updated 
- [ ] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [x] Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- [ ] Added UI tests for slim mode 
- [ ] Added UI tests for full mode
- [ ] Added backend tests for fluxNotes code
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
