### PR TITLE
created a post encounter visit reason referencing previous visit

### DIFF
--- a/src/dataaccess/HardCodedPatient.json
+++ b/src/dataaccess/HardCodedPatient.json
@@ -1356,8 +1356,8 @@
         "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "shr.base.EntryId": "33",
         "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/encounter/EncounterRequested" },
-        "shr.base.PersonOfRecord": { "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "shr.base.EntryId": "1"},
-        "shr.base.Subject": { "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"}, "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "shr.base.EntryId": "1" },
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1"},
+        "shr.base.Subject": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"}, "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1" },
         "shr.action.ActionContext": {
             "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext" },
             "shr.action.Status": { "Value": "active" },

--- a/src/dataaccess/HardCodedPatient.json
+++ b/src/dataaccess/HardCodedPatient.json
@@ -1334,7 +1334,36 @@
             "shr.action.Status": { "Value": "active" },
             "shr.action.ExpectedPerformanceTime": {
                 "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime" },
-                "Value": "28 FEB 2018 16:00 -0500"
+                "Value": "12 FEB 2018 16:00 -0500"
+            },
+            "shr.action.RequestIntent": {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/action/RequestIntent" },
+                "Value": "plan"
+            },
+            "shr.core.Reason": {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Reason" },
+                "Value": "Debra Hernandez672 is coming in to see Dr. X123 Y987 for a check up on the progress of her treatment for Invasive ductal carcinoma of the breast"
+            }
+        },
+        "shr.encounter.ReferralDate": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/encounter/ReferralDate" },
+            "Value": "02 JAN 2018"
+        },
+        "shr.core.CreationTime": {"Value": "01 JAN 2018"},
+        "shr.base.LastUpdated": {"Value": "01 JAN 2018"}
+    },    
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "shr.base.EntryId": "33",
+        "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/encounter/EncounterRequested" },
+        "shr.base.PersonOfRecord": { "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "shr.base.EntryId": "1"},
+        "shr.base.Subject": { "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"}, "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "shr.base.EntryId": "1" },
+        "shr.action.ActionContext": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext" },
+            "shr.action.Status": { "Value": "active" },
+            "shr.action.ExpectedPerformanceTime": {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime" },
+                "Value": "28 FEB 2018 18:00 -0500"
             },
             "shr.action.RequestIntent": {
                 "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/action/RequestIntent" },

--- a/src/dataaccess/HardCodedPatient.json
+++ b/src/dataaccess/HardCodedPatient.json
@@ -1322,7 +1322,7 @@
         },
         "shr.core.CreationTime": {"Value": "01 JAN 2018"},
         "shr.base.LastUpdated": {"Value": "01 JAN 2018"}
-    },
+    },    
     {
         "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "shr.base.EntryId": "33",
@@ -1342,7 +1342,7 @@
             },
             "shr.core.Reason": {
                 "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Reason" },
-                "Value": "Debra Hernandez672 is coming in to see Dr. X123 Y987 for a check up on the progress of her treatment for Invasive ductal carcinoma of the breast"
+                "Value": "Debra Hernandez672 saw Dr. X123 Y987 for a check up on the progress of her treatment for Invasive ductal carcinoma of the breast"
             }
         },
         "shr.encounter.ReferralDate": {

--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -168,25 +168,22 @@ class PatientRecord {
 
     // return the soonest upcoming encounter. Includes encounters happening later today.
     getNextEncounter(){
-        return this.getEncountersChronologicalOrder(new moment())[0];
-    }
+        let encounters = this.getEncountersChronologicalOrder();
 
-    // returns a list of upcoming encounters after the date and time of afterDateTime
-    // this includes encounters scheduled for later in the same day
-    getEncountersChronologicalOrder(afterDateTime = null){
-        let encounters = this.getEntriesOfType(FluxEncounterRequested);
-        encounters.sort(this._encounterTimeSorter);
-
-        // no date provided, return entire list
-        if(Lang.isNull(afterDateTime)){
-            return encounters;
-        }
-
-        // filter out any encounters happening before the specified afterDateTime argument
+        // filter out any encounters happening after the specified moment argument
         return encounters.filter((encounter) => {
             const encounterStartTime = new moment(encounter.expectedPerformanceTime, "D MMM YYYY HH:mm Z");
-            return encounterStartTime.isAfter(afterDateTime, "second");
-        });
+            return encounterStartTime.isAfter(new moment(), "second");
+        })[0];
+    }
+
+    // returns sorted list of encounters
+    getEncountersChronologicalOrder(){
+        let encounters = this.getEntriesOfType(FluxEncounterRequested);
+        encounters.sort(this._encounterTimeSorter);
+        return encounters;
+
+
     }
 
     getNextEncounterReason() {
@@ -194,6 +191,23 @@ class PatientRecord {
         // Tried replacing breast cancer condition text to establish condition context
         // return nextEncounter.reason.replace('Invasive ductal carcinoma of the breast', '@condition[[Invasive ductal carcinoma of the breast]]');
         return nextEncounter.reason;
+    }
+    
+    getPreviousEncounter(){
+        let encounters = this.getEncountersChronologicalOrder();
+
+        // filter out any encounters happening before the specified moment argument
+        return encounters.filter((encounter) => {
+            const encounterStartTime = new moment(encounter.expectedPerformanceTime, "D MMM YYYY HH:mm Z");
+            return encounterStartTime.isBefore(new moment(), "second");
+        })[0];
+        
+        
+    }
+    
+    getPreviousEncounterReason(){
+        const previousEncounter = this.getPreviousEncounter();
+        return previousEncounter.reason;
     }
 
     getConditions() {

--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -172,8 +172,9 @@ class PatientRecord {
 
         // filter out any encounters happening after the specified moment argument
         return encounters.filter((encounter) => {
+            const now = new moment();
             const encounterStartTime = new moment(encounter.expectedPerformanceTime, "D MMM YYYY HH:mm Z");
-            return encounterStartTime.isAfter(new moment(), "second");
+            return encounterStartTime.isAfter(now, "second");
         })[0];
     }
 
@@ -197,10 +198,12 @@ class PatientRecord {
         let encounters = this.getEncountersChronologicalOrder();
 
         // filter out any encounters happening before the specified moment argument
+        
         return encounters.filter((encounter) => {
+            const now = new moment();
             const encounterStartTime = new moment(encounter.expectedPerformanceTime, "D MMM YYYY HH:mm Z");
-            return encounterStartTime.isBefore(new moment(), "second");
-        })[0];
+            return encounterStartTime.isBefore(now, "second");
+        }).pop();
         
         
     }

