### PR TITLE
Note preview styling no corner

### DIFF
--- a/src/dashboardViews/PreEncounterView.css
+++ b/src/dashboardViews/PreEncounterView.css
@@ -4,6 +4,8 @@
 
 #pre-encounter-view-content .fitted-panel { 
     overflow-y: scroll;
+    max-height: calc(100vh - 200px);
+    min-height: 500px !important;
 }
 
 #pre-encounter-view-content .full-panel { 

--- a/src/notes/NoteAssistant.css
+++ b/src/notes/NoteAssistant.css
@@ -5,25 +5,49 @@ span.button-hover {
 
 .clinical-notes-panel {
     margin: auto;
-    width: 150px;
+    width: 160px;
     height: 100px;
+}
+
+.note-new {
+    padding-bottom: 20px;
+    margin-bottom: 20px;
+    text-align: center;
 }
 
 .resume-note-btn {
     background-color: white !important;
     height: 120px;
     width: 100%;
+    margin-bottom: 20px;
 }
 
 .resume-note-btn:hover {
     background: #e6e6e6 !important;
 }
 
+.svg {
+    z-index: 999;
+}
+
+.note-new:hover {
+    cursor:pointer;
+    background: #e6e6e6;
+}
+
+.note {
+    padding-top: 0px !important;
+}
+
+
 .note:hover {
     cursor:pointer;
     background: #e6e6e6;
 }
 
+.notes-table {
+    margin-top: 0px !important;
+}
 /*Playing around with button click animation*/
 /*.note:active {*/
     /*vertical-align: top;*/

--- a/src/notes/NoteAssistant.css
+++ b/src/notes/NoteAssistant.css
@@ -2,7 +2,6 @@ span.button-hover {
     cursor: pointer;
 }
 
-
 .clinical-notes-panel {
     margin: auto;
     width: 160px;
@@ -10,9 +9,15 @@ span.button-hover {
 }
 
 .note-new {
-    padding-bottom: 20px;
+    padding-top: 10px;
+    padding-bottom: 10px;
     margin-bottom: 20px;
     text-align: center;
+}
+
+.note-new:hover {
+    cursor:pointer;
+    background: #e6e6e6;
 }
 
 .resume-note-btn {
@@ -26,19 +31,38 @@ span.button-hover {
     background: #e6e6e6 !important;
 }
 
-.svg {
-    z-index: 999;
+
+.previous-notes-label {
+    font-weight: bold;
+    font-size: 0.8em;
+    margin-left: 10px;
 }
 
-.note-new:hover {
-    cursor:pointer;
-    background: #e6e6e6;
+.sort-label {
+    margin-left: 10px;
+    font-size: 0.8em;
 }
 
+.sort-selection {
+
+    margin-bottom: 20px;
+}
+
+.sort-select {
+    width: 50%;
+    margin-left: 10px;
+}
+.sort-selection .sort-select {
+    font-size: 0.8em;
+}
+
+.sort-item:hover {
+    background-color: #1384b5;
+    color: #fff;
+}
 .note {
     padding-top: 0px !important;
 }
-
 
 .note:hover {
     cursor:pointer;
@@ -48,6 +72,39 @@ span.button-hover {
 .notes-table {
     margin-top: 0px !important;
 }
+
+
+td.existing-note-date {
+    color: #333333 !important;
+    font-weight: bold;
+}
+
+td.existing-note-subject {
+    font-size: 0.8rem;
+    color: #999 !important;
+}
+
+td.existing-note-metadata {
+    color: #999 !important;
+}
+
+.view-more-notes-label {
+    margin-left: 10px;
+    font-size: 0.8em;
+}
+
+.more-notes-btn {
+    background-color: white !important;
+    height: 80px;
+    width: 100%;
+    margin-bottom: 20px;
+    text-transform: none !important;
+}
+
+.more-notes-btn:hover {
+    background: #e6e6e6 !important;
+}
+
 /*Playing around with button click animation*/
 /*.note:active {*/
     /*vertical-align: top;*/

--- a/src/notes/NoteAssistant.css
+++ b/src/notes/NoteAssistant.css
@@ -2,8 +2,31 @@ span.button-hover {
     cursor: pointer;
 }
 
-.resume-note-btn {
-    width: 100%;
-    height: 60px;
-    background-color: white !important;
+
+.clinical-notes-panel {
+    margin: auto;
+    width: 150px;
+    height: 100px;
 }
+
+.resume-note-btn {
+    background-color: white !important;
+    height: 120px;
+    width: 100%;
+}
+
+.resume-note-btn:hover {
+    background: #e6e6e6 !important;
+}
+
+.note:hover {
+    cursor:pointer;
+    background: #e6e6e6;
+}
+
+/*Playing around with button click animation*/
+/*.note:active {*/
+    /*vertical-align: top;*/
+    /*padding: 8px 13px 6px;*/
+/*}*/
+

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -1,4 +1,6 @@
 import React, {Component} from 'react';
+import Divider from 'material-ui/Divider';
+import Paper from 'material-ui/Paper';
 import ContextTray from '../context/ContextTray';
 import Button from '../elements/Button';
 
@@ -23,6 +25,10 @@ class NoteAssistant extends Component {
         );
     }
 
+    test() {
+        console.log("clicked on paper");
+    }
+
     renderNoteAssistantContent(noteAssistantMode) {
 
         switch (noteAssistantMode) {
@@ -42,15 +48,11 @@ class NoteAssistant extends Component {
                 );
             case "clinical-notes":
                 return (
-                    <div>
+                    <div className="clinical-notes-panel">
                         <Button raised
                                 className="resume-note-btn"
                         >Resume in-progress note</Button>
-                        <table>
-                            <tbody>
-                            {this.renderedNotes()}
-                            </tbody>
-                        </table>
+                        {this.renderedNotes()}
                     </div>
                 );
 
@@ -62,21 +64,30 @@ class NoteAssistant extends Component {
 
     renderedNotes() {
         return this.props.patient.getNotes().map((item, i) =>
-
-            <tr className="existing-note-entry" key={i}>
-                <td className="existing-note-date" width="15%">{item.date}</td>
-                <td className="existing-note-metadata" width="55%">
-                    <span id="existing-note-subject">{item.subject}</span> <br/>
-                    <span>{item.hospital}</span> <br/>
-                    <span>{item.clinician}</span>
-                </td>
-                <td className="existing-note-button" width="30%">
-                    <Button raised
-                            className="existing-note-btn"
-                            key={i}
-                    >View Note</Button>
-                </td>
-            </tr>
+            <Paper key={i} className="note" onClick={() => {
+                this.test()
+            }}>
+                <table >
+                    <tbody>
+                    <tr>
+                        <td className="existing-note-date" width="15%">{item.date}</td>
+                    </tr>
+                    <tr>
+                        <td className="existing-note-date" id="existing-note-subject">{item.subject}</td>
+                        </tr>
+                    <Divider />
+                    <tr>
+                        <td className="existing-note-metadata" width="55%">
+                            <span>{item.hospital}</span> <br/>
+                            {/*<span>{item.clinician}</span>*/}
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+                {/*<svg width="100" height="100">*/}
+                    {/*<circle cx="50" cy="50" r="40" stroke="green"  fill="yellow" />*/}
+                {/*</svg>*/}
+            </Paper>
         );
     }
 

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -3,9 +3,10 @@ import Divider from 'material-ui/Divider';
 import Paper from 'material-ui/Paper';
 import ContextTray from '../context/ContextTray';
 import Button from '../elements/Button';
+import Select from 'material-ui/Select';
+import MenuItem from 'material-ui/Menu/MenuItem';
 
 import './NoteAssistant.css';
-
 
 class NoteAssistant extends Component {
 
@@ -13,26 +14,54 @@ class NoteAssistant extends Component {
         super(props);
 
         this.state = {
-            noteAssistantMode: "context-tray"
+            noteAssistantMode: "context-tray",
+            sortIndex: null,
+            maxNotesToDisplay: 4,
+            notesNotDisplayed: null,
+            notesToDisplay: []
         };
     }
 
+    componentWillMount() {
+
+        // Set default value for sort selection
+        this.selectSort(0);
+
+        // Generate notesToDisplay array which will be used to render the notes in clinical notes view
+        let allNotes = this.props.patient.getNotes();
+        for (let i = 0; i < this.state.maxNotesToDisplay; i++) {
+            this.state.notesToDisplay.push(allNotes[i]);
+        }
+
+        // Set the number of notes that are not being displayed
+        let missingNotes = allNotes.length - this.state.maxNotesToDisplay;
+
+        this.setState({ notesNotDisplayed: missingNotes });
+    }
+
+    // Switch view. Currently only switching from context tray to clinical notes is available
+    // Cannot currently switch from clinical notes view back to current note view
     toggleView() {
-        this.setState(
-            {
-                noteAssistantMode: "clinical-notes"
-            }
-        );
+        this.setState({ noteAssistantMode: "clinical-notes" });
+    }
+
+    selectSort(sortIndex) {
+        this.setState({ sortIndex: sortIndex });
     }
 
     test() {
-        console.log("clicked on paper");
+        console.log("clicked on new note");
     }
 
+    // Render the content for the Note Assistant panel
     renderNoteAssistantContent(noteAssistantMode) {
+
+        const numberOfPreviousNotes = this.props.patient.getNotes().length;
 
         switch (noteAssistantMode) {
             case "context-tray":
+
+                // Render the context tray
                 return (
                     <div>
                         <span className="button-hover clinical-notes-btn" onClick={() => {
@@ -46,21 +75,32 @@ class NoteAssistant extends Component {
                         />
                     </div>
                 );
+
+            // Render the clinical notes view which includes new note button, resume note button,
+            // number of previous notes label, sort selection, and preview of previous notes
             case "clinical-notes":
                 return (
                     <div className="clinical-notes-panel">
                         <Paper className="note-new" onClick={() => {
                             this.test()
                         }}>
-                            {this.renderNoteSVG()}
-                            <span><i className="fa fa-plus" aria-hidden="true"></i>New note</span>
+                            <span><i className="fa fa-plus" aria-hidden="true"></i> New note</span>
+                            {/*{this.renderNewNoteSVG()}*/}
                         </Paper>
-
                         <Button raised
                                 className="resume-note-btn"
                         >Resume in-progress note</Button>
 
-                        {this.renderedNotes()}
+                        <span className="previous-notes-label">{numberOfPreviousNotes} previous notes</span>
+
+                        {this.renderSortSelection()}
+
+                        {this.renderNotes()}
+
+                        {this.renderMoreNotesButton()}
+
+                        {/*<span*/}
+                            {/*className="view-more-notes-label">Notes not displayed: {this.state.notesNotDisplayed}</span>*/}
 
                     </div>
                 );
@@ -71,13 +111,29 @@ class NoteAssistant extends Component {
         }
     }
 
-    renderedNotes() {
-        return this.props.patient.getNotes().map((item, i) =>
-            <Paper key={i} className="note" onClick={() => {
-                this.test()
-            }}>
+    renderSortSelection() {
+        return (
+            <div className="sort-selection">
+                <span className="sort-label">Sort by </span>
+                <Select
+                    className="sort-select"
+                    value={this.state.sortIndex}
+                    onChange={(event) => this.selectSort(event.target.value)}
+                >
+                    <MenuItem className="sort-item" value={0}>Date</MenuItem>
+                    <MenuItem className="sort-item" value={1}>Subject</MenuItem>
+                    <MenuItem className="sort-item" value={2}>Hospital</MenuItem>
+                </Select>
+            </div>
+        );
+    }
 
-                {this.renderNoteSVG()}
+    renderNotes() {
+
+        return this.state.notesToDisplay.map((item, i) =>
+            <Paper key={i} className="note">
+
+                {/*{this.renderClinicalNoteSVG()}*/}
 
                 <table className="notes-table">
                     <tbody>
@@ -85,7 +141,7 @@ class NoteAssistant extends Component {
                         <td className="existing-note-date" width="15%">{item.date}</td>
                     </tr>
                     <tr>
-                        <td className="existing-note-date" id="existing-note-subject">{item.subject}</td>
+                        <td className="existing-note-subject" id="existing-note-subject">{item.subject}</td>
                     </tr>
                     <Divider />
                     <tr>
@@ -100,30 +156,61 @@ class NoteAssistant extends Component {
         );
     }
 
-    renderNoteSVG() {
+    renderMoreNotesButton() {
+        if (this.state.notesNotDisplayed > 0) {
+            return (
+                <Button raised
+                        className="more-notes-btn"
+
+                >View {this.state.notesNotDisplayed} more clinical note(s)</Button>
+            );
+        }
+
+    }
+
+    renderClinicalNoteSVG() {
         return (
-            <svg width="160" height="17">
-                <defs>
-                    <filter id="f1" x="0" y="0" width="200%" height="200%">
-                        <feOffset result="offOut" in="SourceGraphic" dx="20" dy="20"/>
-                        <feBlend in="SourceGraphic" in2="offOut" mode="normal"/>
-                    </filter>
-                </defs>
-                <rect x="144" y="0" rx="2" ry="2" width="17" height="17"
-                      fill="white" stroke="#999" strokeWidth="1" opacity="0.5" filter="url(#f1)"/>
-                <line x1="145" y1="0" x2="200" y2="52" stroke="#999" strokeWidth="1" filter="url(#f1)"/>
+            <svg width="160" height="160">
+
+                <rect x="143" y="0" rx="2" ry="2" width="17" height="17"
+                      fill="white" stroke="#999" strokeWidth="1" opacity="0.5"/>
+                <line x1="143" y1="0" x2="200" y2="52" stroke="#999" strokeWidth="1"/>
+
+                <text x="20" y="20" fontFamily="sans-serif" fontSize="20px" fill="red">Date</text>
+                <text x="20" y="40" fontFamily="sans-serif" fontSize="20px" fill="red">note subject</text>
+
+                <line x1="10" y1="50" x2="150" y2="50" stroke="#999" strokeWidth="1"/>
+                <text x="20" y="60" fontFamily="sans-serif" fontSize="20px" fill="red">hospital</text>
+            </svg>
+        );
+    }
+
+    renderNewNoteSVG() {
+        return (
+            <svg width="11px" height="11px" viewBox="0 0 11 11" version="1.1" xmlns="http://www.w3.org/2000/svg">
+                <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd" strokeLinecap="square">
+                    <g id="Group-Copy-3" transform="translate(0.660429, 0.452719)" stroke="#16253E"
+                       strokeWidth="1.5552">
+                        <path d="M0.465836188,4.96173944 L8.70583619,4.96173944" id="Line"></path>
+                        <path d="M4.59517238,1.04666266 L4.59517238,9.28624923" id="Line-Copy"></path>
+                    </g>
+                </g>
+                <text x="0" y="0" fontFamily="sans-serif" fontSize="20px" fill="red">New note</text>
             </svg>
         );
     }
 
     render() {
 
+        // If the note viewer is editable then we want to be able to edit notes and view the context tray
         if (this.props.isNoteViewerEditable) {
             return (
                 <div>
                     {this.renderNoteAssistantContent(this.state.noteAssistantMode)}
                 </div>
             );
+
+            // If the note viewer is read only the we want to be able to view the clinical notes
         } else {
             return (
                 <div>

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -49,10 +49,19 @@ class NoteAssistant extends Component {
             case "clinical-notes":
                 return (
                     <div className="clinical-notes-panel">
+                        <Paper className="note-new" onClick={() => {
+                            this.test()
+                        }}>
+                            {this.renderNoteSVG()}
+                            <span><i className="fa fa-plus" aria-hidden="true"></i>New note</span>
+                        </Paper>
+
                         <Button raised
                                 className="resume-note-btn"
                         >Resume in-progress note</Button>
+
                         {this.renderedNotes()}
+
                     </div>
                 );
 
@@ -67,14 +76,17 @@ class NoteAssistant extends Component {
             <Paper key={i} className="note" onClick={() => {
                 this.test()
             }}>
-                <table >
+
+                {this.renderNoteSVG()}
+
+                <table className="notes-table">
                     <tbody>
                     <tr>
                         <td className="existing-note-date" width="15%">{item.date}</td>
                     </tr>
                     <tr>
                         <td className="existing-note-date" id="existing-note-subject">{item.subject}</td>
-                        </tr>
+                    </tr>
                     <Divider />
                     <tr>
                         <td className="existing-note-metadata" width="55%">
@@ -84,10 +96,23 @@ class NoteAssistant extends Component {
                     </tr>
                     </tbody>
                 </table>
-                {/*<svg width="100" height="100">*/}
-                    {/*<circle cx="50" cy="50" r="40" stroke="green"  fill="yellow" />*/}
-                {/*</svg>*/}
             </Paper>
+        );
+    }
+
+    renderNoteSVG() {
+        return (
+            <svg width="160" height="17">
+                <defs>
+                    <filter id="f1" x="0" y="0" width="200%" height="200%">
+                        <feOffset result="offOut" in="SourceGraphic" dx="20" dy="20"/>
+                        <feBlend in="SourceGraphic" in2="offOut" mode="normal"/>
+                    </filter>
+                </defs>
+                <rect x="144" y="0" rx="2" ry="2" width="17" height="17"
+                      fill="white" stroke="#999" strokeWidth="1" opacity="0.5" filter="url(#f1)"/>
+                <line x1="145" y1="0" x2="200" y2="52" stroke="#999" strokeWidth="1" filter="url(#f1)"/>
+            </svg>
         );
     }
 

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -50,7 +50,7 @@ class NoteAssistant extends Component {
     }
 
     test() {
-        console.log("clicked on new note");
+        console.log("clicked on new note button");
     }
 
     // Render the content for the Note Assistant panel

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -26,7 +26,7 @@ class NotesPanel extends Component {
         } else {
             return (
                 <Row center="xs">
-                    <Col sm={8}>
+                    <Col sm={12}>
                         {this.renderNoteAssistant()}
                     </Col>
                 </Row>

--- a/src/summary/DataSummaryPanel.css
+++ b/src/summary/DataSummaryPanel.css
@@ -14,22 +14,22 @@
     margin-top: 20px;
 }
 
-table.existing-notes td {
-    padding: 20px 10px;
-}
+/*table.existing-notes td {*/
+    /*padding: 20px 10px;*/
+/*}*/
 
-td.existing-note-metadata {
-    color: #333333;
-}
+/*td.existing-note-metadata {*/
+    /*color: #333333;*/
+/*}*/
 
-td.existing-note-date {
-    color: #999;
-}
+/*td.existing-note-date {*/
+    /*color: #999;*/
+/*}*/
 
-td span#existing-note-subject {
-    font-weight: bold;
-    font-size: 1rem;
-}
+/*td span#existing-note-subject {*/
+    /*font-weight: bold;*/
+    /*font-size: 1rem;*/
+/*}*/
 
 /*Explicitly add in top and bottom border for last cell in row because it is removed in the Data Summary Table css*/
 tr.existing-note-entry td:last-child {


### PR DESCRIPTION
Deleting this old branch...

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [ ] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [ ] This pull request describes why these changes were made
- [ ] Recognizes any potential shortcomings/bugs in the description 
- [ ] Cheat sheet is updated
- [ ] Demo script is updated 
- [ ] Documentation on Wiki has been updated 
- [ ] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [ ] Note parser has been updated if structured phrases change

**Code Quality**

- [ ] 4-space indents - convert any tabs to spaces
- [ ] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [ ] Code is commented

**Tests**

- [ ] Existing tests passed
- [ ] Added UI tests for slim mode 
- [ ] Added UI tests for full mode
- [ ] Added backend tests for fluxNotes code
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
