### PR TITLE
Added Minimap Section Short Names

### DIFF
--- a/src/containers/FullApp.jsx
+++ b/src/containers/FullApp.jsx
@@ -171,6 +171,7 @@ export default class FullApp extends Component {
 
         // Get the Current Dashboard based on superRole of user
         const CurrentDashboard = this.dashboardManager.getDashboardForSuperRole(this.state.superRole);
+
         return (
             <MuiThemeProvider theme={theme}>
                 <div className="FullApp">

--- a/src/dashboard/ClinicianDashboard.jsx
+++ b/src/dashboard/ClinicianDashboard.jsx
@@ -5,7 +5,7 @@ import TargetedDataPanel from '../panels/TargetedDataPanel';
 import NotesPanel from '../panels/NotesPanel';
 import './ClinicianDashboard.css';
 
-class ClinicianDashboard extends Component {
+export default class ClinicianDashboard extends Component {
     constructor() {
         super();
 
@@ -33,7 +33,6 @@ class ClinicianDashboard extends Component {
     // Performs any updates based on changes to the state, specifically:
     // - Updates the layout when the task changes.
     componentWillReceiveProps = (nextProps) => {
-
         // If the clinical event has changed, update the layout and if the note editor should be viewable and editable
         // based on the clinical event
         if (nextProps.appState.clinicalEvent !== this.props.appState.clinicalEvent) {
@@ -91,7 +90,7 @@ class ClinicianDashboard extends Component {
         });
     }
 
-    // Based on currentClinicalEvent, determines if a note should be viewed 
+    // Based on currentClinicalEvent, determines if a note should be viewed
     noteViewerBasedOnClinicalEvent = (currentClinicalEvent) => {
         switch (currentClinicalEvent) {
             case "pre-encounter":
@@ -224,5 +223,3 @@ ClinicianDashboard.proptypes = {
     updateLayoutOnNewNoteClicked: PropTypes.func.isRequired,
     currentViewMode: PropTypes.object.isRequired,
 };
-
-export default ClinicianDashboard;

--- a/src/lib/react-minimap/components/Child.js
+++ b/src/lib/react-minimap/components/Child.js
@@ -1,38 +1,55 @@
-import React from 'react';
-import PropTypes from 'prop-types'
-import '../react-minimap.css'
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import _ from 'lodash';
 
-export class Child extends React.Component {
+import '../react-minimap.css';
 
-  render() {
-    const {width, height, left, top} = this.props
-    return (
-      <div
-        style={{
-          position: 'absolute',
-          width,
-          height,
-          left,
-          top,
-        }}
-        className="minimap-children"
-      >
-        {this.props.title 
-          ? <div className="minimap-title"> 
-            {this.props.title}
-          </div> 
-          : ""}
-      </div>
-    );
-  }
+export default class Child extends Component {
+    render() {
+        const { width, height, left, top, title, shortTitle } = this.props;
+        let displayTitle = title;
+
+        /* manually render a clone div to calculate dimensions because cannot get
+         * dimensions of original div until rendered by react, after which is too late
+         * (cannot modify the state during render)
+         */
+
+        // create hidden clone div of title element
+        const titleDiv = document.createElement('div');
+        titleDiv.setAttribute('class', 'minimap-title-hidden');
+        titleDiv.appendChild(document.createTextNode(title));
+        document.body.appendChild(titleDiv);
+
+        // calculate dimensions
+        const titleWidth = titleDiv.scrollWidth;
+        const titleHeight = titleDiv.scrollHeight;
+
+        // remove clone div
+        titleDiv.parentNode.removeChild(titleDiv);
+
+        // determine if short title should be rendered
+        if (titleWidth > width || titleHeight > height) {
+            displayTitle = shortTitle;
+        }
+
+        return (
+            <div style={{position: 'absolute', width, height, left, top}} className="minimap-children">
+                {displayTitle &&
+                    <div className="minimap-title">
+                        {displayTitle}
+                    </div>
+                }
+            </div>
+        );
+    }
 }
 
 Child.propTypes = {
-  width: PropTypes.number.isRequired,
-  height: PropTypes.number.isRequired,
-  top: PropTypes.number.isRequired,
-  left: PropTypes.number.isRequired,
-  node: PropTypes.any,
+    width: PropTypes.number.isRequired,
+    height: PropTypes.number.isRequired,
+    top: PropTypes.number.isRequired,
+    left: PropTypes.number.isRequired,
+    node: PropTypes.any,
+    title: PropTypes.string.isRequired,
+    shortTitle: PropTypes.string
 };
-
-export default Child

--- a/src/lib/react-minimap/react-minimap.js
+++ b/src/lib/react-minimap/react-minimap.js
@@ -48,7 +48,7 @@ export class Minimap extends React.Component {
     this.downState = false
     this.initState = false
   }
-  
+
   componentDidMount() {
     const {onMountCenterOnX, onMountCenterOnY} = this.props
     setTimeout(() => this.synchronize({centerOnX: onMountCenterOnX, centerOnY:onMountCenterOnY}));
@@ -64,8 +64,8 @@ export class Minimap extends React.Component {
     if (nextProps.keepAspectRatio !== this.props.keepAspectRatio) {
       setTimeout(this.synchronize);
     } else if (nextProps.children !== this.props.children) {
-      setTimeout(this.synchronize);    
-    } 
+      setTimeout(this.synchronize);
+    }
   }
 
   componentDidUpdate() {
@@ -88,7 +88,7 @@ export class Minimap extends React.Component {
 
     let ratioX = width / scrollWidth;
     let ratioY = height / scrollHeight;
-    
+
     if (keepAspectRatio) {
       if (ratioX < ratioY) {
         ratioY = ratioX
@@ -112,6 +112,7 @@ export class Minimap extends React.Component {
         const xM = (left + scrollLeft - sourceRect.left) * ratioX;
         const yM = (top + scrollTop - sourceRect.top) * ratioY;
         const title = node.getAttribute(this.props.titleAttribute);
+        const shortTitle = node.getAttribute(this.props.shortTitleAttribute);
         return (
           <ChildComponent
             key={key}
@@ -121,6 +122,7 @@ export class Minimap extends React.Component {
             top={Math.round( yM )}
             node={node}
             title={title}
+            shortTitle={shortTitle}
           />
         )
       })
@@ -179,7 +181,7 @@ export class Minimap extends React.Component {
     this.l += dx;
     this.t += dy;
 
-    // Sanity checks: 
+    // Sanity checks:
     this.l = (this.l < 0 ? 0 : this.l)
     this.t = (this.t < 0 ? 0 : this.t)
 
@@ -188,7 +190,7 @@ export class Minimap extends React.Component {
     const left = this.l / coefX;
     const top = this.t / coefY;
 
-    
+
     this.source.scrollLeft = Math.round( left );
     this.source.scrollTop = Math.round( top );
     this.redraw();
@@ -209,7 +211,7 @@ export class Minimap extends React.Component {
     const lX = scroll[ 0 ] * scaleX;
     const lY = scroll[ 1 ] * scaleY;
 
-    // Ternary operation includes sanity check 
+    // Ternary operation includes sanity check
     this.w = (Math.round( lW ) > this.state.width) ? this.state.width : Math.round( lW );
     this.h = (Math.round( lH ) > this.state.height) ? this.state.height : Math.round( lH );
     this.l = Math.round( lX );
@@ -230,15 +232,15 @@ export class Minimap extends React.Component {
 
   redraw() {
     this.setState({
-      ...this.state, 
+      ...this.state,
       viewport: (
-        <div 
-          className="minimap-viewport" 
+        <div
+          className="minimap-viewport"
           style={{
             width : this.w,
             height : this.h,
             left : this.l,
-            top : this.t      
+            top : this.t
           }}
         />
       )
@@ -249,23 +251,23 @@ export class Minimap extends React.Component {
   render() {
     const {width, height} = this.state
 
-    return (  
-      <div 
+    return (
+      <div
         className={"minimap-container " + this.props.className}
-        onScroll={this.synchronize} 
+        onScroll={this.synchronize}
         ref={(source) => {this.source = source;}}
       >
-        <div 
+        <div
           className="minimap"
-          style={{            
-            width: `${width}px`, 
+          style={{
+            width: `${width}px`,
             height: `${height}px`,
           }}
-          
-          ref={(minimap) => { this.minimap = minimap; }} 
 
-          onMouseDown={this.down} 
-          onTouchStart={this.down} 
+          ref={(minimap) => { this.minimap = minimap; }}
+
+          onMouseDown={this.down}
+          onTouchStart={this.down}
           onTouchMove={this.move}
           onMouseMove={this.move}
           onTouchEnd={this.up}

--- a/src/panels/TargetedDataPanel.css
+++ b/src/panels/TargetedDataPanel.css
@@ -1,34 +1,52 @@
-.panel-heading { 
+.panel-heading {
     text-align: left;
 }
 
 .fitted-panel.minimap-container {
     margin-left: 90px;
-    width: auto; 
+    width: auto;
 }
 
 .fitted-panel .minimap {
-    background-color: #ffffff; 
-    border: none; 
+    position: absolute;
+    left: 0;
+    /*margin: 0;*/
+    background-color: #ffffff;
+    border: none;
     float: none;
     backface-visibility: hidden;
     -webkit-backface-visibility: hidden;
-    position: absolute; 
-    left: 0;
-    padding-left: 0;
-    /*width: 80px;*/
-    height: calc(100vh - 200px);
-} 
+}
+
+/*.minimap-viewport {
+    background-color: #555;
+    opacity: 0.1;
+    width: 100px !important;
+}*/
 
 .minimap-children {
     display: flex;
+    /*margin: 3px 10px;*/
     align-items: center;
     justify-content: center;
+    /*background-color: #fff;*/
     background-color: #eee;
     border-radius: 5px;
+    /*border: 1px solid #ccc;*/
+    /*cursor: pointer;*/
 }
 
 .minimap-children .minimap-title {
     text-align: center;
     font-size: 12px;
+}
+
+.minimap-title-hidden {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 78px;
+    font-size: 12px;
+    display: block;
+    visibility: hidden;
 }

--- a/src/panels/TargetedDataPanel.jsx
+++ b/src/panels/TargetedDataPanel.jsx
@@ -1,34 +1,33 @@
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+
 import TargetedDataSubpanel from '../summary/TargetedDataSubpanel';
 import Minimap from '../lib/react-minimap/react-minimap.js';
 import '../lib/react-minimap/react-minimap.css'
 import './TargetedDataPanel.css';
 
-class TargetedDataPanel extends Component { 
-    componentWillReceiveProps(nextProps) { 
-        if (nextProps.targetedDataPanelSize !== this.props.targetedDataPanelSize) { 
-            this.forceUpdate()
+export default class TargetedDataPanel extends Component {
+    componentWillReceiveProps(nextProps) {
+        if (nextProps.targetedDataPanelSize !== this.props.targetedDataPanelSize) {
+            this.forceUpdate();
         }
     }
 
-    render () { 
+    render () {
         // The css data attribute associated with the minimap
-        const minimapAttribute = "data-test-summary-section";
-        // const visibility = (this.props.isTargetedDataSubpanelVisible ? "visible" : "hidden")
-        // const styles = {
-        //     visibility: visibility
-        // };
-        
+        const minimapAttribute = 'data-test-summary-section';
+        const shortTitleAttribute = 'data-minimap-short-title';
+
         return (
-            <div>
-                <Minimap 
+            <div className="targeted-data-panel">
+                <Minimap
                     selector={`[${minimapAttribute}]`}
                     className="fitted-panel"
                     titleAttribute={minimapAttribute}
+                    shortTitleAttribute={shortTitleAttribute}
                     width={80}
                     isFullHeight={true}
-                >   
+                >
                     <div id="summary-subpanel">
                         <div className="summary-section">
                             <TargetedDataSubpanel
@@ -41,19 +40,20 @@ class TargetedDataPanel extends Component {
                                 allowItemClick={this.props.isNoteViewerEditable}
                             />
                         </div>
-                    </div> 
+                    </div>
                 </Minimap>
             </div>
         );
     }
 }
 
-TargetedDataPanel.proptypes = { 
+TargetedDataPanel.proptypes = {
     appState: PropTypes.shape({
         patient: PropTypes.object.isRequired,
         condition: PropTypes.object,
         summaryMetadata: PropTypes.object.isRequired
     }).isRequired,
+    targetedDataPanelSize: PropTypes.string.isRequired,
     handleSummaryItemSelected: PropTypes.func.isRequired,
     isWide: PropTypes.bool.isRequired,
     itemInserted: PropTypes.func.isRequired,
@@ -61,5 +61,3 @@ TargetedDataPanel.proptypes = {
     possibleClinicalEvents: PropTypes.array.isRequired,
     isNoteViewerEditable: PropTypes.bool.isRequired,
 }
-
-export default TargetedDataPanel;

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -43,7 +43,7 @@ export default class SummaryMetadata {
                         name: "Visit Reason",
                         shortName: "Reason",
                         clinicalEvents: ["pre-encounter"],
-                        type: "NarrativeOnly", 
+                        type: "NarrativeOnly",
                         narrative: [
                             {
                                 defaultTemplate: "${Reason.Reason}",
@@ -72,8 +72,9 @@ export default class SummaryMetadata {
                     },
                     {
                         name: "Visit Reason",
+                        shortName: "Reason",
                         clinicalEvents: ["post-encounter"],
-                        type: "NarrativeOnly", 
+                        type: "NarrativeOnly",
                         narrative: [
                             {
                                 defaultTemplate: "${Reason.Reason}",
@@ -86,7 +87,7 @@ export default class SummaryMetadata {
                         data: [
                             {
                                 name: "Reason",
-                                items: [ 
+                                items: [
                                     {
                                         name: "Reason",
                                         value: (patient, currentConditionEntry) => {
@@ -99,7 +100,7 @@ export default class SummaryMetadata {
                                 ]
                             }
                         ]
-                    },                    
+                    },
                     {
                         name: "Summary",
                         shortName: "Summary",

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -1,43 +1,47 @@
-import FluxHistologicGrade from '../model/oncology/FluxHistologicGrade';
-import FluxTumorDimensions from '../model/oncology/FluxTumorDimensions';
 import Lang from 'lodash'
 import moment from 'moment';
 
+import FluxHistologicGrade from '../model/oncology/FluxHistologicGrade';
+import FluxTumorDimensions from '../model/oncology/FluxTumorDimensions';
+
 /*
-  Each section has the following properties:
-    name                Displayed at the top of the section and in the mini-map
-    type                Dictates the format of the data section described later. Visualizers are implemented to support specific data types.
-    narrative           This section is only used if the section will be displayed using a narrative visualizer. It provides templates for turning the
-                        data into sentences.
-    data                Provides the retrieval of the source data to be displayed in the section in the format dictated by the type property above. The
-                        data is a list of subsections which each have the following possible properties:
-                          name          The name of the subsection. Some visualizers display the subsection names.
-                          items         The list of data items in the format dictated by the type
-                          itemsFunction A function that returns the list of data items in the format dictated by the type
-                          headings      Indicates the a set of column heading labels for tabular visualizers
-                          shortcut      Indicates a shortcut name to use for the first column of insertable data.
-                          code          Indicates a code to be used by an itemsFunction. This allows multiple sections to share the same itemsFunction
-                          bands         Indicates a set of value ranges and the assessment for that range. Some visualizers display bands
-    defaultVisualizer   Indicates the visualizer type for the default visualizer to use for the section. The following ways to specify the default are
-                        supported:
-                            "tabular"                                               The specified visualizer type will be the default visualizer 
-                                                                                    for the section if supported by the data type.
-                            {clinicalEvent: X, defaultVisualizer: Y}                The specified visualizer type Y will be used if the current 
-                                                                                    clinical event is X otherwise the first visualizer registered 
-                                                                                    for the data type will be used.
-                            ["X", {clinicalEvent: Y, defaultVisualizer: Z}, ...]    A list of options allowing an overall default X that is used 
-                                                                                    if one of the specific clinical events (e.g. Y) doesn't match 
-                                                                                    the currently selected one. If a specific one matches, it uses
-                                                                                    the corresponding default visualizer (e.g. Z)
+    Each section has the following properties:
+        name                Displayed at the top of the section and in the mini-map
+        shortName           Displayed in the mini-map when the name is too long to fit -- max 10 characters
+        type                Dictates the format of the data section described later. Visualizers are implemented to support specific data types.
+        narrative           This section is only used if the section will be displayed using a narrative visualizer. It provides templates for
+                            turning the data into sentences.
+        data                Provides the retrieval of the source data to be displayed in the section in the format dictated by the type property
+                            above. The data is a list of subsections which each have the following possible properties:
+                                name            The name of the subsection. Some visualizers display the subsection names.
+                                items           The list of data items in the format dictated by the type
+                                itemsFunction   A function that returns the list of data items in the format dictated by the type
+                                headings        Indicates the a set of column heading labels for tabular visualizers
+                                shortcut        Indicates a shortcut name to use for the first column of insertable data.
+                                code            Indicates a code to be used by an itemsFunction. This allows multiple sections to share the same
+                                                itemsFunction
+                                bands           Indicates a set of value ranges and the assessment for that range. Some visualizers display bands
+        defaultVisualizer   Indicates the visualizer type for the default visualizer to use for the section. The following ways to specify the
+                            default are supported:
+                                "tabular"                                               The specified visualizer type will be the default
+                                                                                        visualizer for the section if supported by the data type.
+                                {clinicalEvent: X, defaultVisualizer: Y}                The specified visualizer type Y will be used if the current
+                                                                                        clinical event is X otherwise the first visualizer
+                                                                                        registered for the data type will be used.
+                                ["X", {clinicalEvent: Y, defaultVisualizer: Z}, ...]    A list of options allowing an overall default X that is used
+                                                                                        if one of the specific clinical events (e.g. Y) doesn't match
+                                                                                        the currently selected one. If a specific one matches, it
+                                                                                        uses the corresponding default visualizer (e.g. Z)
 */
 
-class SummaryMetadata {
+export default class SummaryMetadata {
     constructor() {
         this.hardCodedMetadata = {
             "http://snomed.info/sct/408643008": {
                 sections: [
                     {
                         name: "Visit Reason",
+                        shortName: "Reason",
                         clinicalEvents: ["pre-encounter"],
                         type: "NarrativeOnly", 
                         narrative: [
@@ -52,7 +56,7 @@ class SummaryMetadata {
                         data: [
                             {
                                 name: "Reason",
-                                items: [ 
+                                items: [
                                     {
                                         name: "Reason",
                                         value: (patient, currentConditionEntry) => {
@@ -98,6 +102,7 @@ class SummaryMetadata {
                     },                    
                     {
                         name: "Summary",
+                        shortName: "Summary",
                         type: "NameValuePairs",
                         /*eslint no-template-curly-in-string: "off"*/
                         narrative: [
@@ -137,7 +142,7 @@ class SummaryMetadata {
                                         value: (patient, currentConditionEntry) => {
                                             return currentConditionEntry.laterality;
                                         }
-                                    },                                    
+                                    },
                                     {
                                         name: "Stage",
                                         value: (patient, currentConditionEntry) => {
@@ -212,11 +217,12 @@ class SummaryMetadata {
                                     }
                                 ]
                             }
-                            
+
                         ]
                     },
                     {
                         name: "Procedures",
+                        shortName: "Procedures",
                         type: "Columns",
                         data: [
                             {
@@ -227,7 +233,8 @@ class SummaryMetadata {
                         ]
                     },
                     {
-                        name: "Conditions",
+                        name: "Active Conditions",
+                        shortName: "Conditions",
                         type: "Columns",
                         notFiltered: true,
                         data: [
@@ -241,12 +248,14 @@ class SummaryMetadata {
                     },
                     {
                         name: "Disease Status",
+                        shortName: "Disease",
                         clinicalEvents: ["pre-encounter"],
                         type: "DiseaseStatusValues",
                         itemsFunction: this.getProgressions,
                     },
                     {
                         name: "Labs",
+                        shortName: "Labs",
                         clinicalEvents: ["pre-encounter"],
                         type: "ValueOverTime",
                         data: [
@@ -341,6 +350,7 @@ class SummaryMetadata {
                     },
                     {
                         name: "Medications",
+                        shortName: "Meds",
                         clinicalEvents: ["pre-encounter"],
                         defaultVisualizer: "chart",
                         type: "Medications",
@@ -353,6 +363,7 @@ class SummaryMetadata {
                     },
                     {
                         name: "Pathology Results",
+                        shortName: "Pathology",
                         type: "NameValuePairs",
                         /*eslint no-template-curly-in-string: "off"*/
                         narrative: [
@@ -436,6 +447,7 @@ class SummaryMetadata {
                     },
                     {
                         name: "Genetics",
+                        shortName: "Genetics",
                         type: "NameValuePairs",
                         /*eslint no-template-curly-in-string: "off"*/
                         narrative: [
@@ -464,6 +476,7 @@ class SummaryMetadata {
                     },
                     {
                         name: "Timeline",
+                        shortName: "Timeline",
                         type: "Events",
                         data: [
                             {
@@ -490,6 +503,7 @@ class SummaryMetadata {
                 sections: [
                     {
                         name: "Condition",
+                        shortName: "Condition",
                         type: "NameValuePairs",
                         /*eslint no-template-curly-in-string: "off"*/
                         narrative: [
@@ -532,6 +546,7 @@ class SummaryMetadata {
                     },
                     {
                         name: "Procedures",
+                        shortName: "Procedures",
                         type: "Columns",
                         data: [
                             {
@@ -543,6 +558,7 @@ class SummaryMetadata {
                     },
                     {
                         name: "Labs",
+                        shortName: "Labs",
                         type: "ValueOverTime",
                         data: [
                             {
@@ -563,6 +579,7 @@ class SummaryMetadata {
                     },
                     {
                         name: "Medications",
+                        shortName: "Meds",
                         clinicalEvents: ["pre-encounter"],
                         defaultVisualizer: "chart",
                         type: "Columns",
@@ -576,7 +593,8 @@ class SummaryMetadata {
                         ]
                     },
                     {
-                        name: "Conditions",
+                        name: "Active Conditions",
+                        shortName: "Conditions",
                         type: "Columns",
                         notFiltered: true,
                         data: [
@@ -590,6 +608,7 @@ class SummaryMetadata {
                     },
                     {
                         name: "Timeline",
+                        shortName: "Timeline",
                         type: "Events",
                         data: [
                             {
@@ -675,7 +694,7 @@ class SummaryMetadata {
         });
     }
 
-    getTestsForSubSection = (patient, currentConditionEntry, subsection) => { 
+    getTestsForSubSection = (patient, currentConditionEntry, subsection) => {
         if (Lang.isNull(patient) || Lang.isNull(currentConditionEntry)) return [];
         const labResults = currentConditionEntry.getTests();
         labResults.sort(currentConditionEntry._labResultsTimeSorter);
@@ -694,7 +713,7 @@ class SummaryMetadata {
         return labs
     }
 
-    getProgressions = (patient, condition, subsection) => { 
+    getProgressions = (patient, condition, subsection) => {
         if (Lang.isNull(patient) || Lang.isNull(condition)) return [];
         const progressions = patient.getProgressionsForConditionChronologicalOrder(condition);
 
@@ -898,5 +917,3 @@ class SummaryMetadata {
         return subset;
     }
 }
-
-export default SummaryMetadata;

--- a/src/summary/TargetedDataSection.jsx
+++ b/src/summary/TargetedDataSection.jsx
@@ -18,14 +18,14 @@ export default class TargetedDataSection extends Component {
             chosenVisualizer: null
         };
     }
-    
+
     componentDidUpdate() {
         const optionsForSection = this.getOptions(this.props.section);
         const defaultVisualizer = this.determineDefaultVisualizer(this.props.section, this.props.clinicalEvent, optionsForSection);
         //const defaultOrTabular = optionsForSection.length > 0 ? optionsForSection[0] : 'tabular';
         if (this.state.defaultVisualizer !== defaultVisualizer ||
             (this.state.chosenVisualizer !== null && !optionsForSection.includes(this.state.chosenVisualizer))) {
-            this.setState({defaultVisualizer: defaultVisualizer, chosenVisualizer: null});
+            this.setState({ defaultVisualizer, chosenVisualizer: null });
         }
     }
 
@@ -53,7 +53,7 @@ export default class TargetedDataSection extends Component {
         }
         return optionsForSection[0];
     }
-    
+
     determineIfDefaultVisualizerItemAffectsCurrentSituation = (defaultVisualizer, clinicalEvent, optionsForSection) => {
         if (Lang.isObject(defaultVisualizer)) {
             if (clinicalEvent === defaultVisualizer.clinicalEvent) {
@@ -68,7 +68,7 @@ export default class TargetedDataSection extends Component {
     }
 
     handleViewChange = (chosenVisualizer) => {
-        this.setState({chosenVisualizer});
+        this.setState({ chosenVisualizer });
     }
 
     checkVisualization = () => {
@@ -130,10 +130,10 @@ export default class TargetedDataSection extends Component {
 
         const viz = this.props.visualizerManager.getVisualizer(type, visualization);
         if (Lang.isNull(viz)) return null;
-        
+
         const sectionTransform = viz.transform;
         const Visualizer = viz.visualizer;
-                
+
         return (
             <Visualizer
                 patient={patient}

--- a/src/summary/TargetedDataSubpanel.jsx
+++ b/src/summary/TargetedDataSubpanel.jsx
@@ -1,47 +1,48 @@
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Divider from 'material-ui/Divider';
+import _ from 'lodash';
+
 import TargetedDataSection from './TargetedDataSection';
 import VisualizerManager from './VisualizerManager';
 import 'font-awesome/css/font-awesome.min.css';
 import './TargetedDataSubpanel.css';
 
-class TargetedDataSubpanel extends Component {
-    constructor() {
-        super();
+export default class TargetedDataSubpanel extends Component {
+    constructor(props) {
+        super(props);
+
         this._visualizerManager = new VisualizerManager();
     }
 
     getConditionMetadata() {
-        const {condition} = this.props;
-
+        const { condition, summaryMetadata } = this.props;
         let codeSystem, code, conditionMetadata = null;
+
         if (condition != null) {
             codeSystem = condition.codeSystem;
             code = condition.code;
-            conditionMetadata = this.props.summaryMetadata[codeSystem + "/" + code];
+            conditionMetadata = summaryMetadata[codeSystem + "/" + code];
         }
 
         if (condition == null || conditionMetadata == null) {
-            conditionMetadata = this.props.summaryMetadata["default"];
+            conditionMetadata = summaryMetadata["default"];
         }
 
         return conditionMetadata;
     }
 
     renderSections() {
-        const clinicalEvent = this.props.clinicalEvent;
+        const { clinicalEvent, patient, condition, onItemClicked, allowItemClick, isWide } = this.props;
         const conditionMetadata = this.getConditionMetadata();
-        if (conditionMetadata == null) {
-            return null;
-        }
-        const {patient, condition, onItemClicked, allowItemClick, isWide} = this.props;
+
+        if (conditionMetadata == null) return null;
 
         return conditionMetadata.sections.filter((section, i) => {
             return !section.clinicalEvents || section.clinicalEvents.includes(clinicalEvent);
         }).map((section, i) => {
             return (
-                <div key={i} data-test-summary-section={section.name}>
+                <div key={i} data-test-summary-section={section.name} data-minimap-short-title={section.shortName}>
                     <TargetedDataSection
                         type={section.type}
                         visualizerManager={this._visualizerManager}
@@ -49,33 +50,24 @@ class TargetedDataSubpanel extends Component {
                         section={section}
                         patient={patient}
                         condition={condition}
-                        clinicalEvent={this.props.clinicalEvent}
+                        clinicalEvent={clinicalEvent}
                         onItemClicked={onItemClicked}
                         allowItemClick={allowItemClick}
                         isWide={isWide}
                     />
-                    
-                    { i < conditionMetadata.sections.length - 1 ? <Divider className="divider"/> : null }
+
+                    {i < conditionMetadata.sections.length - 1 ? <Divider className="divider"/> : null}
                 </div>
             );
         });
     }
 
-    renderSummaryList() {
-        return (
-            <div id="summary-list">
-                {this.renderSections()}
-            </div>
-        );
-    }
-
     render() {
         return (
-            <div 
-                id="condition-summary-section" 
-                className={this.props.className}
-            >
-                {this.renderSummaryList()}
+            <div id="condition-summary-section" className={this.props.className}>
+                <div id="summary-list">
+                    {this.renderSections()}
+                </div>
             </div>
         );
     }
@@ -90,5 +82,3 @@ TargetedDataSubpanel.propTypes = {
     allowItemClick: PropTypes.bool,
     onItemClicked: PropTypes.func
 };
-
-export default TargetedDataSubpanel;

--- a/test/ui/FullApp.js
+++ b/test/ui/FullApp.js
@@ -1,4 +1,4 @@
-import { Selector } from 'testcafe';
+import { Selector, ClientFunction } from 'testcafe';
 import hardCodedPatient from '../../src/dataaccess/HardCodedPatient.json';
 import PatientRecord from '../../src/patient/PatientRecord.jsx';
 import '../../src/model/init';
@@ -89,30 +89,6 @@ test('Clicking "New Note" button in pre-encounter mode changes layout and displa
 
     await t
         .expect(editor.exists).ok();
-});
-
-
-fixture('Patient Mode - Minimap')
-    .page(startPage);
-
-test.only('Section shortnames are used when minimap section too small for long section names', async t => {
-    const visitReasonSection = Selector('.minimap-children').find('div').withText('Visit Reason');
-    const reasonSection = Selector('.minimap-children').find('div').withText('Reason');
-
-    // Check long name exists and short name does not
-    await t
-        .expect(visitReasonSection.exists).ok();
-
-    // Resize window to small size, check short name exists and long name does not
-    await t
-        .resizeWindow(200, 100)
-        .expect(reasonSection.exists).ok()
-        .expect(visitReasonSection.exists).notOk();
-
-    // Maximize window, check long name exists and short name does not
-    await t
-        .maximizeWindow()
-        .expect(visitReasonSection.exists).ok();
 });
 
 

--- a/test/ui/FullApp.js
+++ b/test/ui/FullApp.js
@@ -91,6 +91,40 @@ test('Clicking "New Note" button in pre-encounter mode changes layout and displa
         .expect(editor.exists).ok();
 });
 
+
+fixture('Patient Mode - Minimap')
+    .page(startPage);
+
+test('Section shortnames are used when minimap section too small for long section names', async t => {
+    const visitReasonSection = Selector('.minimap-children').find('div').withText('Visit Reason');
+    const reasonSection = Selector('.minimap-children').find('div').withText(/^Reason$/);
+
+    // Check long name exists and short name does not
+    await t
+        .maximizeWindow()
+        .expect(visitReasonSection.exists).ok();
+
+    await t
+        .expect(reasonSection.exists).notOk();
+
+    // Resize window to small size, check short name exists and long name does not
+    await t
+        .resizeWindow(200, 100)
+        .expect(reasonSection.exists).ok();
+
+    await t
+        .expect(visitReasonSection.exists).notOk();
+
+    // Maximize window, check long name exists and short name does not
+    await t
+        .maximizeWindow()
+        .expect(visitReasonSection.exists).ok();
+
+    await t
+        .expect(reasonSection.exists).notOk();
+});
+
+
 fixture('Patient Mode - Editor')
     .page(startPage);
 

--- a/test/ui/FullApp.js
+++ b/test/ui/FullApp.js
@@ -95,33 +95,24 @@ test('Clicking "New Note" button in pre-encounter mode changes layout and displa
 fixture('Patient Mode - Minimap')
     .page(startPage);
 
-test('Section shortnames are used when minimap section too small for long section names', async t => {
+test.only('Section shortnames are used when minimap section too small for long section names', async t => {
     const visitReasonSection = Selector('.minimap-children').find('div').withText('Visit Reason');
-    const reasonSection = Selector('.minimap-children').find('div').withText(/^Reason$/);
+    const reasonSection = Selector('.minimap-children').find('div').withText('Reason');
 
     // Check long name exists and short name does not
     await t
-        .maximizeWindow()
         .expect(visitReasonSection.exists).ok();
-
-    await t
-        .expect(reasonSection.exists).notOk();
 
     // Resize window to small size, check short name exists and long name does not
     await t
         .resizeWindow(200, 100)
-        .expect(reasonSection.exists).ok();
-
-    await t
+        .expect(reasonSection.exists).ok()
         .expect(visitReasonSection.exists).notOk();
 
     // Maximize window, check long name exists and short name does not
     await t
         .maximizeWindow()
         .expect(visitReasonSection.exists).ok();
-
-    await t
-        .expect(reasonSection.exists).notOk();
 });
 
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1214,8 +1214,8 @@ big.js@^3.1.3:
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"
 
 bin-v8-flags-filter@^1.0.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/bin-v8-flags-filter/-/bin-v8-flags-filter-1.1.2.tgz#790d4bb6d8e5368804ec46fd1470649ccd5278a6"
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/bin-v8-flags-filter/-/bin-v8-flags-filter-1.1.3.tgz#14c018c6cca7529767c1f42f12bd3bb20d61e4d3"
 
 binary-extensions@^1.0.0:
   version "1.10.0"


### PR DESCRIPTION
# Added Minimap Section Short Names

Added minimap section short names to `SummaryMetadata.jsx` for use in minimap labels when the names are too large to fit in the parent container. Short names should be 10 characters or less as described in `SummaryMetadata.jsx`. Logic added to `Child.js` component for minimap that manually renders a clone div to calculate the dimensions of the `minimap-title` div and compares it to its parent div. If either width or height exceeds that of the parent, the short name is used instead.

Tested in Chrome and IE. Other minor changes due to code and editor whitespace cleanup. Unable to add UI test, so needs to be tested manually. Best way to test function is to reduce height of browser until short name is used in a section.

Note: Made minimap styling changes to bring in line with design (fixes contrast and padding issues), but was determined to be out-of-scope for this task, so was commented out for now.


_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- Cheat sheet is updated
- Demo script is updated 
- Documentation on Wiki has been updated 
- Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- Added UI tests for slim mode 
- Added UI tests for full mode
- Added backend tests for fluxNotes code
- Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
