### PR TITLE
Add finish and sign button

### DIFF
--- a/src/dashboard/ClinicianDashboard.css
+++ b/src/dashboard/ClinicianDashboard.css
@@ -6,7 +6,7 @@
     overflow-y: scroll;
     overflow-x: hidden;
     text-align: left;
-    /* 106px is the height of the Patient Control Panel, 16px is the height of the top margin of post encounter view content */
+    /* 106px is the height of the Patient Control Panel, 16px is the height of the top margin of post encounter view content*/
     max-height: calc(100vh - 106px - 16px);
     min-height: 400px !important;
 }

--- a/src/panels/NotesPanel.css
+++ b/src/panels/NotesPanel.css
@@ -2,7 +2,7 @@
     position: fixed;
     bottom: 0px;
     width: calc(35vw);
-    /*background-color: #ffffff;*/
+    background-color: #ffffff;
     text-align: left;
     z-index: 5;
     display: flex;

--- a/src/panels/NotesPanel.css
+++ b/src/panels/NotesPanel.css
@@ -2,16 +2,15 @@
     position: fixed;
     bottom: 0px;
     width: calc(35vw);
-    background-color: #ffffff;
-    border-top: 1px solid #d9d9d9 !important;
+    /*background-color: #ffffff;*/
+    /*border-top: 1px solid #d9d9d9 !important;*/
     text-align: left;
-    -webkit-box-shadow: 0px -2px 3px rgba(125, 125, 125, 0.7);
-    -moz-box-shadow: 0px -2px 3px rgba(125, 125, 125, 0.7);
-    box-shadow: 0px -2px 3px rgba(125, 125, 125, 0.7);
+    /*-webkit-box-shadow: 0px -2px 3px rgba(125, 125, 125, 0.7);*/
+    /*-moz-box-shadow: 0px -2px 3px rgba(125, 125, 125, 0.7);*/
+    /*box-shadow: 0px -2px 3px rgba(125, 125, 125, 0.7);*/
     z-index: 5;
     display: flex;
     justify-content: center;
-    overflow-x: hidden;
 }
 
 .btn_finish {
@@ -22,4 +21,9 @@
     margin: 20px 20px 20px 20px;
 }
 
-
+.editor-panel {
+    /* 106px is the height of the Patient Control Panel, 16px is the height of the top margin of post encounter view content, 76px is the height of the sign button */
+    max-height: calc(100vh - 106px - 16px - 76px) !important;
+    /*needed to overwrite min-height set by fitted-panel*/
+    min-height: 0px !important;
+}

--- a/src/panels/NotesPanel.css
+++ b/src/panels/NotesPanel.css
@@ -1,24 +1,25 @@
 #finish-sign-component {
     position: fixed;
     bottom: 0px;
-    /*left: 25vw;*/
-    /*width: calc(75vw - 14px);*/
     width: calc(35vw);
     background-color: #ffffff;
     border-top: 1px solid #d9d9d9 !important;
     text-align: left;
-    -webkit-box-shadow: 0px -2px 3px rgba(125,125,125,0.7);
-    -moz-box-shadow:    0px -2px 3px rgba(125,125,125,0.7);
-    box-shadow:         0px -2px 3px rgba(125,125,125,0.7);
+    -webkit-box-shadow: 0px -2px 3px rgba(125, 125, 125, 0.7);
+    -moz-box-shadow: 0px -2px 3px rgba(125, 125, 125, 0.7);
+    box-shadow: 0px -2px 3px rgba(125, 125, 125, 0.7);
     z-index: 5;
+    display: flex;
+    justify-content: center;
+    overflow-x: hidden;
 }
 
 .btn_finish {
     background-color: #FFFFFF !important;
     text-transform: none !important;
-    display: inline-block;
+    display: inline-block !important;
     min-width: 90% !important;
-    margin: 20px 32px 20px 20px;
-    /*max-width: 50px;*/
-    /*justify-content: flex-start !important;*/
+    margin: 20px 20px 20px 20px;
 }
+
+

--- a/src/panels/NotesPanel.css
+++ b/src/panels/NotesPanel.css
@@ -3,11 +3,7 @@
     bottom: 0px;
     width: calc(35vw);
     /*background-color: #ffffff;*/
-    /*border-top: 1px solid #d9d9d9 !important;*/
     text-align: left;
-    /*-webkit-box-shadow: 0px -2px 3px rgba(125, 125, 125, 0.7);*/
-    /*-moz-box-shadow: 0px -2px 3px rgba(125, 125, 125, 0.7);*/
-    /*box-shadow: 0px -2px 3px rgba(125, 125, 125, 0.7);*/
     z-index: 5;
     display: flex;
     justify-content: center;
