### PR TITLE
Reason for next visit

### DIFF
--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -189,6 +189,11 @@ class PatientRecord {
         });
     }
 
+    getNextEncounterReason() {
+        const nextEncounter = this.getNextEncounter();
+        return nextEncounter.reason;
+    }
+
     getConditions() {
         return this.getEntriesIncludingType(FluxCondition);
     }

--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -191,6 +191,8 @@ class PatientRecord {
 
     getNextEncounterReason() {
         const nextEncounter = this.getNextEncounter();
+        // Tried replacing breast cancer condition text to establish condition context
+        // return nextEncounter.reason.replace('Invasive ductal carcinoma of the breast', '@condition[[Invasive ductal carcinoma of the breast]]');
         return nextEncounter.reason;
     }
 

--- a/src/shortcuts/Shortcuts.json
+++ b/src/shortcuts/Shortcuts.json
@@ -382,5 +382,21 @@
     "isContext": false,
     "stringTriggers": [{"name": "@HPI", "description": "Insert patient's history of present illness"}],
     "knownParentContexts": "ConditionInserter"
+  },
+  {
+    "type": "InsertValue",
+    "id": "ReasonForNextVisitInserter",
+    "getData": {
+      "object": "patient",
+      "method": "getNextEncounterReason"
+    },
+    "isContext": false,
+    "stringTriggers": [
+      {
+        "name": "@reason for next visit",
+        "description": "Insert reason for patient's next visit"
+      }
+    ],
+    "knownParentContexts": "Patient"
   }
 ]

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -30,7 +30,8 @@ class SummaryMetadata {
                                             const nextEncounter = patient.getNextEncounter();
                                             if (Lang.isUndefined(nextEncounter)) return "No upcoming appointments";
                                             return patient.getNextEncounter().reason;
-                                        }
+                                        },
+                                        shortcut: "@reason for next visit"
                                     }
                                 ]
                             }


### PR DESCRIPTION
This PR addresses JIRA-908.

Added @reason for next visit shortcut which pulls the reason into the editor.

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
-  Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
-  Cheat sheet is updated
-  Demo script is updated 
-  Documentation on Wiki has been updated 
-  Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

-  Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
-  Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
-  Added UI tests for slim mode 
-  Added UI tests for full mode
-  Added backend tests for fluxNotes code
-  Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
