### PR TITLE
Implement sign button

### DIFF
--- a/src/containers/FullApp.jsx
+++ b/src/containers/FullApp.jsx
@@ -7,7 +7,8 @@ import green from 'material-ui/colors/green';
 import red from 'material-ui/colors/red';
 import Lang from 'lodash';
 
-import DashboardManager from '../dashboard/DashboardManager'
+import SecurityManager from '../security/SecurityManager';
+import DashboardManager from '../dashboard/DashboardManager';
 import ShortcutManager from '../shortcuts/ShortcutManager';
 import ContextManager from '../context/ContextManager';
 import DataAccess from '../dataaccess/DataAccess';
@@ -43,6 +44,7 @@ export default class FullApp extends Component {
         this.dashboardManager = new DashboardManager();
         this.shortcutManager = new ShortcutManager(this.props.shortcuts);
         this.contextManager = new ContextManager(patient, this.onContextUpdate);
+        this.securityManager = new SecurityManager();
 
         this.state = {
             clinicalEvent: "post-encounter",
@@ -55,11 +57,24 @@ export default class FullApp extends Component {
             patient: patient,
             selectedText: null,
             documentText: null,
-            superRole: 'Clinician',
+            loginUser: "",
+            superRole: 'Clinician', // possibly add that to security manager too
             summaryItemToInsert: '',
             summaryMetadata: this.summaryMetadata.getMetadata(),
             noteClosed: false,
+
         };
+    }
+
+    // On component mount, grab the username of the logged in user
+    componentDidMount() {
+        const userProfile = this.securityManager.getUserProfile();
+
+        if (userProfile) {
+            this.setState({loginUser: userProfile.getUserName()});
+        } else {
+            console.error("Login failed");
+        }
     }
 
     // pass this function to children to set full app global state
@@ -152,6 +167,8 @@ export default class FullApp extends Component {
     }
 
     render() {
+
+
         // Get the Current Dashboard based on superRole of user
         const CurrentDashboard = this.dashboardManager.getDashboardForSuperRole(this.state.superRole);
         return (
@@ -163,6 +180,7 @@ export default class FullApp extends Component {
                                 <PatientControlPanel
                                     appTitle={this.props.display}
                                     supportLogin={true}
+                                    loginUser={this.state.loginUser}
                                     patient={this.state.patient}
                                     possibleClinicalEvents={this.possibleClinicalEvents}
                                     clinicalEvent={this.state.clinicalEvent}
@@ -176,6 +194,7 @@ export default class FullApp extends Component {
                             // App default settings
                             title={this.props.display}
                             supportLogin={true}
+                            loginUser={this.state.loginUser}
                             possibleClinicalEvents={this.possibleClinicalEvents}
                             dataAccess={this.dataAccess}
                             summaryMetadata={this.summaryMetadata}

--- a/src/dashboard/ClinicianDashboard.jsx
+++ b/src/dashboard/ClinicianDashboard.jsx
@@ -177,6 +177,7 @@ class ClinicianDashboard extends Component {
 
                 <div style={notesPanelStyles}>
                     <NotesPanel
+                        loginUser={this.props.loginUser}
                         contextManager={this.props.contextManager}
                         errors={this.props.appState.errors}
                         isNoteViewerVisible={isNoteViewerVisible}

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -146,7 +146,7 @@ export default class NoteAssistant extends Component {
         let date = new moment().format("D MMM YYYY");
         let subject = "New Note";
         let hospital = "Dana Farber";
-        let clinician = "Dr. X123";
+        let clinician = this.props.loginUser;
         let signed = false;
 
         // Add new unsigned note to patient record
@@ -166,12 +166,13 @@ export default class NoteAssistant extends Component {
         let emptyNote = "";
         this.toggleView("context-tray");
         this.props.loadNote(emptyNote);
+        this.props.setFullAppState("noteClosed", false);
 
         // Create info to be set for new note
         let date = new moment().format("D MMM YYYY");
         let subject = "New Note";
         let hospital = "Dana Farber";
-        let clinician = "Dr. X123";
+        let clinician = this.props.loginUser;
         let content = emptyNote;
         let signed = false;
 

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -66,13 +66,29 @@ export default class NoteAssistant extends Component {
         this.props.closeNote(this.closeNote);
     }
 
+    // Sorts the lab results in chronological order with the most recent first (so that it shows up first in the clinical notes list)
+    notesTimeSorter(a, b) {
+        const a_startTime = new moment(a.date, "D MMM YYYY");
+        const b_startTime = new moment(b.date, "D MMM YYYY");
+        if (a_startTime > b_startTime) {
+            return -1;
+        }
+        if (a_startTime < b_startTime) {
+            return 1;
+        }
+
+        return 0;
+    }
+
     getNotesFromPatient(props) {
         // Generate notesToDisplay array which will be used to render the notes in clinical notes view
         let allNotes = props.patient.getNotes();
         let signedNotes = Lang.filter(allNotes, o => o.signed);
+        signedNotes.sort(this.notesTimeSorter);
         let unsignedNotes = Lang.filter(allNotes, o => !o.signed);
         const maxNotes = Math.min(this.state.maxNotesToDisplay, signedNotes.length);
         this.notesToDisplay = [];
+
         for (let i = 0; i < maxNotes; i++) {
             this.notesToDisplay.push(signedNotes[i]);
         }
@@ -300,7 +316,7 @@ export default class NoteAssistant extends Component {
     renderInProgressNote(note, i) {
         let selected = Lang.isEqual(this.props.selectedNote, note);
         // if we have closed the note, selected = false
-        if(Lang.isEqual(this.props.noteClosed, true)){
+        if (Lang.isEqual(this.props.noteClosed, true)) {
             selected = false;
         }
 
@@ -351,7 +367,7 @@ export default class NoteAssistant extends Component {
     renderClinicalNote(item, i) {
         let selected = Lang.isEqual(this.props.selectedNote, item);
         // if we have closed the note, selected = false
-        if(Lang.isEqual(this.props.noteClosed, true)){
+        if (Lang.isEqual(this.props.noteClosed, true)) {
             selected = false;
         }
 

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -86,7 +86,14 @@ export default class NotesPanel extends Component {
     }
 
     handleSignButtonClick() {
-        console.log("clicked sign button");
+
+        // Set signed attribute on the selected note to be true
+        let tempNote =  this.state.selectedNote;
+        tempNote.signed = true;
+        this.setState({selectedNote: tempNote});
+
+        // Close the current note
+       this.closeNote();
     }
 
     renderSignButton() {
@@ -102,11 +109,12 @@ export default class NotesPanel extends Component {
     }
 
     renderNotesPanelContent() {
+
         // If isNoteViewerVisible is true, render the flux notes editor and the note assistant
         if (this.props.isNoteViewerVisible) {
 
-            // If not viewer is editable, render the sign note button, else don't render sign note button
-            if(this.props.isNoteViewerEditable) {
+            // If note viewer is editable and a note is selected, render the sign note button
+            if(this.props.isNoteViewerEditable && this.state.selectedNote) {
                 return (
                     <div>
                         <Row center="xs">
@@ -120,6 +128,7 @@ export default class NotesPanel extends Component {
                         </Row>
                     </div>
                 );
+                // Else don't render sign note button
             } else {
                 return (
                     <div>
@@ -183,6 +192,7 @@ export default class NotesPanel extends Component {
         return (
             <div className="fitted-panel panel-content dashboard-panel">
                 <NoteAssistant
+                    loginUser={this.props.loginUser}
                     isNoteViewerEditable={this.props.isNoteViewerEditable}
                     setFullAppState={this.props.setFullAppState}
                     patient={this.props.patient}

--- a/src/panels/PatientControlPanel.jsx
+++ b/src/panels/PatientControlPanel.jsx
@@ -11,7 +11,7 @@ import './PatientControlPanel.css';
 class PatientControlPanel extends Component {
     render() {
         const { patient } = this.props;
-        const login = (this.props.supportLogin) ? ( <Button style={{color: "#17263f"}}>Dr. X123 Y987</Button> ) : "";
+        const login = (this.props.supportLogin) ? ( <Button style={{color: "#17263f"}}>{this.props.loginUser}</Button> ) : "";
         const firstName = patient.getName().split(' ')[0];
         const patientConditions = this.props.patient ? this.props.patient.getConditions() : [];
 

--- a/src/security/SecurityManager.jsx
+++ b/src/security/SecurityManager.jsx
@@ -1,0 +1,10 @@
+import UserProfile from './UserProfile';
+
+// Security Manager will handle all security related functionality of the app (authentication, authorization, etc)
+class SecurityManager {
+
+     getUserProfile() {
+        return new UserProfile("Dr. X123 Y987");
+    }
+}
+export default SecurityManager;

--- a/src/security/UserProfile.jsx
+++ b/src/security/UserProfile.jsx
@@ -1,0 +1,15 @@
+// This class stores user profile information
+class UserProfile {
+   constructor(name) {
+         this._name = name;
+   }
+
+   getUserName() {
+       return this._name;
+   }
+
+   getSuperRole() {
+       return "Clinician";
+   }
+}
+export default UserProfile;

--- a/test/ui/FullApp.js
+++ b/test/ui/FullApp.js
@@ -643,13 +643,43 @@ test('Clicking on an in-progress note shows the sign note button', async t => {
         .ok()
 });
 
-// Verifies automatic saving
-test('Contents of in-progress note saved when switching to a completed note and back', async t => {
-     const editor = Selector("div[data-slate-editor='true']");
+test.only('Clicking on the sign note button moves the note from in progress notes to existing notes', async t => {
     const clinicalNotesButton = Selector('#notes-btn');
     const newNoteButton = Selector('.note-new');
     const inProgressNotes = Selector('.in-progress-note');
-        const note = Selector('.existing-note');
+    const signNoteButton = Selector('.btn_finish');
+
+    // Click clinical notes button
+    await t
+        .click(clinicalNotesButton);
+
+    // Click "New note" button
+    await t
+        .click(newNoteButton)
+        .click(clinicalNotesButton);
+
+    // Get the current number of in-progress notes
+    const inProgressNotesLength = await inProgressNotes.count;
+
+    // Click "Sign note" button
+    await t
+        .click(signNoteButton);
+
+    // Get the updated number of in-progress notes
+    const updatedInProgressNotesLength = await inProgressNotes.count;
+
+    // There should be one less in-progress notes
+    await t
+        .expect(updatedInProgressNotesLength)
+        .eql(inProgressNotesLength - 1);
+});
+
+// Verifies automatic saving
+test('Contents of in-progress note saved when switching to a completed note and back', async t => {
+    const editor = Selector("div[data-slate-editor='true']");
+    const clinicalNotesButton = Selector('#notes-btn');
+    const inProgressNotes = Selector('.in-progress-note');
+    const note = Selector('.existing-note');
     
     // Enter some text in the editor
     await t

--- a/test/ui/FullApp.js
+++ b/test/ui/FullApp.js
@@ -579,7 +579,7 @@ test('Clicking on an in-progress note in post encounter mode loads the note in t
     const clinicalNotesButton = Selector('#notes-btn');
     const newNoteButton = Selector('.note-new');
     const inProgressNotes = Selector('.in-progress-note');
-    
+
     // Enter some text in the editor
     await t
         .typeText(editor, "This is a note.");
@@ -643,7 +643,7 @@ test('Clicking on an in-progress note shows the sign note button', async t => {
         .ok()
 });
 
-test.only('Clicking on the sign note button moves the note from in progress notes to existing notes', async t => {
+test('Clicking on the sign note button moves the note from in progress notes to existing notes', async t => {
     const clinicalNotesButton = Selector('#notes-btn');
     const newNoteButton = Selector('.note-new');
     const inProgressNotes = Selector('.in-progress-note');
@@ -680,7 +680,7 @@ test('Contents of in-progress note saved when switching to a completed note and 
     const clinicalNotesButton = Selector('#notes-btn');
     const inProgressNotes = Selector('.in-progress-note');
     const note = Selector('.existing-note');
-    
+
     // Enter some text in the editor
     await t
         .typeText(editor, "This is a note.");


### PR DESCRIPTION
This PR addresses jira 814.
- Added "Sign note" button
- "Sign note" button is displayed on the screen only when the note editor is editable and a note is selected (can't sign a note that is already signed)
- Clicking the "Sign note" button sets the sign attribute on the note to true and closes the note editor
- Signing a note moves an in-progress note from the list of in-progress notes to the list of existing notes (to see this, look at the increase in number on the "View X more more clinical notes" button or in NoteAssistant update the max notes to display from 3 to at least 5 to see the signed note show up in the list)
- Added SecurityManager and UserProfile classes to store the logged in user. The name of the logged in user in the patient control panel and the name of the clinician that is added to a new note now use the name from the user profile
- Added UI test to check that number of in progress notes decreases when the current in-progress note is signed


_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- N/A Cheat sheet is updated
- N/A Demo script is updated 
- N/A Documentation on Wiki has been updated 
- N/A Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- N/A Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- N/A Added UI tests for slim mode 
- [x] Added UI tests for full mode
- N/A Added backend tests for fluxNotes code
- N/A Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