@@ -23,7 +19,8 @@
 
 .editor-panel {
     /* 106px is the height of the Patient Control Panel, 16px is the height of the top margin of post encounter view content, 76px is the height of the sign button */
-    max-height: calc(100vh - 106px - 16px - 76px) !important;
-    /*needed to overwrite min-height set by fitted-panel*/
-    min-height: 0px !important;
+    height: calc(100vh - 106px - 16px - 76px) !important;
+    overflow-y: scroll;
+    overflow-x: hidden;
+    text-align: left;
 }

--- a/src/panels/NotesPanel.css
+++ b/src/panels/NotesPanel.css
@@ -1,0 +1,24 @@
+#finish-sign-component {
+    position: fixed;
+    bottom: 0px;
+    /*left: 25vw;*/
+    /*width: calc(75vw - 14px);*/
+    width: calc(35vw);
+    background-color: #ffffff;
+    border-top: 1px solid #d9d9d9 !important;
+    text-align: left;
+    -webkit-box-shadow: 0px -2px 3px rgba(125,125,125,0.7);
+    -moz-box-shadow:    0px -2px 3px rgba(125,125,125,0.7);
+    box-shadow:         0px -2px 3px rgba(125,125,125,0.7);
+    z-index: 5;
+}
+
+.btn_finish {
+    background-color: #FFFFFF !important;
+    text-transform: none !important;
+    display: inline-block;
+    min-width: 90% !important;
+    margin: 20px 32px 20px 20px;
+    /*max-width: 50px;*/
+    /*justify-content: flex-start !important;*/
+}

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -79,24 +79,55 @@ export default class NotesPanel extends Component {
         this.saveNoteChild();
     }
 