--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -198,9 +198,8 @@ class PatientRecord {
         let encounters = this.getEncountersChronologicalOrder();
 
         // filter out any encounters happening before the specified moment argument
-        
+        const now = new moment();
         return encounters.filter((encounter) => {
-            const now = new moment();
             const encounterStartTime = new moment(encounter.expectedPerformanceTime, "D MMM YYYY HH:mm Z");
             return encounterStartTime.isBefore(now, "second");
         }).pop();

--- a/src/shortcuts/Shortcuts.json
+++ b/src/shortcuts/Shortcuts.json
@@ -398,5 +398,21 @@
       }
     ],
     "knownParentContexts": "Patient"
+  },
+  {
+    "type": "InsertValue",
+    "id": "ReasonForPreviousVisitInserter",
+    "getData": {
+      "object": "patient",
+      "method": "getPreviousEncounterReason"
+    },
+    "isContext": false,
+    "stringTriggers": [
+      {
+        "name": "@reason for previous visit",
+        "description": "Insert reason for patient's previous visit"
+      }
+    ],
+    "knownParentContexts": "Patient"
   }
 ]

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -38,6 +38,7 @@ class SummaryMetadata {
                 sections: [
                     {
                         name: "Visit Reason",
+                        clinicalEvents: ["pre-encounter"],
                         type: "NarrativeOnly", 
                         narrative: [
                             {
@@ -65,6 +66,36 @@ class SummaryMetadata {
                             }
                         ]
                     },
+                    {
+                        name: "Visit Reason",
+                        clinicalEvents: ["post-encounter"],
+                        type: "NarrativeOnly", 
+                        narrative: [
+                            {
+                                defaultTemplate: "${Reason.Reason}",
+                                dataMissingTemplate: "No recent ${Reason.Reason}",
+                                useDataMissingTemplateCriteria: [
+                                    "Reason.Reason"
+                                ]
+                            },
+                        ],
+                        data: [
+                            {
+                                name: "Reason",
+                                items: [ 
+                                    {
+                                        name: "Reason",
+                                        value: (patient, currentConditionEntry) => {
+                                            const previousEncounter = patient.getPreviousEncounter();
+                                            if (Lang.isUndefined(previousEncounter)) return "No recent appointments";
+                                            return patient.getPreviousEncounter().reason;
+                                        },
+                                        shortcut: "@reason for previous visit"
+                                    }
+                                ]
+                            }
+                        ]
+                    },                    
                     {
                         name: "Summary",
                         type: "NameValuePairs",


### PR DESCRIPTION
Created a new section in summary metadata with a visit reason for post encounter mode. This reason references the last appointment in the hard coded patient closes to the current time. I also updated hard coded patient so that the previous encounter and the next encounter are the same. This will make sure that the demo will not be affected. 

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- NA Cheat sheet is updated
- NA Demo script is updated 
- NA Documentation on Wiki has been updated 
- NA Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- NA Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- NA Added UI tests for slim mode 
- NA Added UI tests for full mode
- NA Added backend tests for fluxNotes code
- NA Added note parser examples to test new functionality


## Reviewer 1: Mike

- [X] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [X] The tests appropriately test the new code, including edge cases
- [X] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
