### PR TITLE
Multi line suggestion bug

### DIFF
--- a/src/context/ContextPortal.css
+++ b/src/context/ContextPortal.css
@@ -8,6 +8,9 @@
     background-color: rgb(255, 255, 255);
     margin-top: 30px;
     z-index: 1111;
+}
+
+.scrollable {
     max-height: 212px; /* 6 list elements at 32px each, plus 10px of margin on top and bottom */
     overflow-y: auto;
 }

--- a/src/context/ContextPortal.jsx
+++ b/src/context/ContextPortal.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import Portal from 'react-portal'
 import Calendar from 'rc-calendar';
 import ContextItem from './ContextItem'
-import position from '../lib/slate-suggestions-dist/caret-position';
 import Lang from 'lodash'
 import './ContextPortal.css';
 import 'rc-calendar/assets/index.css';
@@ -121,7 +120,7 @@ class ContextPortal extends React.Component {
     adjustPosition = () => {
         const { menu } = this.state
         if (!menu || !menu.style) return;
-        const rect = position();
+        const rect = this.props.getPosition();
 
         if (!rect) {
             // TODO: No positioning to use. Removing style may not be correct.

--- a/src/context/ContextPortal.jsx
+++ b/src/context/ContextPortal.jsx
@@ -201,10 +201,12 @@ class ContextPortal extends React.Component {
         const TYPE_CALENDAR = 1;
         const { contexts } = this.props;
         let type;
+        let className = "context-portal";
         if (Lang.isNull(contexts)) return null;
         
         if (Lang.isArray(contexts)) {
             type = TYPE_LIST;
+            className += " scrollable";
         } else if (contexts === "date-id") {
             type = TYPE_CALENDAR;
         } else {
@@ -219,7 +221,7 @@ class ContextPortal extends React.Component {
                 onOpen={this.onOpen} 
                 onClose={this.onClose}
             >
-                <div className="context-portal" ref="contextPortal">
+                <div className={className} ref="contextPortal">
                     {type === TYPE_CALENDAR ? this.renderCalendar() : this.renderListOptions()}
                 </div>
             </Portal>

--- a/src/context/ContextPortal.jsx
+++ b/src/context/ContextPortal.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Portal from 'react-portal'
 import Calendar from 'rc-calendar';
 import ContextItem from './ContextItem'
+import position from '../lib/slate-suggestions-dist/caret-position';
 import Lang from 'lodash'
 import './ContextPortal.css';
 import 'rc-calendar/assets/index.css';
@@ -120,19 +121,26 @@ class ContextPortal extends React.Component {
     adjustPosition = () => {
         const { menu } = this.state
         if (!menu || !menu.style) return;
+        const rect = position();
 
-        menu.style.position = 'absolute';
-        menu.style.width = 300;
-        menu.style.background = '#fff';
-        menu.style.padding = 10;
-        menu.style.display = 'block';
-        menu.style.opacity = 1;
-        if (window.innerHeight - this.props.top < 230) {
-            menu.style.bottom = `${window.innerHeight - this.props.top - window.pageYOffset}px`;
-            menu.style.left = `${this.props.left + window.pageXOffset + 10}px`;
+        if (!rect) {
+            // TODO: No positioning to use. Removing style may not be correct.
+            menu.removeAttribute('style');
+            menu.style.display = 'none'
         } else {
-            menu.style.top = `${this.props.top + window.pageYOffset}px`;
-            menu.style.left = `${this.props.left + window.pageXOffset}px`;
+            menu.style.position = 'absolute';
+            menu.style.width = 300;
+            menu.style.background = '#fff';
+            menu.style.padding = 10;
+            menu.style.display = 'block';
+            menu.style.opacity = 1;
+            if (window.innerHeight - rect.top < 230) {
+                menu.style.bottom = `${window.innerHeight - rect.top - window.pageYOffset}px`;
+                menu.style.left = `${rect.left + window.pageXOffset + 10}px`;
+            } else {
+                menu.style.top = `${rect.top + window.pageYOffset}px`;
+                menu.style.left = `${rect.left + window.pageXOffset}px`;
+            }
         }
     }
     /*

--- a/src/lib/slate-suggestions-dist/caret-position.js
+++ b/src/lib/slate-suggestions-dist/caret-position.js
@@ -1,19 +1,57 @@
 // Acquire from http://jsfiddle.net/gliheng/vbucs/12/
-function position(domElement, offsetx, offsety) {
-  offsetx = offsetx || 0
-  offsety = offsety || 0
+function position($node, offsetx, offsety) {
+    offsetx = offsetx || 0
+    offsety = offsety || 0
 
-  const pos = { left: 0, top: 0 }
-  const children = domElement.childNodes;
+    let nodeLeft = 0
+    let nodeTop = 0
+    if ($node) {
+        nodeLeft = $node.offsetLeft
+        nodeTop = $node.offsetTop
+    }
 
-  for(const child of children) { 
-      if (child.getBoundingClientRect && child.getAttribute("data-key")) { 
-          const rect = child.getBoundingClientRect();
-          pos.left = rect.left + rect.width + offsetx;
-          pos.top = rect.top + offsety;
-      }
-  }
-  return pos
+    const pos = { left: 0, top: 0 }
+
+    if (document.selection) {
+        const range = document.selection.createRange()
+        pos.left = range.offsetLeft + offsetx - nodeLeft
+        pos.top = range.offsetTop + offsety - nodeTop
+    } else if (window.getSelection) {
+        const sel = window.getSelection()
+        if (sel.rangeCount === 0) return null
+        const range = sel.getRangeAt(0).cloneRange()
+
+        try {
+            range.setStart(range.startContainer, range.startOffset - 1)
+        } catch (e) {}
+
+        const rect = range.getBoundingClientRect()
+
+        if (range.endOffset === 0 || range.toString() === '') {
+            // first char of line
+            if (range.startContainer === $node) {
+                // empty div
+                if (range.endOffset === 0) {
+                    pos.top = 0
+                    pos.left = 0
+                } else {
+                    // firefox need this
+                    const range2 = range.cloneRange()
+                    range2.setStart(range2.startContainer, 0)
+                    const rect2 = range2.getBoundingClientRect()
+                    pos.left = rect2.left + offsetx - nodeLeft
+                    pos.top = rect2.top + rect2.height + offsety - nodeTop
+                }
+            } else {
+                pos.top = range.startContainer.offsetTop
+                pos.left = range.startContainer.offsetLeft
+            }
+        } else {
+            pos.left = rect.left + rect.width + offsetx - nodeLeft
+            pos.top = rect.top + offsety - nodeTop
+        }
+    }
+    return pos
 };
 
 export default position

--- a/src/lib/slate-suggestions-dist/current-word.js
+++ b/src/lib/slate-suggestions-dist/current-word.js
@@ -1,12 +1,6 @@
-function getCurrentWord(text, index, initialIndex) {
-  if (text[index] === undefined) return "";
-  if (index < initialIndex) {
-    return getCurrentWord(text, index - 1, initialIndex) + text[index]
-  }
-  if (index > initialIndex) {
-    return text[index] + getCurrentWord(text, index + 1, initialIndex)
-  }
-  return getCurrentWord(text, index - 1, initialIndex) + text[index] + getCurrentWord(text, index + 1, initialIndex)
+function getCurrentWord(text, index, trigger) {
+    const startIndex = text.lastIndexOf(trigger, index + 1)
+    return text.substring(startIndex, index + 1)
 }
 
 export default getCurrentWord

--- a/src/lib/slate-suggestions-dist/index.js
+++ b/src/lib/slate-suggestions-dist/index.js
@@ -41,7 +41,7 @@ function SuggestionsPlugin(opts) {
         }
       } else {
         if (callback.onKeyDown) {
-          callback.onKeyDown(keyCode, data)
+          callback.onKeyDown(keyCode, data);
         }
       }
     }

--- a/src/lib/slate-suggestions-dist/index.js
+++ b/src/lib/slate-suggestions-dist/index.js
@@ -1,61 +1,69 @@
 import React from 'react'
 import Portal from './suggestion-portal'
 import {
-  UP_ARROW_KEY,
-  DOWN_ARROW_KEY,
-  ENTER_KEY
+    UP_ARROW_KEY,
+    DOWN_ARROW_KEY,
+    ENTER_KEY
 } from './constants'
 
 function matchTrigger(state, trigger) {
-  const currentNode = state.blocks.first()
+    const currentNode = state.blocks.first()
 
-  return state.isFocused && trigger.test(currentNode.text)
+    return state.isFocused && trigger.test(currentNode.text)
 }
 
 function SuggestionsPlugin(opts) {
-  const capture = opts.capture
-  const callback = {}
+    const capture = opts.capture
+    const callback = {}
 
-  function onKeyDown(e, data, state, editor) {
-    const keyCode = e.keyCode
-    callback.editor = editor
+    function onKeyDown(e, data, state, editor) {
+        const keyCode = e.keyCode
+        callback.editor = editor
 
-    if (matchTrigger(state, capture)) {
-      // Prevent default up and down arrow key press when portal is open
-      if ((keyCode === UP_ARROW_KEY || keyCode === DOWN_ARROW_KEY)) {
-        e.preventDefault()
-      }
+        if (matchTrigger(state, capture)) {
+            // Prevent default up and down arrow key press when portal is open
+            if ((keyCode === UP_ARROW_KEY || keyCode === DOWN_ARROW_KEY)) {
+                e.preventDefault()
+            }
 
-      // Prevent default return/enter key press when portal is open
-      if (keyCode === ENTER_KEY) {
-        e.preventDefault()
+            // Prevent default return/enter key press when portal is open
+            if (keyCode === ENTER_KEY) {
+                e.preventDefault()
+                // Handle enter
+                if (callback.onEnter && callback.suggestion !== undefined) {
+                    const newEditorState =  callback.onEnter(callback.suggestion)
 
-        // Close portal
-        if (callback.closePortal) {
-          callback.closePortal()
+                    // Close portal -- resets suggestion to default, so must be done after onEnter
+                    if (callback.closePortal) {
+                        callback.closePortal()
+                    }
+                    return newEditorState
+                } else { 
+                    // Close portal
+                    if (callback.closePortal) {
+                        callback.closePortal()
+                    }
+                }
+            } else {
+                if (callback.onKeyDown) {
+                    callback.onKeyDown(keyCode, data);
+                }
+            }
         }
-
-        // Handle enter
-        if (callback.onEnter && callback.suggestion !== undefined) {
-          return callback.onEnter(callback.suggestion)
-        }
-      } else {
-        if (callback.onKeyDown) {
-          callback.onKeyDown(keyCode, data);
-        }
-      }
     }
-  }
 
-  return {
-    onKeyDown,
-    SuggestionPortal: (props) =>
-      <Portal
-        {...props}
-        {...opts}
-        callback={callback}
-      />
-  }
+    return {
+        onKeyDown,
+        SuggestionPortal: (props) => {
+            return (
+                <Portal
+                    {...props}
+                    {...opts}
+                    callback={callback}
+                />
+            );
+        }
+    }
 }
 
 export default SuggestionsPlugin

--- a/src/lib/slate-suggestions-dist/suggestion-item.js
+++ b/src/lib/slate-suggestions-dist/suggestion-item.js
@@ -2,27 +2,31 @@ import React from 'react'
 
 class SuggestionItem extends React.Component {
 
-  onClick = (e) => {
-    this.props.closePortal()
+    onClick = (e) => {
+        this.props.closePortal()
 
-    const { editor, suggestion, appendSuggestion } = this.props
+        const { editor, suggestion, appendSuggestion } = this.props
 
-    const state = appendSuggestion(suggestion)
+        const state = appendSuggestion(suggestion)
 
-    editor.onChange(state)
-  }
+        editor.onChange(state)
+    }
 
-  onMouseEnter = () =>
-    this.props.setSelectedIndex(this.props.index)
+    onMouseEnter = () => {
+        this.props.setSelectedIndex(this.props.index)
+    }
 
-  render = () =>
-    <li
-      className={this.props.index === this.props.selectedIndex ? 'selected' : undefined}
-      onClick={this.onClick}
-      onMouseEnter={this.onMouseEnter}
-    >
-      {this.props.suggestion.suggestion}
-    </li>
+    render = () => {
+        return (
+            <li
+                className={this.props.index === this.props.selectedIndex ? 'selected' : undefined}
+                onClick={this.onClick}
+                onMouseEnter={this.onMouseEnter}
+            >
+                {this.props.suggestion.suggestion}
+            </li>
+        );
+    }
 }
 
 export default SuggestionItem

--- a/src/lib/slate-suggestions-dist/suggestion-portal.js
+++ b/src/lib/slate-suggestions-dist/suggestion-portal.js
@@ -252,6 +252,7 @@ class SuggestionPortal extends React.Component {
             const rect = position()
             if (!rect) { 
                 menu.removeAttribute('style');
+                menu.style.display = 'none'
             } else { 
                 menu.style.display = 'block'
                 menu.style.opacity = 1
@@ -271,6 +272,8 @@ class SuggestionPortal extends React.Component {
     // Closes portal
     closePortal = () => {
         const { menu } = this.state;
+        console.log('----- closing portal')
+        console.log(menu)
         // No menu to close: return
         if (!menu) return;
 

--- a/src/lib/slate-suggestions-dist/suggestion-portal.js
+++ b/src/lib/slate-suggestions-dist/suggestion-portal.js
@@ -1,12 +1,12 @@
 import React from 'react'
 import Portal from 'react-portal'
-import Slate from '../slate'
 import position from './caret-position'
 import SuggestionItem from './suggestion-item'
 import getCurrentWord from './current-word'
 import {
   UP_ARROW_KEY,
   DOWN_ARROW_KEY,
+  ENTER_KEY,
   RESULT_SIZE,
 } from './constants'
 

--- a/src/lib/slate-suggestions-dist/suggestion-portal.js
+++ b/src/lib/slate-suggestions-dist/suggestion-portal.js
@@ -5,270 +5,250 @@ import position from './caret-position'
 import SuggestionItem from './suggestion-item'
 import getCurrentWord from './current-word'
 import {
-  UP_ARROW_KEY,
-  DOWN_ARROW_KEY,
-  RESULT_SIZE,
+    UP_ARROW_KEY,
+    DOWN_ARROW_KEY,
+    RESULT_SIZE,
 } from './constants'
 
 class SuggestionPortal extends React.Component {
 
-  componentDidMount = () => {
-    this.adjustPosition()
-  }
-
-  componentDidUpdate = () => {
-    this.adjustPosition()
-  }
-
-  constructor(props) {
-    super()
-    props.callback.onKeyDown = this.onKeyDown
-    props.callback.onEnter = props.onEnter
-    props.callback.closePortal = this.closePortal
-    props.callback.readOnly = false
-
-    this.state = {
-      selectedIndex: 0,
+    componentDidMount = () => {
+        this.adjustPosition()
     }
 
-    if (typeof props.suggestions === 'function') {
-      props.callback.suggestion = undefined
-    } else {
-      const filteredSuggestions = props.suggestions.slice(0, props.resultSize ? props.resultSize : RESULT_SIZE)
-      props.callback.suggestion = filteredSuggestions[this.state.selectedIndex]
-    }
-  }
-
-  onOpen = (portal) => {
-    this.setState({
-      menu: portal.firstChild 
-    });
-  }
-
-  setCallbackSuggestion = (filteredSuggestions, selectedIndex=0) => {
-    if (filteredSuggestions.length) {
-      this.props.callback.suggestion = filteredSuggestions[selectedIndex]
-    } else {
-      this.props.callback.suggestion = undefined
-    }
-  }
-
-  onKeyDown = (keyCode, data) => {
-    if (keyCode === DOWN_ARROW_KEY || keyCode === UP_ARROW_KEY) {
-        const height = this.refs.suggestionPortal.offsetHeight;
-        const numberOfElementsVisible = Math.floor(height/32);
-        const filteredSuggestions  = this.getFilteredSuggestions();
-        const positionChange = (keyCode === DOWN_ARROW_KEY) ? +1 : -1; 
-        const newIndex = this.getMenuPostion(positionChange);
-        this.changeMenuPosition(positionChange)
-        this.setCallbackSuggestion(filteredSuggestions, newIndex);
-        // newIndex - (numberOfElementsVisible - 1) forces the scrolling to happen once your reach the bottom of the list in view.
-        // 32 is the height of each suggestion in the list, 10 allows for the margin
-        this.refs.suggestionPortal.scrollTop = (newIndex - (numberOfElementsVisible - 1)) * 32 + 10;
-    } else {
-      const filteredSuggestions  = this.getFilteredSuggestions(data);
-      this.setSelectedIndex(0)
-      if (typeof filteredSuggestions.then === 'function') {
-        filteredSuggestions.then(filteredSuggestions => {
-          this.setCallbackSuggestion(filteredSuggestions, 0)
-        }).catch(() => {
-          this.setCallbackSuggestion([], 0)
-        })
-      } else {
-        this.setCallbackSuggestion(filteredSuggestions, 0)
-      }
-    }
-  }
-
-  getMenuPostion = (change) => { 
-    // this will allow wrap around to the end of the list
-    const filteredSuggestions  = this.getFilteredSuggestions();
-    if(filteredSuggestions.length === 0) { 
-      return 0;
-    } else { 
-      const changePlusOriginalLength = change + filteredSuggestions.length;
-      const changeAfterWrapping = (this.state.selectedIndex + changePlusOriginalLength) % filteredSuggestions.length;      
-      return changeAfterWrapping;
-    }
-  }
-
-  changeMenuPosition = (change) => { 
-    const changeAfterWrapping = this.getMenuPostion(change);
-    this.setState({ 
-        selectedIndex: changeAfterWrapping
-    })
-  }
-
-  matchTrigger = () => {
-    const { state, trigger, startOfParagraph } = this.props
-
-    const stateCondition = state.isFocused && !state.isExpanded
-
-    if (!state.selection.anchorKey) return false
-
-    const { anchorText, anchorOffset } = state
-
-    if (startOfParagraph) {
-      return stateCondition && anchorText.text === trigger
+    componentDidUpdate = () => {
+        this.adjustPosition()
     }
 
-    const lastChar = anchorText.text[anchorOffset - 1]
+      constructor(props) {
+        super()
+        props.callback.onKeyDown = this.onKeyDown
+        props.callback.onEnter = props.onEnter
+        props.callback.closePortal = this.closePortal
+        props.callback.readOnly = false
 
-    return stateCondition && lastChar && lastChar === trigger
-  }
-
-  matchCapture = () => {
-    const { state, capture } = this.props
-
-    if (!state.selection.anchorKey) return ''
-
-    const { anchorText, anchorOffset } = state
-
-    const currentWord = getCurrentWord(anchorText.text, anchorOffset - 1, anchorOffset - 1)
-
-    const text = this.getMatchText(currentWord, capture)
-
-    return text
-  }
-
-  getMatchText = (text, trigger) => {
-    const matchArr = text.match(trigger)
-
-    if (matchArr) {
-      return matchArr[1].toLowerCase()
-    }
-
-    return undefined
-  }
-
-  getFilteredSuggestions = (incomingData) => {
-    const { suggestions, state, capture, resultSize } = this.props
-
-    if (!state.selection.anchorKey) return []
-
-    const { anchorText, anchorOffset } = state
-
-    let nextChar = "";
-    // If there is incoming data from a keydown, include that as next char
-    if (incomingData !== undefined) { 
-      nextChar = this.convertSlateDataObjectToCharacter(incomingData);
-      if (nextChar == null) return [];
-    }
-    const currentWord = getCurrentWord(anchorText.text + nextChar, anchorOffset - 1, anchorOffset - 1);//GQ added +nextChar
-
-    const text = this.getMatchText(currentWord, capture)
-
-    if (typeof suggestions === 'function') {
-      return suggestions(text)
-    } else {
-      return suggestions
-        .filter(suggestion => suggestion.key.toLowerCase().indexOf(text) !== -1)
-        .slice(0, resultSize ? resultSize : RESULT_SIZE)
-    }
-  }
-
-  convertSlateDataObjectToCharacter = (data) => {
-    const code = data.code;
-    const isShift = data.isShift;
-    if (code < 48) return null;
-    if (code < 58) { // number keys
-        if (isShift) {
-            if (code === 48) return ")";
-            if (code === 49) return "!";
-            if (code === 50) return "@";
-            if (code === 51) return "#";
-            if (code === 52) return "$";
-            if (code === 53) return "%";
-            if (code === 54) return "^";
-            if (code === 55) return "&";
-            if (code === 56) return "*";
-            if (code === 57) return "(";
+        this.state = {
+            selectedIndex: 0,
         }
-        return String.fromCharCode(code);
-    }
-    if (code >= 65 && code <= 90) { // A-Z, a-z
-        if (isShift) return String.fromCharCode(code);
-        return String.fromCharCode(code + 32);
-    }
-    if (code >= 96 && code <= 105) return String.fromCharCode(code - 48); // numpad 0-9
-    if (code === 187 && !isShift) return "=";
-    if (code === 188 && !isShift) return ",";
-    if (code === 189 && !isShift) return '-';
-    if (code === 190 && !isShift) return ".";
-    if (code === 191 && !isShift) return "/";
-    if (code === 187 && isShift) return "+";
-    if (code === 188 && isShift) return "<";
-    if (code === 189 && isShift) return '_';
-    if (code === 190 && isShift) return ">";
-    if (code === 191 && isShift) return "?";
-    return null;
-  }
 
-  adjustPosition = () => {
-    const { menu } = this.state
-    if (!menu) return
+        if (typeof props.suggestions === 'function') {
+            props.callback.suggestion = undefined
+        } else {
+            const filteredSuggestions = props.suggestions.slice(0, props.resultSize ? props.resultSize : RESULT_SIZE)
+            props.callback.suggestion = filteredSuggestions[this.state.selectedIndex]
+            }
+        }
 
-    const match = this.matchCapture();
-    if (match === undefined) {
-      menu.removeAttribute('style')
-      return
+    onOpen = (portal) => {
+        this.setState({
+            menu: portal.firstChild 
+        });
     }
 
-    const parentNode = this.props.state.document.getParent(this.props.state.selection.startKey);
-    const el = Slate.findDOMNode(parentNode);
-
-    if (this.matchTrigger() || match) {
-      const rect = position(el)
-      menu.style.display = 'block'
-      menu.style.opacity = 1
-      if (window.innerHeight - rect.top < 230) {
-        menu.style.bottom = `${window.innerHeight - rect.top - window.pageYOffset}px` // eslint-disable-line no-mixed-operators
-        menu.style.left = `${rect.left + window.pageXOffset + 10}px` // eslint-disable-line no-mixed-operators
-      } else {
-        menu.style.top = `${rect.top + window.pageYOffset}px` // eslint-disable-line no-mixed-operators
-        menu.style.left = `${rect.left + window.pageXOffset}px` // eslint-disable-line no-mixed-operators
-      }
+    setCallbackSuggestion = (filteredSuggestions, selectedIndex=0) => {
+        if (filteredSuggestions.length) {
+            this.props.callback.suggestion = filteredSuggestions[selectedIndex]
+        } else {
+            this.props.callback.suggestion = undefined
+        }
     }
-  }
 
-  closePortal = () => {
-    const { menu } = this.state
-    if (!menu) return
+    onKeyDown = (keyCode, data) => {
+        if (keyCode === DOWN_ARROW_KEY || keyCode === UP_ARROW_KEY) {
+            const filteredSuggestions  = this.getFilteredSuggestions();
+            const positionChange = (keyCode === DOWN_ARROW_KEY) ? +1 : -1; 
+            const newIndex = this.getMenuPostion(positionChange);
+            this.changeMenuPosition(positionChange)
+            this.setCallbackSuggestion(filteredSuggestions, newIndex);
+        } else {
+            const filteredSuggestions  = this.getFilteredSuggestions(data);
+            this.setSelectedIndex(0)
+            if (typeof filteredSuggestions.then === 'function') {
+                filteredSuggestions.then(filteredSuggestions => {
+                    this.setCallbackSuggestion(filteredSuggestions, 0)
+                }).catch(() => {
+                    this.setCallbackSuggestion([], 0)
+                })
+            } else {
+                this.setCallbackSuggestion(filteredSuggestions, 0)
+            }
+        }
+    }
 
-    menu.removeAttribute('style')
-    return
-  }
+    getMenuPostion = (change) => { 
+        // this will allow wrap around to the end of the list
+        const filteredSuggestions  = this.getFilteredSuggestions();
+        if(filteredSuggestions.length === 0) { 
+            return 0;
+        } else { 
+            const changePlusOriginalLength = change + filteredSuggestions.length;
+            const changeAfterWrapping = (this.state.selectedIndex + changePlusOriginalLength) % filteredSuggestions.length;      
+            return changeAfterWrapping;
+        }
+    }
 
-  setSelectedIndex = (selectedIndex) => {
-    this.setState({
-      selectedIndex: selectedIndex
-    })
-  }
+    changeMenuPosition = (change) => { 
+        const changeAfterWrapping = this.getMenuPostion(change);
+        this.setState({ 
+            selectedIndex: changeAfterWrapping
+        })
+    }
 
-  render = () => {
-    const filteredSuggestions  = this.getFilteredSuggestions();
+    matchTrigger = () => {
+        const { state, trigger, startOfParagraph } = this.props
+        const stateCondition = state.isFocused && !state.isExpanded
+        if (!state.selection.anchorKey) return false
 
-    return (
-      <Portal isOpened onOpen={this.onOpen}>
-        <div className="suggestion-portal" ref="suggestionPortal">
-          <ul>
-            {filteredSuggestions.map((suggestion, index) =>
-              <SuggestionItem
-                key={suggestion.key}
-                index={index}
-                suggestion={suggestion}
-                selectedIndex={this.state.selectedIndex}
-                setSelectedIndex={this.setSelectedIndex}
-                appendSuggestion={this.props.callback.onEnter}
-                closePortal={this.closePortal}
-                editor={this.props.callback.editor}
-              />
-            )}
-          </ul>
-        </div>
-      </Portal>
-    )
-  }
+        const { anchorText, anchorOffset } = state
+        if (startOfParagraph) {
+            return stateCondition && anchorText.text === trigger
+        }
+ 
+        const lastChar = anchorText.text[anchorOffset - 1]
+
+        return stateCondition && lastChar && lastChar === trigger
+    }
+
+    matchCapture = () => {
+        const { state, capture } = this.props
+        if (!state.selection.anchorKey) return ''
+        const { anchorText, anchorOffset } = state
+        const currentWord = getCurrentWord(anchorText.text, anchorOffset - 1, anchorOffset - 1)
+        const text = this.getMatchText(currentWord, capture)
+        return text
+    }
+
+    getMatchText = (text, trigger) => {
+        const matchArr = text.match(trigger)
+        if (matchArr) {
+            return matchArr[1].toLowerCase()
+        }
+        return undefined
+    }
+
+    getFilteredSuggestions = (incomingData) => {
+        const { suggestions, state, capture, resultSize } = this.props
+    
+        if (!state.selection.anchorKey) return []
+    
+        const { anchorText, anchorOffset } = state
+    
+        let nextChar = "";
+        // If there is incoming data from a keydown, include that as next char
+        if (incomingData !== undefined) { 
+            nextChar = this.convertSlateDataObjectToCharacter(incomingData);
+            if (nextChar == null) return [];
+        }
+        const currentWord = getCurrentWord(anchorText.text + nextChar, anchorOffset - 1, anchorOffset - 1);//GQ added +nextChar
+    
+        const text = this.getMatchText(currentWord, capture)
+    
+        if (typeof suggestions === 'function') {
+            return suggestions(text)
+        } else {
+            return suggestions
+                .filter(suggestion => suggestion.key.toLowerCase().indexOf(text) !== -1)
+                .slice(0, resultSize ? resultSize : RESULT_SIZE)
+        }
+    }
+
+    convertSlateDataObjectToCharacter = (data) => {
+        const code = data.code;
+        const isShift = data.isShift;
+        if (code < 48) return null;
+        if (code < 58) { // number keys
+            if (isShift) {
+                if (code === 48) return ")";
+                if (code === 49) return "!";
+                if (code === 50) return "@";
+                if (code === 51) return "#";
+                if (code === 52) return "$";
+                if (code === 53) return "%";
+                if (code === 54) return "^";
+                if (code === 55) return "&";
+                if (code === 56) return "*";
+                if (code === 57) return "(";
+            }
+            return String.fromCharCode(code);
+        }
+        if (code >= 65 && code <= 90) { // A-Z, a-z
+            if (isShift) return String.fromCharCode(code);
+            return String.fromCharCode(code + 32);
+        }
+        if (code >= 96 && code <= 105) return String.fromCharCode(code - 48); // numpad 0-9
+        if (code === 187 && !isShift) return "=";
+        if (code === 188 && !isShift) return ",";
+        if (code === 189 && !isShift) return '-';
+        if (code === 190 && !isShift) return ".";
+        if (code === 191 && !isShift) return "/";
+        if (code === 187 && isShift) return "+";
+        if (code === 188 && isShift) return "<";
+        if (code === 189 && isShift) return '_';
+        if (code === 190 && isShift) return ">";
+        if (code === 191 && isShift) return "?";
+        return null;
+    }
+
+    adjustPosition = () => {
+        const { menu } = this.state
+        if (!menu) return
+    
+        const match = this.matchCapture();
+        if (match === undefined) {
+            menu.removeAttribute('style')
+            return
+        }
+    
+        const parentNode = this.props.state.document.getParent(this.props.state.selection.startKey);
+        const el = Slate.findDOMNode(parentNode);
+    
+        if (this.matchTrigger() || match) {
+            const rect = position(el)
+            menu.style.display = 'block'
+            menu.style.opacity = 1
+            menu.style.top = `${rect.top + window.pageYOffset}px` // eslint-disable-line no-mixed-operators
+            menu.style.left = `${rect.left + window.pageXOffset}px` // eslint-disable-line no-mixed-operators
+        }
+    }
+
+    closePortal = () => {
+        const { menu } = this.state
+        if (!menu) return
+    
+        menu.removeAttribute('style')
+        return
+    }
+
+    setSelectedIndex = (selectedIndex) => {
+        this.setState({
+            selectedIndex: selectedIndex
+        })
+    }
+
+    render = () => {
+        const filteredSuggestions  = this.getFilteredSuggestions();
+    
+        return (
+            <Portal isOpened onOpen={this.onOpen}>
+                <div className="suggestion-portal">
+                    <ul>
+                        {filteredSuggestions.map((suggestion, index) =>
+                            <SuggestionItem
+                                key={suggestion.key}
+                                index={index}
+                                suggestion={suggestion}
+                                selectedIndex={this.state.selectedIndex}
+                                setSelectedIndex={this.setSelectedIndex}
+                                appendSuggestion={this.props.callback.onEnter}
+                                closePortal={this.closePortal}
+                                editor={this.props.callback.editor}
+                            />
+                        )}
+                    </ul>
+                </div>
+            </Portal>
+        );
+    }
 }
 
 export default SuggestionPortal

--- a/src/lib/slate-suggestions-dist/suggestion-portal.js
+++ b/src/lib/slate-suggestions-dist/suggestion-portal.js
@@ -246,6 +246,12 @@ class SuggestionPortal extends React.Component {
         // If there is no menu, return
         if (!menu) return;
 
+        // Prevent portal from opening when Context Portal is open
+        if (this.props.contextPortalOpen) {
+            this.closePortal();
+            return;
+        }
+
         const match = this.matchCapture();
         if (match === undefined) {
             // No match: remove menu styling
@@ -254,10 +260,10 @@ class SuggestionPortal extends React.Component {
         }
 
         if (this.matchTrigger() || match) {
-            const rect = position()
+            const rect = this.props.getPosition();
             if (!rect) { 
-                menu.removeAttribute('style');
-                menu.style.display = 'none'
+                // menu.removeAttribute('style');
+                // menu.style.display = 'none'
             } else { 
                 menu.style.display = 'block'
                 menu.style.opacity = 1
@@ -282,13 +288,12 @@ class SuggestionPortal extends React.Component {
     // Closes portal
     closePortal = () => {
         const { menu } = this.state;
-        console.log('----- closing portal')
-        console.log(menu)
         // No menu to close: return
         if (!menu) return;
 
         // Remove menu styling
         menu.removeAttribute('style');
+        menu.style.display = 'none';
         // Reset default suggestion for elements
         this.setDefaultSuggestion();
         return;
@@ -298,7 +303,7 @@ class SuggestionPortal extends React.Component {
         const filteredSuggestions  = this.getFilteredSuggestions();
 
         return (
-            <Portal isOpened onOpen={this.openPortal}>
+            <Portal isOpened closeOnEsc closeOnOutsideClick onOpen={this.openPortal}>
                 <div className="suggestion-portal" ref="suggestionPortal">
                     <ul>
                         {filteredSuggestions.map((suggestion, index) =>

--- a/src/lib/slate-suggestions-dist/suggestion-portal.js
+++ b/src/lib/slate-suggestions-dist/suggestion-portal.js
@@ -11,16 +11,17 @@ import {
 } from './constants'
 
 class SuggestionPortal extends React.Component {
-
+    // Adjust position on initial mount
     componentDidMount = () => {
         this.adjustPosition()
     }
 
+    // Adjust position on each update
     componentDidUpdate = () => {
         this.adjustPosition()
     }
 
-      constructor(props) {
+    constructor(props) {
         super()
         props.callback.onKeyDown = this.onKeyDown
         props.callback.onEnter = props.onEnter
@@ -36,8 +37,8 @@ class SuggestionPortal extends React.Component {
         } else {
             const filteredSuggestions = props.suggestions.slice(0, props.resultSize ? props.resultSize : RESULT_SIZE)
             props.callback.suggestion = filteredSuggestions[this.state.selectedIndex]
-            }
         }
+    }   
 
     onOpen = (portal) => {
         this.setState({

--- a/src/lib/slate-suggestions-dist/suggestion-portal.js
+++ b/src/lib/slate-suggestions-dist/suggestion-portal.js
@@ -184,6 +184,18 @@ class SuggestionPortal extends React.Component {
         }
     }
 
+    setDefaultSuggestion = () => { 
+        const { suggestions, resultSize, trigger } = this.props
+        // Set first suggestion
+        let filteredSuggestions; 
+        if (typeof suggestions === 'function') {
+            filteredSuggestions = suggestions('');
+        } else {
+            filteredSuggestions = suggestions.slice(0, resultSize ? resultSize : RESULT_SIZE)
+        }
+        this.setCallbackSuggestion(filteredSuggestions, 0);
+    }
+
     // Turn event data into characters to match against
     convertSlateDataObjectToCharacter = (data) => {
         const code = data.code;
@@ -264,6 +276,8 @@ class SuggestionPortal extends React.Component {
 
         // Remove menu styling
         menu.removeAttribute('style');
+        // Reset default suggestion for elements
+        this.setDefaultSuggestion();
         return;
     }
 

--- a/src/lib/slate-suggestions-dist/suggestion-portal.js
+++ b/src/lib/slate-suggestions-dist/suggestion-portal.js
@@ -1,13 +1,12 @@
 import React from 'react'
 import Portal from 'react-portal'
-import Slate from '../Slate'
+import Slate from '../slate'
 import position from './caret-position'
 import SuggestionItem from './suggestion-item'
 import getCurrentWord from './current-word'
 import {
   UP_ARROW_KEY,
   DOWN_ARROW_KEY,
-  ENTER_KEY,
   RESULT_SIZE,
 } from './constants'
 

--- a/src/lib/slate-suggestions-dist/suggestion-portal.js
+++ b/src/lib/slate-suggestions-dist/suggestion-portal.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import Portal from 'react-portal'
+import Slate from '../Slate'
 import position from './caret-position'
 import SuggestionItem from './suggestion-item'
 import getCurrentWord from './current-word'

--- a/src/lib/slate-suggestions-dist/suggestion-portal.js
+++ b/src/lib/slate-suggestions-dist/suggestion-portal.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import Portal from 'react-portal'
-import Slate from '../slate'
 import position from './caret-position'
 import SuggestionItem from './suggestion-item'
 import getCurrentWord from './current-word'
@@ -236,18 +235,17 @@ class SuggestionPortal extends React.Component {
             menu.removeAttribute('style');
             return;
         }
-    
-        const parentNode = this.props.state.document.getParent(this.props.state.selection.startKey);
-        const el = Slate.findDOMNode(parentNode);
 
         if (this.matchTrigger() || match) {
-            // Update position of menu styling
-            // const rect = position(el)
             const rect = position()
-            menu.style.display = 'block'
-            menu.style.opacity = 1
-            menu.style.top = `${rect.top + window.pageYOffset}px` // eslint-disable-line no-mixed-operators
-            menu.style.left = `${rect.left + window.pageXOffset}px` // eslint-disable-line no-mixed-operators
+            if (!rect) { 
+                menu.removeAttribute('style');
+            } else { 
+                menu.style.display = 'block'
+                menu.style.opacity = 1
+                menu.style.top = `${rect.top + window.pageYOffset}px` // eslint-disable-line no-mixed-operators
+                menu.style.left = `${rect.left + window.pageXOffset}px` // eslint-disable-line no-mixed-operators
+            }
         }
     }
 

--- a/src/lib/slate-suggestions-dist/suggestion-portal.js
+++ b/src/lib/slate-suggestions-dist/suggestion-portal.js
@@ -75,12 +75,17 @@ class SuggestionPortal extends React.Component {
     // Use new key-presses to update the current suggestion
     onKeyDown = (keyCode, data) => {
         if (keyCode === DOWN_ARROW_KEY || keyCode === UP_ARROW_KEY) {
+            const height = this.refs.suggestionPortal.offsetHeight;
+            const numberOfElementsVisible = Math.floor(height/32);
             // If up/down, change position in list
             const filteredSuggestions  = this.getFilteredSuggestions();
             const positionChange = (keyCode === DOWN_ARROW_KEY) ? +1 : -1; 
             const newIndex = this.getNewMenuPostion(positionChange);
             this.setSelectedIndex(newIndex)
             this.setCallbackSuggestion(filteredSuggestions, newIndex);
+            // newIndex - (numberOfElementsVisible - 1) forces the scrolling to happen once your reach the bottom of the list in view.
+            // 32 is the height of each suggestion in the list, 10 allows for the margin
+            this.refs.suggestionPortal.scrollTop = (newIndex - (numberOfElementsVisible - 1)) * 32 + 10;
         } else {
             // Else, determine character and update suggestions accordingly
             const newFilteredSuggestions  = this.getFilteredSuggestions(data);
@@ -256,8 +261,13 @@ class SuggestionPortal extends React.Component {
             } else { 
                 menu.style.display = 'block'
                 menu.style.opacity = 1
-                menu.style.top = `${rect.top + window.pageYOffset}px` // eslint-disable-line no-mixed-operators
-                menu.style.left = `${rect.left + window.pageXOffset}px` // eslint-disable-line no-mixed-operators
+                if (window.innerHeight - rect.top < 230) {
+                    menu.style.bottom = `${window.innerHeight - rect.top - window.pageYOffset}px` // eslint-disable-line no-mixed-operators
+                    menu.style.left = `${rect.left + window.pageXOffset + 10}px` // eslint-disable-line no-mixed-operators
+                } else {
+                    menu.style.top = `${rect.top + window.pageYOffset}px` // eslint-disable-line no-mixed-operators
+                    menu.style.left = `${rect.left + window.pageXOffset}px` // eslint-disable-line no-mixed-operators
+                }
             }
         }
     }
@@ -289,7 +299,7 @@ class SuggestionPortal extends React.Component {
 
         return (
             <Portal isOpened onOpen={this.openPortal}>
-                <div className="suggestion-portal">
+                <div className="suggestion-portal" ref="suggestionPortal">
                     <ul>
                         {filteredSuggestions.map((suggestion, index) =>
                             <SuggestionItem

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -255,8 +255,24 @@ class FluxNotesEditor extends React.Component {
             return this.lastPosition;
         } else {
             let pos = position();
-            this.lastPosition = pos;
-            return pos;
+            // If position is calculated to be 0, 0, use our old method of calculating position.
+            if (pos.top === 0 && pos.left === 0) {
+                const parentNode = this.state.state.document.getParent(this.state.state.selection.startKey);
+                const el = Slate.findDOMNode(parentNode);
+                const children = el.childNodes;
+            
+                for (const child of children) {
+                    if (child.getBoundingClientRect && child.getAttribute("data-key")) {
+                        const rect = child.getBoundingClientRect();
+                        pos.left = rect.left + rect.width;
+                        pos.top = rect.top;
+                    }
+                }
+            }
+            if (pos.top !== undefined && pos.left !== undefined) {
+                this.lastPosition = pos;
+            }
+            return this.lastPosition;
         }
     }
 

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -164,8 +164,6 @@ class FluxNotesEditor extends React.Component {
             state: initialState,
             isPortalOpen: false,
             portalOptions: null,
-            left: 0,
-            top: 0
         };
 
         // this.props.setFullAppState('isNoteViewerEditable', true);
@@ -252,17 +250,14 @@ class FluxNotesEditor extends React.Component {
 
     openPortalToSelectValueForShortcut(shortcut, needToDelete, transform) {
         let portalOptions = shortcut.getValueSelectionOptions();
-        let pos = position();
 
         this.setState({
             isPortalOpen: true,
             portalOptions: portalOptions,
             needToDelete: needToDelete,
-            left: pos.left,
-            top: pos.top
         });
         this.selectingForShortcut = shortcut;
-        return transform.blur();
+        return transform.focus();
     }
 
     // called from portal when an item is selected (context is not null) or if portal is closed without
@@ -717,8 +712,6 @@ class FluxNotesEditor extends React.Component {
                     <InsertersPortal
                         state={this.state.state}/>
                     <ContextPortal
-                        left={this.state.left}
-                        top={this.state.top}
                         state={this.state.state}
                         callback={callback}
                         onSelected={this.onPortalSelection}

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -265,14 +265,12 @@ class FluxNotesEditor extends React.Component {
                 }
             }
             return pos;
-        };
+        }
 
         if (!this.editorHasFocus) {
             if (this.lastPosition.top === 0 && this.lastPosition.left === 0) {   
                 this.lastPosition = positioningUsingSlateNodes();
-            } else { 
-                // No changes to lastPosition
-            }
+            } 
         } else {
             const pos = position();
             // If position is calculated to be 0, 0, use our old method of calculating position.

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -16,6 +16,7 @@ import Button from '../elements/Button';
 import Divider from 'material-ui/Divider';
 import AutoReplace from 'slate-auto-replace'
 import SuggestionsPlugin from '../lib/slate-suggestions-dist'
+import position from '../lib/slate-suggestions-dist/caret-position.js'
 import StructuredFieldPlugin from './StructuredFieldPlugin';
 import NoteParser from '../noteparser/NoteParser';
 import './FluxNotesEditor.css';
@@ -45,31 +46,6 @@ const structuredFieldTypes = [
     }
 ]
 
-//  Helper Functions
-//
-// Given upper-most dom element of the editor, the current node and state, return the cursor position  
-function getPos(domElement, node, state) {
-    const offsetx = 0;
-    const offsety = 0;
-    var pos = {left: 0, top: 0};
-
-    const children = domElement.childNodes;
-
-    for (const child of children) {
-        if (child.getBoundingClientRect && child.getAttribute("data-key")) {
-            const rect = child.getBoundingClientRect();
-            pos.left = rect.left + rect.width + offsetx;
-            pos.top = rect.top + offsety;
-        }
-    }
-    return pos;
-}
-// Given a state, return the position of the cursor
-function position(state) {
-    const parentNode = state.state.document.getParent(state.state.selection.startKey);
-    const el = Slate.findDOMNode(parentNode);
-    return getPos(el, parentNode, state);
-}
 // Given  text and starting index, recursively traverse text to find index location of text
 function getIndexRangeForCurrentWord(text, index, initialIndex, initialChar) {
     if (index === initialIndex) {
@@ -276,7 +252,7 @@ class FluxNotesEditor extends React.Component {
 
     openPortalToSelectValueForShortcut(shortcut, needToDelete, transform) {
         let portalOptions = shortcut.getValueSelectionOptions();
-        let pos = position(this.state);
+        let pos = position();
 
         this.setState({
             isPortalOpen: true,


### PR DESCRIPTION
Fixed a bug concerning the placement of the suggestion dropdown in the case where a user is typing into a multi-line paragraph. In the process I performed a pretty massive overhaul on the suggestion-plugin code, bringing the styling inline with our current code-quality standards, adding comments where I could, and updating the code in a few other places. As a result, a few other bugs have been addressed in the process. 

1. Original Bug: Shortcuts that require two selections (e.g. '@condition' prompts users for a second selection containing all the patients current conditions) would not close the first suggestion menu. This menu now closes. 
2. Original Bug: Backspacing into a suggestion (e.g. '@age' -> '@ag') used to remove the menu/disable the insertion of a suggestion. This is no longer the case, and the expected element is now inserted.
3. Original Bug: The nil case for suggestions (i.e. just '@') used to always insert the previously typed shortcut, regardless of what the suggestion menu indicated. This has now been fixed.

Hopefully this, along with the work Julia has been doing, should prepare our for the demo and make it easier to make changes to the editor in the long term. 

It's also worth noting that the changes we've made to the suggestion plugin have become pretty drastic. A result of this is that I suggest we use my fork of the original repo (https://github.com/Dtphelan1/slate-suggestions/) as the canonical version of the tool. The previous repo is largely a ghosttown, with PR's in limbo for months now (one of them being ours from August!)

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- **N/A** Cheat sheet is updated
- **N/A** Demo script is updated 
- **N/A** Documentation on Wiki has been updated 
- **N/A** Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- **N/A**  Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- **N/A**  Added UI tests for slim mode 
- **N/A**  Added UI tests for full mode
- **N/A**  Added backend tests for fluxNotes code
- **N/A**  Added note parser examples to test new functionality


## Reviewer 1: Julia

- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
-  The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