-    handleFinishButtonClick() {
+    handleSignButtonClick() {
         console.log("clicked sign button");
+    }
+
+    renderSignButton() {
+        return (
+            <div id="finish-sign-component">
+                <Button raised className="btn_finish" onClick={() => {
+                    this.handleSignButtonClick();
+                }}>
+                    Sign note
+                </Button>
+            </div>
+        );
     }
 
     renderNotesPanelContent() {
         // If isNoteViewerVisible is true, render the flux notes editor and the note assistant
         if (this.props.isNoteViewerVisible) {
-            return (
-                <Row center="xs">
-                    <Col sm={7} md={8} lg={9}>
-                        {this.renderFluxNotesEditor()}
-                    </Col>
 
-                    <Col sm={5} md={4} lg={3}>
-                        {this.renderNoteAssistant()}
-                    </Col>
-                </Row>
-            );
+            // If not viewer is editable, render the sign note button, else don't render sign note button
+            if(this.props.isNoteViewerEditable) {
+                return (
+                    <div>
+                        <Row center="xs">
+                            <Col sm={7} md={8} lg={9}>
+                                {this.renderFluxNotesEditor()}
+                                {this.renderSignButton()}
+                            </Col>
+                            <Col sm={5} md={4} lg={3}>
+                                {this.renderNoteAssistant()}
+                            </Col>
+                        </Row>
+                    </div>
+                );
+            } else {
+                return (
+                    <div>
+                        <Row center="xs">
+                            <Col sm={7} md={8} lg={9}>
+                                {this.renderFluxNotesEditor()}
+                            </Col>
+                            <Col sm={5} md={4} lg={3}>
+                                {this.renderNoteAssistant()}
+                            </Col>
+                        </Row>
+                    </div>
+                );
+            }
 
             // Else just render the note assistant
         } else {
@@ -137,18 +168,7 @@ export default class NotesPanel extends Component {
                     currentViewMode={this.props.currentViewMode}
                     updateSelectedNote={this.updateSelectedNote}
                 />
-                <div id="finish-sign-component">
-                    <Button
-                        raised
-                        className="btn_finish"
-                        onClick={() => {
-                            this.handleFinishButtonClick();
-                        }}
-                    >
-                        Sign note
-                    </Button>
 
-                </div>
             </div>
         );
     }

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -168,7 +168,6 @@ export default class NotesPanel extends Component {
                     currentViewMode={this.props.currentViewMode}
                     updateSelectedNote={this.updateSelectedNote}
                 />
-
             </div>
         );
     }

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -2,6 +2,7 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {Row, Col} from 'react-flexbox-grid';
 import FluxNotesEditor from '../notes/FluxNotesEditor';
+import Button from '../elements/Button';
 import Lang from 'lodash';
 import NoteAssistant from '../notes/NoteAssistant';
 import './NotesPanel.css';
@@ -78,6 +79,10 @@ export default class NotesPanel extends Component {
         this.saveNoteChild();
     }
 
+    handleFinishButtonClick() {
+        console.log("clicked sign button");
+    }
+
     renderNotesPanelContent() {
         // If isNoteViewerVisible is true, render the flux notes editor and the note assistant
         if (this.props.isNoteViewerVisible) {
@@ -132,6 +137,18 @@ export default class NotesPanel extends Component {
                     currentViewMode={this.props.currentViewMode}
                     updateSelectedNote={this.updateSelectedNote}
                 />
+                <div id="finish-sign-component">
+                    <Button
+                        raised
+                        className="btn_finish"
+                        onClick={() => {
+                            this.handleFinishButtonClick();
+                        }}
+                    >
+                        Sign note
+                    </Button>
+
+                </div>
             </div>
         );
     }

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -143,7 +143,7 @@ export default class NotesPanel extends Component {
 
     renderFluxNotesEditor() {
         return (
-            <div className="fitted-panel panel-content dashboard-panel">
+            <div className="fitted-panel panel-content dashboard-panel editor-panel">
                 <FluxNotesEditor
                     onSelectionChange={this.props.handleSelectionChange}
                     newCurrentShortcut={this.props.newCurrentShortcut}

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -143,7 +143,7 @@ export default class NotesPanel extends Component {
 
     renderFluxNotesEditor() {
         return (
-            <div className="fitted-panel panel-content dashboard-panel editor-panel">
+            <div className="panel-content dashboard-panel editor-panel">
                 <FluxNotesEditor
                     onSelectionChange={this.props.handleSelectionChange}
                     newCurrentShortcut={this.props.newCurrentShortcut}

--- a/test/ui/FullApp.js
+++ b/test/ui/FullApp.js
@@ -515,7 +515,7 @@ test('Clicking on an existing note in post encounter mode loads the note in the 
     await t
         .expect(editor.textContent)
         .notEql("Enter your clinical note here or choose a template to start from...");
-})
+});
 
 test('Clicking on a note in the clinical notes view updates the information in the note header', async t =>  {
     const clinicalNotesButton = Selector('#notes-btn');
@@ -534,8 +534,7 @@ test('Clicking on a note in the clinical notes view updates the information in t
     await t
         .expect(noteHeaderName)
         .notEql("Pathology Assessment");
-})
-
+});
 
 test('Clicking on an existing note in post encounter mode puts the NotesPanel in a read only mode with the clinical notes view displayed and the context toggle button disabled', async t => {
     const editor = Selector("div[data-slate-editor='true']");
@@ -601,8 +600,47 @@ test('Clicking on an in-progress note in post encounter mode loads the note in t
     await t
         .expect(editor.textContent)
         .notEql("Enter your clinical note here or choose a template to start from...");
-})
+});
 
+test('Clicking on an existing note hides the sign note button', async t => {
+    const clinicalNotesButton = Selector('#notes-btn');
+    const note = Selector('.existing-note');
+    const signButton = Selector('.btn_finish');
+
+    // Click on the clinical notes button to switch to clinical notes view
+    await t
+        .click(clinicalNotesButton);
+
+    // Click on one of the existing notes
+    await t
+        .click(note)
+
+    // Check that the sign button exists
+    await t
+        .expect(signButton.exists)
+        .notOk()
+});
+
+test('Clicking on an in-progress note shows the sign note button', async t => {
+    const editor = Selector("div[data-slate-editor='true']");
+    const clinicalNotesButton = Selector('#notes-btn');
+    const newNoteButton = Selector('.note-new');
+    const signButton = Selector('.btn_finish');
+
+    // Click on the clinical notes button to switch to clinical notes view
+    await t
+        .click(clinicalNotesButton);
+
+    // Click on the new note button to create an in-progress note and toggle back to clinical notes view
+    await t
+        .click(newNoteButton)
+        .click(clinicalNotesButton);
+
+    // Check that the sign button exists
+    await t
+        .expect(signButton.exists)
+        .ok()
+});
 
 // Verifies automatic saving
 test('Contents of in-progress note saved when switching to a completed note and back', async t => {


### PR DESCRIPTION
This PR address jira 813. 

Added sign note button to the bottom of the text editor. The button only shows up when the editor is in editing mode. When the editor is in read only mode (when an existing note clicked) the button is not rendered. 

Styled the button so that it looks like the mockups and the text does not overflow into the sign button component (thanks @Dtphelan1 for the styling tips).

Added UI tests to check that the sign note button only renders when in an in progress note

Known issues:
- When the browser is resized so that the width and height are small, the editor text flows into the sign button component. 
![image](https://user-images.githubusercontent.com/26877672/35938942-a9a26b94-0c18-11e8-8947-c0917e71e8e0.png)
A jira issue was added for this: https://jira.mitre.org/browse/ASCODCP-930

- It would be ideal for users to have to scroll to the bottom of an in progress note before the sign button is displayed, forcing users to verify the note content before signing it. This is not currently implemented. A jira issue was added for this: https://jira.mitre.org/browse/ASCODCP-931

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- N/A Cheat sheet is updated
- N/A Demo script is updated 
- N/A Documentation on Wiki has been updated 
- N/A Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- N/A Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- N/A Added UI tests for slim mode 
- [x] Added UI tests for full mode
- N/A Added backend tests for fluxNotes code
- N/A Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
