### PR TITLE
Fix bugs related to templates and using the enter key.

### DIFF
--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -338,8 +338,8 @@ class FluxNotesEditor extends React.Component {
     }
 
     onChange = (state) => {
-        let indexOfLastNode = state.toJSON().document.nodes["0"].nodes.length - 1;
-        let endOfNoteKey = state.toJSON().document.nodes["0"].nodes[indexOfLastNode].key;
+        let indexOfLastNode = state.toJSON().document.nodes.length - 1;
+        let endOfNoteKey = state.toJSON().document.nodes[indexOfLastNode].key;
         let endOfNoteOffset = 0;
         // If the editor has no structured phrases, use the number of characters in the first 'node'
         if(Lang.isEqual(indexOfLastNode, 0)){
@@ -460,7 +460,15 @@ class FluxNotesEditor extends React.Component {
     }
 
     insertPlainText = (transform, text) => {
-        let returnIndex = text.indexOf("\r");
+        // Check for \r\n, \r, or \n to insert a new line in Slate
+        let returnIndex = text.indexOf("\r\n");
+        if (returnIndex === -1) {
+            returnIndex = text.indexOf("\r");
+        }
+        if (returnIndex === -1) {
+            returnIndex = text.indexOf("\n");
+        }
+        
         if (returnIndex >= 0) {
             let result = this.insertPlainText(transform, text.substring(0, returnIndex));
             result = this.insertNewLine(result);


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

Our new template was being entered into Slate as one block. This is because we were creating new blocks in slate when we saw a \r character, but our template has \n characters. We now check for \r\n, \r, and \n. 

We also were not determining the end of the editor content correctly, which only became apparent now that we have a longer note. I changed the way we are looking for the end of the note, allowing the full note to be saved and then reloaded.

These two changes fixed a few bugs identified recently.
- Jira 913. This was fixed by both of these changes. The template was only inserting one block of text, and using the enter key in the template created a new block, which we were not saving. The template is now inserting a new block each time there is a new paragraph, which is what happens when you type. The end of the note is correctly determined, so the full text is saved. Adding text using the enter key in the middle of the note still allows the editor to find the end of the note and save new text in the middle.
- Two of the three bugs I listed in my last PR:
    - Inserting a structured phrase at the bottom of the progress note template now correctly positions the portal. This was not working before since the blocks in the template were off and it could not determine the correct positioning. Note, until this is rebased with the last PR, the portal will still open down, but the left positioning is correct now.
    - Inserting a structured phrase in the middle of the template now opens the portal, as expected. I think this was also fixed when the template insertion was fixed to include multiple blocks.

If anyone finds any other bugs they think should be addressed in this PR, let me know. Also if you find any cases where these bugs were not fixed, let me know too!


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
-  Cheat sheet is updated
-  Demo script is updated 
-  Documentation on Wiki has been updated 
-  Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

-  Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- [ ] Added UI tests for slim mode 
- [ ] Added UI tests for full mode
- [ ] Added backend tests for fluxNotes code
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
