### PR TITLE
Default visualizer

### DIFF
--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -283,6 +283,7 @@ class SummaryMetadata {
                     {
                         name: "Medications",
                         clinicalEvents: ["pre-encounter"],
+                        defaultVisualizer: "chart",
                         type: "Medications",
                         data: [
                             {

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -3,6 +3,34 @@ import FluxTumorDimensions from '../model/oncology/FluxTumorDimensions';
 import Lang from 'lodash'
 import moment from 'moment';
 
+/*
+  Each section has the following properties:
+    name                Displayed at the top of the section and in the mini-map
+    type                Dictates the format of the data section described later. Visualizers are implemented to support specific data types.
+    narrative           This section is only used if the section will be displayed using a narrative visualizer. It provides templates for turning the
+                        data into sentences.
+    data                Provides the retrieval of the source data to be displayed in the section in the format dictated by the type property above. The
+                        data is a list of subsections which each have the following possible properties:
+                          name          The name of the subsection. Some visualizers display the subsection names.
+                          items         The list of data items in the format dictated by the type
+                          itemsFunction A function that returns the list of data items in the format dictated by the type
+                          headings      Indicates the a set of column heading labels for tabular visualizers
+                          shortcut      Indicates a shortcut name to use for the first column of insertable data.
+                          code          Indicates a code to be used by an itemsFunction. This allows multiple sections to share the same itemsFunction
+                          bands         Indicates a set of value ranges and the assessment for that range. Some visualizers display bands
+    defaultVisualizer   Indicates the visualizer type for the default visualizer to use for the section. The following ways to specify the default are
+                        supported:
+                            "tabular"                                               The specified visualizer type will be the default visualizer 
+                                                                                    for the section if supported by the data type.
+                            {clinicalEvent: X, defaultVisualizer: Y}                The specified visualizer type Y will be used if the current 
+                                                                                    clinical event is X otherwise the first visualizer registered 
+                                                                                    for the data type will be used.
+                            ["X", {clinicalEvent: Y, defaultVisualizer: Z}, ...]    A list of options allowing an overall default X that is used 
+                                                                                    if one of the specific clinical events (e.g. Y) doesn't match 
+                                                                                    the currently selected one. If a specific one matches, it uses
+                                                                                    the corresponding default visualizer (e.g. Z)
+*/
+
 class SummaryMetadata {
     constructor() {
         this.hardCodedMetadata = {
@@ -505,6 +533,7 @@ class SummaryMetadata {
                     {
                         name: "Medications",
                         clinicalEvents: ["pre-encounter"],
+                        defaultVisualizer: "chart",
                         type: "Columns",
                         data: [
                             {

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -196,7 +196,7 @@ class SummaryMetadata {
                         ]
                     },
                     {
-                        name: "Active Conditions",
+                        name: "Conditions",
                         type: "Columns",
                         notFiltered: true,
                         data: [
@@ -545,7 +545,7 @@ class SummaryMetadata {
                         ]
                     },
                     {
-                        name: "Active Conditions",
+                        name: "Conditions",
                         type: "Columns",
                         notFiltered: true,
                         data: [

--- a/src/summary/TargetedDataSection.jsx
+++ b/src/summary/TargetedDataSection.jsx
@@ -10,22 +10,33 @@ export default class TargetedDataSection extends Component {
         super(props);
 
         const optionsForSection = this.getOptions(props.section);
-        const defaultOrTabular = optionsForSection.length > 0 ? optionsForSection[0] : 'tabular';
+        const defaultVisualizer = this.determineDefaultVisualizer(props.section, optionsForSection);
+        //const defaultOrTabular = optionsForSection.length > 0 ? optionsForSection[0] : 'tabular';
 
-        // this.state.defaultVisualizer is the first possible visualization, this.state.chosenVisualizer changes when icons are clicked
+        // this.state.defaultVisualizer is the default visualization, this.state.chosenVisualizer changes when icons are clicked
         this.state = {
-            defaultVisualizer: defaultOrTabular,
+            defaultVisualizer: defaultVisualizer,
             chosenVisualizer: null
         };
     }
-
+    
     componentDidUpdate() {
         const optionsForSection = this.getOptions(this.props.section);
-        const defaultOrTabular = optionsForSection.length > 0 ? optionsForSection[0] : 'tabular';
-        if (this.state.defaultVisualizer !== defaultOrTabular ||
+        const defaultVisualizer = this.determineDefaultVisualizer(this.props.section, optionsForSection);
+        //const defaultOrTabular = optionsForSection.length > 0 ? optionsForSection[0] : 'tabular';
+        if (this.state.defaultVisualizer !== defaultVisualizer ||
             (this.state.chosenVisualizer !== null && !optionsForSection.includes(this.state.chosenVisualizer))) {
-            this.setState({defaultVisualizer: defaultOrTabular, chosenVisualizer: null});
+            this.setState({defaultVisualizer: defaultVisualizer, chosenVisualizer: null});
         }
+    }
+
+    determineDefaultVisualizer = (section, optionsForSection) => {
+        if (optionsForSection.length === 0) return 'tabular';
+        if (section.defaultVisualizer && optionsForSection.includes(section.defaultVisualizer)) {
+            console.log('explicit default for ' + section.name);
+            return section.defaultVisualizer;
+        }
+        return optionsForSection[0];
     }
 
     handleViewChange = (chosenVisualizer) => {
@@ -123,7 +134,7 @@ export default class TargetedDataSection extends Component {
                     {this.renderVisualizationOptions(visualizationOptions)}
                 </h2>
 
-                {encounterView && <div className="section-header__condition encounter">{selectedCondition}</div>}
+                {encounterView && !notFiltered && <div className="section-header__condition encounter">{selectedCondition}</div>}
 
                 {this.renderSection(section)}
             </div>

--- a/src/summary/VisualizerManager.jsx
+++ b/src/summary/VisualizerManager.jsx
@@ -66,8 +66,8 @@ class VisualizerManager {
                     { "dataType": "NameValuePairs", "visualizerType": "tabular", "visualizer": TabularListVisualizer, "transform": this.transformNameValuePairToColumns },
                     { "dataType": "NameValuePairs", "visualizerType": "narrative", "visualizer": NarrativeNameValuePairsVisualizer },
                     { "dataType": "Events", "visualizerType": "timeline", "visualizer": TimelineEventsVisualizer },
-                    { "dataType": "Medications", "visualizerType": "chart", "visualizer": MedicationRangeChartVisualizer },
                     { "dataType": "Medications", "visualizerType": "tabular", "visualizer": TabularListVisualizer, "transform": this.transformMedicationsToColumns },
+                    { "dataType": "Medications", "visualizerType": "chart", "visualizer": MedicationRangeChartVisualizer },
                     { "dataType": "ValueOverTime", "visualizerType": "chart", "visualizer": BandedLineChartVisualizer },
                     { "dataType": "NarrativeOnly", "visualizerType": "narrative", "visualizer": NarrativeNameValuePairsVisualizer },
                     { "dataType": "DiseaseStatusValues", "visualizerType": "chart", "visualizer": ProgressionLineChartVisualizer }

--- a/test/backend/views/FullApp.test.js
+++ b/test/backend/views/FullApp.test.js
@@ -89,3 +89,22 @@ describe('TargetedDataControl', function() {
             .to.eq('narrative');
     });
 });
+describe('TargetedDataControl - correct default visualizer Medications', function() {
+    it('correct default visualizer', function() {
+        const summaryMetadata = new SummaryMetadata();
+        // Look for the first NameValuePair section which should be Summary. Assumes it does not have a defaultVisualizer property
+        const section = summaryMetadata.hardCodedMetadata["http://snomed.info/sct/408643008"].sections.find((section) => {
+            return (section.type === "Medications");
+        });
+        const expectedDefault = 'chart';
+
+        const visualizerManager = new VisualizerManager()
+        const wrapper = shallow(<TargetedDataSection section={section} type={section.type} visualizerManager={visualizerManager} isWide={false} clinicalEvent='pre-encounter'/>);
+
+        // Initial state
+        expect(wrapper.state('defaultVisualizer'))
+            .to.eq(expectedDefault);
+        expect(wrapper.state('chosenVisualizer'))
+            .to.be.null;
+    });
+});

--- a/test/backend/views/FullApp.test.js
+++ b/test/backend/views/FullApp.test.js
@@ -15,7 +15,7 @@ Enzyme.configure({ adapter: new Adapter() });
 
 describe('UpdateErrors', function () {
     it('should set state.errors to equal the provided argument', function () {
-        const wrapper = shallow(<FullApp />);
+        const wrapper = shallow(<FullApp display='test' />);
         const emptyErrors = [];
         wrapper.instance().updateErrors(emptyErrors);
         expect(wrapper.state('errors'))
@@ -31,7 +31,7 @@ describe('UpdateErrors', function () {
 
 describe('setFullAppState', function() {
     it('sets the state on the component', function() {
-        const wrapper = shallow(<FullApp />);
+        const wrapper = shallow(<FullApp display='test'/>);
 
         wrapper.instance().setFullAppState('testKey', 'testValue');
         expect(wrapper.state('testKey'))
@@ -58,8 +58,10 @@ describe('setFullAppState', function() {
 describe('TargetedDataControl', function() {
     it('noteDisplayMode buttons update state', function() {
         const summaryMetadata = new SummaryMetadata();
-        // Top item is Reason for Visit which has no buttons, so look at second item Summary which is .sections[1]
-        const section = summaryMetadata.hardCodedMetadata["http://snomed.info/sct/408643008"].sections[1];
+        // Look for the first NameValuePair section which should be Summary. Assumes it does not have a defaultVisualizer property
+        const section = summaryMetadata.hardCodedMetadata["http://snomed.info/sct/408643008"].sections.find((section) => {
+            return (section.type === "NameValuePairs");
+        });
         let options = [];
         if (section.type === "NameValuePairs") {
             options.push('tabular');
@@ -72,7 +74,7 @@ describe('TargetedDataControl', function() {
         const defaultOrTabular = options.length > 0 ? options[0] : 'tabular';
 
         const visualizerManager = new VisualizerManager()
-        const wrapper = shallow(<TargetedDataSection section={section} type={section.type} visualizerManager={visualizerManager} />);
+        const wrapper = shallow(<TargetedDataSection section={section} type={section.type} visualizerManager={visualizerManager} isWide={false} clinicalEvent='post-encounter'/>);
 
         // Initial state
         expect(wrapper.state('defaultVisualizer'))


### PR DESCRIPTION
JIRA 848. Default visualizer can be specified in each summary section by visualizer type (e.g., chart or tabular or narrative, etc.). Defaults specific to workflow/clinical event can also be done.

Added documentation of summary format to top of SummaryMetadata.jsx including defaultVisualizer.

Added a backend test that verifies the default visualizer for medications in pre-encounter is chart.

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [ ] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [ ] This pull request describes why these changes were made
- [ ] Recognizes any potential shortcomings/bugs in the description 
- [ ] Cheat sheet is updated
- [ ] Demo script is updated 
- [ ] Documentation on Wiki has been updated 
- [ ] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [ ] Note parser has been updated if structured phrases change

**Code Quality**

- [ ] 4-space indents - convert any tabs to spaces
- [ ] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [ ] Code is commented

**Tests**

- [ ] Existing tests passed
- [ ] Added UI tests for slim mode 
- [ ] Added UI tests for full mode
- [ ] Added backend tests for fluxNotes code
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
