### PR TITLE
Allergies Table in Pre-encounter View

### DIFF
--- a/src/dataaccess/HardCodedPatient.json
+++ b/src/dataaccess/HardCodedPatient.json
@@ -1284,6 +1284,19 @@
                 "shr.condition.Severity": {
                     "Value" : {
                         "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+                        "shr.core.Coding":[{ "Value": "mild", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/reaction-event-severity"}, 
+                        "shr.core.DisplayText": {"Value": "Mild"}}]
+                    }
+                },
+                "shr.core.OccurrenceTime": {
+                    "Value": "13 JAN 2015"
+                }
+            },
+            {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/allergy/AdverseReaction" },
+                "shr.condition.Severity": {
+                    "Value" : {
+                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
                         "shr.core.Coding":[{ "Value": "severe", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/reaction-event-severity"}, 
                         "shr.core.DisplayText": {"Value": "Severe"}}]
                     }
@@ -1308,6 +1321,19 @@
             }
         ],
         "shr.allergy.AdverseReaction": [
+            {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/allergy/AdverseReaction" },
+                "shr.condition.Severity": {
+                    "Value" : {
+                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+                        "shr.core.Coding":[{ "Value": "moderate", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/reaction-event-severity"}, 
+                        "shr.core.DisplayText": {"Value": "Moderate"}}]
+                    }
+                },
+                "shr.core.OccurrenceTime": {
+                    "Value": "13 JAN 2015"
+                }
+            },
             {
                 "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/allergy/AdverseReaction" },
                 "shr.condition.Severity": {

--- a/src/dataaccess/HardCodedPatient.json
+++ b/src/dataaccess/HardCodedPatient.json
@@ -1288,6 +1288,13 @@
                         "shr.core.DisplayText": {"Value": "Mild"}}]
                     }
                 },
+                "shr.allergy.Manifestation": {
+                    "Value" : {
+                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+                        "shr.core.Coding":[{ "Value": "272027003", "shr.core.CodeSystem": {"Value": "http://snomed.info/sct"}, 
+                        "shr.core.DisplayText": {"Value": "Headache"}}]
+                    }
+                },
                 "shr.core.OccurrenceTime": {
                     "Value": "13 JAN 2015"
                 }
@@ -1299,6 +1306,13 @@
                         "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
                         "shr.core.Coding":[{ "Value": "severe", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/reaction-event-severity"}, 
                         "shr.core.DisplayText": {"Value": "Severe"}}]
+                    }
+                },
+                "shr.allergy.Manifestation": {
+                    "Value" : {
+                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+                        "shr.core.Coding":[{ "Value": "249497008", "shr.core.CodeSystem": {"Value": "http://snomed.info/sct"}, 
+                        "shr.core.DisplayText": {"Value": "Vomiting"}}]
                     }
                 },
                 "shr.core.OccurrenceTime": {
@@ -1330,6 +1344,13 @@
                         "shr.core.DisplayText": {"Value": "Moderate"}}]
                     }
                 },
+                "shr.allergy.Manifestation": {
+                    "Value" : {
+                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+                        "shr.core.Coding":[{ "Value": "267060006", "shr.core.CodeSystem": {"Value": "http://snomed.info/sct"}, 
+                        "shr.core.DisplayText": {"Value": "Diarrhea"}}]
+                    }
+                },
                 "shr.core.OccurrenceTime": {
                     "Value": "13 JAN 2015"
                 }
@@ -1341,6 +1362,13 @@
                         "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
                         "shr.core.Coding":[{ "Value": "mild", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/reaction-event-severity"}, 
                         "shr.core.DisplayText": {"Value": "Mild"}}]
+                    }
+                },
+                "shr.allergy.Manifestation": {
+                    "Value" : {
+                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+                        "shr.core.Coding":[{ "Value": "267105001", "shr.core.CodeSystem": {"Value": "http://snomed.info/sct"}, 
+                        "shr.core.DisplayText": {"Value": "Itching"}}]
                     }
                 },
                 "shr.core.OccurrenceTime": {

--- a/src/dataaccess/HardCodedPatient.json
+++ b/src/dataaccess/HardCodedPatient.json
@@ -1273,6 +1273,26 @@
         "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/allergy/AllergyIntolerance" },
         "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1"},
         "Value": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{"Value": "412533000", "shr.core.CodeSystem": {"Value": "http://snomed.info/sct"}, "shr.core.DisplayText": "Wheat Bran"}]},
+        "shr.allergy.SubstanceCategory": [
+            {
+                "Value": "food"
+            }
+        ],
+        "shr.allergy.AdverseReaction": [
+            {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/allergy/AdverseReaction" },
+                "shr.condition.Severity": {
+                    "Value" : {
+                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+                        "shr.core.Coding":[{ "Value": "severe", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/reaction-event-severity"}, 
+                        "shr.core.DisplayText": {"Value": "Severe"}}]
+                    }
+                },
+                "shr.core.OccurrenceTime": {
+                    "Value": "13 JAN 2015"
+                }
+            }
+        ],
         "shr.core.CreationTime": {"Value": "13 JAN 2015"},
         "shr.base.LastUpdated": {"Value": "13 JUN 2015"}
     },
@@ -1282,6 +1302,26 @@
         "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/allergy/AllergyIntolerance" },
         "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1"},
         "Value": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding": [{"Value": "410942007", "shr.core.CodeSystem": {"Value": "http://snomed.info/sct"}, "shr.core.DisplayText": "Milk - dietary"}]},
+        "shr.allergy.SubstanceCategory": [
+            {
+                "Value": "food"
+            }
+        ],
+        "shr.allergy.AdverseReaction": [
+            {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/allergy/AdverseReaction" },
+                "shr.condition.Severity": {
+                    "Value" : {
+                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+                        "shr.core.Coding":[{ "Value": "mild", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/reaction-event-severity"}, 
+                        "shr.core.DisplayText": {"Value": "Mild"}}]
+                    }
+                },
+                "shr.core.OccurrenceTime": {
+                    "Value": "13 JAN 2015"
+                }
+            }
+        ],
         "shr.core.CreationTime": {"Value": "13 JAN 2015"},
         "shr.base.LastUpdated": {"Value": "13 JUN 2015"}
     },

--- a/src/model/allergy/FluxAllergyIntolerance.js
+++ b/src/model/allergy/FluxAllergyIntolerance.js
@@ -35,8 +35,18 @@ class FluxAllergyIntolerance {
      */
     get severity() {
         const adverseReactions = this.getAdverseReactionsBySeverityAndTime();
-        if (adverseReactions.length === 0) return "N/A";
+        if (adverseReactions.length === 0 || !adverseReactions[0].severity) return "";
         return adverseReactions[0].severity.value.coding[0].displayText.value;
+    }
+
+    /*
+     *  Getter for manifestation of allergy
+     *  Returns the manifestation displayText of the most severe adverse reaction
+     */
+    get manifestation() {
+        const adverseReactions = this.getAdverseReactionsBySeverityAndTime();
+        if (adverseReactions.length === 0 || !adverseReactions[0].manifestation) return "";
+        return adverseReactions[0].manifestation.value.coding[0].displayText.value;
     }
 
     /*

--- a/src/model/allergy/FluxAllergyIntolerance.js
+++ b/src/model/allergy/FluxAllergyIntolerance.js
@@ -19,6 +19,16 @@ class FluxAllergyIntolerance {
     }
 
     /*
+     *  Getter for category
+     *  Returns first category in substanceCategory array
+     *  Returns null if no substanceCategory or array is empty
+     */
+    get category() {
+        if (!this._allergyIntolerance.substanceCategory || this._allergyIntolerance.substanceCategory.length === 0) return null;
+        return this._allergyIntolerance.substanceCategory[0].code;
+    }
+
+    /*
      *  Getter for severity of allergy
      *  Returns the string of the most severe adverse reaction
      *  Possible return values are Mild, Moderate, Severe

--- a/src/model/allergy/FluxAllergyIntolerance.js
+++ b/src/model/allergy/FluxAllergyIntolerance.js
@@ -1,14 +1,15 @@
 import AllergyIntolerance from '../shr/allergy/AllergyIntolerance';
+import moment from 'moment';
 
 class FluxAllergyIntolerance {
     constructor(json) {
         this._allergyIntolerance = AllergyIntolerance.fromJSON(json);
     }
-    
+
     get entryInfo() {
         return this._allergyIntolerance.entryInfo;
     }
-    
+
     /*
      *  Getter for allergy
      *  Returns displayText string for allergy
@@ -17,6 +18,67 @@ class FluxAllergyIntolerance {
         return this._allergyIntolerance.value.coding[0].displayText;
     }
 
-}
+    /*
+     *  Getter for severity of allergy
+     *  Returns the string of the most severe adverse reaction
+     *  Possible return values are Mild, Moderate, Severe
+     */
+    get severity() {
+        const adverseReactions = this.getAdverseReactionsBySeverityAndTime();
+        if (adverseReactions.length === 0) return "N/A";
+        return adverseReactions[0].severity.value.coding[0].displayText.value;
+    }
 
-export default FluxAllergyIntolerance;
+    /*
+     *  Returns list of adverse reactions on allergy sorted by severity and time
+     */
+    getAdverseReactionsBySeverityAndTime() {
+        if (!this._allergyIntolerance.adverseReaction) return [];
+        return this._allergyIntolerance.adverseReaction.sort(this._adverseReactionsSorter);
+    }
+
+    // Sort adverse reactions by severity and time
+    _adverseReactionsSorter(a, b) {
+        let a_severity, b_severity;
+        switch (a.severity.value.coding[0].code) {
+            case "severe": {
+                a_severity = 1;
+                break;
+            }
+            case "moderate": {
+                a_severity = 0;
+                break;
+            }
+            default: {
+                a_severity = -1;
+            }
+        }
+
+        switch (b.severity.value.coding[0].code) {
+            case "severe": {
+                b_severity = 1;
+                break;
+            }
+            case "moderate": {
+                b_severity = 0;
+                break;
+            }
+            default: {
+                b_severity = -1;
+            }
+        }
+
+        if (a_severity > b_severity) return -1;
+        else if (a_severity < b_severity) return 1;
+
+        const a_time = new moment(a.occurrenceTime.dateTime, "D MMM YYYY");
+        const b_time = new moment(b.occurrenceTime.dateTime, "D MMM YYYY");
+
+        if (a_time > b_time) return -1;
+        else if (a_time < b_time) return 1;
+        return 0;
+    }
+
+    }
+
+    export default FluxAllergyIntolerance;

--- a/src/model/allergy/FluxAllergyIntolerance.js
+++ b/src/model/allergy/FluxAllergyIntolerance.js
@@ -11,10 +11,10 @@ class FluxAllergyIntolerance {
     }
 
     /*
-     *  Getter for allergy
+     *  Getter for allergy name
      *  Returns displayText string for allergy
      */
-    get allergyIntolerance() {
+    get name() {
         return this._allergyIntolerance.value.coding[0].displayText;
     }
 

--- a/src/model/allergy/FluxNoKnownAllergy.js
+++ b/src/model/allergy/FluxNoKnownAllergy.js
@@ -16,6 +16,13 @@ class FluxNoKnownAllergy {
     get noKnownAllergy() {
         return this._noKnownAllergy.value.coding[0].displayText;
     }
+
+    /*
+     *  Getter for code
+     */
+    get code() {
+        return this._noKnownAllergy.value.coding[0].code;
+    }
 }
 
 export default FluxNoKnownAllergy;

--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -242,6 +242,10 @@ class PatientRecord {
         return allAllergies;
     }
 
+    getAllAllergiesSortedBySeverity() {
+        return this.getAllAllergies().sort(this._allergiesSeveritySorter);
+    }
+
     // gets all allergy intolerances
     getAllergyIntolerances() {
         return this.getAllAllergies().filter((a) => {
@@ -253,24 +257,6 @@ class PatientRecord {
     getNoKnownAllergies() {
         return this.getAllAllergies().filter((a) => {
             return a instanceof FluxNoKnownAllergy;
-        });
-    }
-
-    getDrugAllergies() {
-        const allergies = this.getAllAllergies();
-        return allergies.filter((a) => {
-            return (
-                (a instanceof FluxNoKnownAllergy && a.code === "409137002") ||
-                (a instanceof FluxAllergyIntolerance && a.category === "medication")
-            );
-        });
-    }
-
-    getNonDrugAllergies() {
-        const drugAllergies = this.getDrugAllergies();
-
-        return this.getAllAllergies().filter((a) => {
-            return !drugAllergies.includes(a);
         });
     }
 
@@ -555,6 +541,42 @@ class PatientRecord {
         if (a.type > b.type) {
             return 1;
         }
+        return 0;
+    }
+
+    _allergiesSeveritySorter(a, b) {
+        let a_severity, b_severity;
+
+        switch (a.severity) {
+            case "Severe": {
+                a_severity = 1;
+                break;
+            }
+            case "Moderate": {
+                a_severity = 0;
+                break;
+            }
+            default: {
+                a_severity = -1;
+            } 
+        }
+
+        switch (b.severity) {
+            case "Severe": {
+                b_severity = 1;
+                break;
+            }
+            case "Moderate": {
+                b_severity = 0;
+                break;
+            }
+            default: {
+                b_severity = -1;
+            }
+        }
+
+        if (a_severity > b_severity) return -1;
+        else if (a_severity < b_severity) return 1;
         return 0;
     }
 

--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -234,7 +234,7 @@ class PatientRecord {
         return conditions;
     }
     
-    getAllergies() {
+    getAllAllergies() {
         let allergies = this.getEntriesIncludingType(FluxAllergyIntolerance);
         const noKnownAllergies = this.getEntriesIncludingType(FluxNoKnownAllergy);
         const allAllergies = allergies.concat(noKnownAllergies);
@@ -242,7 +242,7 @@ class PatientRecord {
     }
     
     getAllergiesAsText() {
-        const allergies = this.getAllergies();
+        const allergies = this.getAllAllergies();
         let result = "";
         let first = true;
         allergies.forEach((allergy, index) => {

--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -242,8 +242,8 @@ class PatientRecord {
         return allAllergies;
     }
 
-    getAllAllergiesSortedBySeverity() {
-        return this.getAllAllergies().sort(this._allergiesSeveritySorter);
+    getAllergyIntolerancesSortedBySeverity() {
+        return this.getAllergyIntolerances().sort(this._allergiesSeveritySorter);
     }
 
     // gets all allergy intolerances

--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -234,11 +234,26 @@ class PatientRecord {
         return conditions;
     }
     
+    // gets all allergy entries from patient
     getAllAllergies() {
         let allergies = this.getEntriesIncludingType(FluxAllergyIntolerance);
         const noKnownAllergies = this.getEntriesIncludingType(FluxNoKnownAllergy);
         const allAllergies = allergies.concat(noKnownAllergies);
         return allAllergies;
+    }
+
+    // gets all allergy intolerances
+    getAllergyIntolerances() {
+        return this.getAllAllergies().filter((a) => {
+            return a instanceof FluxAllergyIntolerance;
+        });
+    }
+
+    // gets all no known allergies
+    getNoKnownAllergies() {
+        return this.getAllAllergies().filter((a) => {
+            return a instanceof FluxNoKnownAllergy;
+        });
     }
 
     getDrugAllergies() {

--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -240,6 +240,22 @@ class PatientRecord {
         const allAllergies = allergies.concat(noKnownAllergies);
         return allAllergies;
     }
+
+    // returns all instances of FluxAllergyIntolerance with specificed category
+    getAllergiesByCategory(category) {
+        const allergies = this.getEntriesIncludingType(FluxAllergyIntolerance);
+        
+        // if an allergy does not have a category
+        if (category === "other") {
+            return allergies.filter((a) => {
+                return Lang.isNull(a.category);
+            });
+        }
+
+        return allergies.filter((a) => {
+            return a.category === category;
+        });
+    }
     
     getAllergiesAsText() {
         const allergies = this.getAllAllergies();
@@ -252,7 +268,7 @@ class PatientRecord {
             if (allergy instanceof FluxNoKnownAllergy) {
                 result += allergy.noKnownAllergy
             } else if (allergy instanceof FluxAllergyIntolerance) {
-                result += allergy.allergyIntolerance;
+                result += allergy.name;
             } else {
                 result += allergy.value.coding[0].displayText;
             }

--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -241,6 +241,24 @@ class PatientRecord {
         return allAllergies;
     }
 
+    getDrugAllergies() {
+        const allergies = this.getAllAllergies();
+        return allergies.filter((a) => {
+            return (
+                (a instanceof FluxNoKnownAllergy && a.code === "409137002") ||
+                (a instanceof FluxAllergyIntolerance && a.category === "medication")
+            );
+        });
+    }
+
+    getNonDrugAllergies() {
+        const drugAllergies = this.getDrugAllergies();
+
+        return this.getAllAllergies().filter((a) => {
+            return !drugAllergies.includes(a);
+        });
+    }
+
     // returns all instances of FluxAllergyIntolerance with specificed category
     getAllergiesByCategory(category) {
         const allergies = this.getEntriesIncludingType(FluxAllergyIntolerance);

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -726,7 +726,7 @@ export default class SummaryMetadata {
         if (Lang.isNull(patient) || Lang.isNull(currentConditionEntry)) return [];
         const allergies = patient.getAllergyIntolerances();
         return allergies.map((a) => {
-            return [{value: a.name}, a.severity, "Causes Hives"];
+            return [{value: a.name}, a.severity, a.manifestation];
         });
     }
 

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -1,7 +1,7 @@
-import FluxHistologicGrade from '../model/oncology/FluxHistologicGrade';
-import FluxTumorDimensions from '../model/oncology/FluxTumorDimensions';
 import Lang from 'lodash'
 import moment from 'moment';
+import FluxHistologicGrade from '../model/oncology/FluxHistologicGrade';
+import FluxTumorDimensions from '../model/oncology/FluxTumorDimensions';
 
 /*
     Each section has the following properties:

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -485,6 +485,7 @@ export default class SummaryMetadata {
                                 headings: ["Allergy", "Severity", "Effects"],
                                 itemsFunction: this.getItemListForAllergies,
                                 preTableCount: "allergies",
+                                postTableList: this.getItemListForNoKnownAllergies,
                             }
                         ]
                     },
@@ -631,6 +632,7 @@ export default class SummaryMetadata {
                                 headings: ["Allergy", "Severity", "Effects"],
                                 itemsFunction: this.getItemListForAllergies,
                                 preTableCount: "allergies",
+                                postTableList: this.getItemListForNoKnownAllergies,
                             }
                         ]
                     },
@@ -724,9 +726,17 @@ export default class SummaryMetadata {
 
     getItemListForAllergies = (patient, currentConditionEntry) => {
         if (Lang.isNull(patient) || Lang.isNull(currentConditionEntry)) return [];
-        const allergies = patient.getAllAllergiesSortedBySeverity();
+        const allergies = patient.getAllergyIntolerancesSortedBySeverity();
         return allergies.map((a) => {
             return [{value: a.name}, a.severity, a.manifestation];
+        });
+    }
+
+    getItemListForNoKnownAllergies = (patient, currentConditionEntry) => {
+        if (Lang.isNull(patient) || Lang.isNull(currentConditionEntry)) return [];
+        let noKnownAllergies = patient.getNoKnownAllergies();
+        return noKnownAllergies.map((a) => {
+            return [{value: a.noKnownAllergy}];
         });
     }
 

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -2,7 +2,6 @@ import FluxHistologicGrade from '../model/oncology/FluxHistologicGrade';
 import FluxTumorDimensions from '../model/oncology/FluxTumorDimensions';
 import Lang from 'lodash'
 import moment from 'moment';
-import FluxAllergyIntolerance from '../model/allergy/FluxAllergyIntolerance';
 
 /*
     Each section has the following properties:
@@ -482,15 +481,11 @@ export default class SummaryMetadata {
                         notFiltered: true,
                         data: [
                             {
-                                name: "Non Drug",
+                                name: "",
                                 headings: ["Allergy", "Severity", "Effects"],
-                                itemsFunction: this.getItemListForNonDrugAllergies
-                            },
-                            {
-                                name: "Drug",
-                                headings: ["Allergy", "Severity", "Effects"],
-                                itemsFunction: this.getItemListForDrugAllergies
-                            },
+                                itemsFunction: this.getItemListForAllergies,
+                                preTableCount: "allergies",
+                            }
                         ]
                     },
                     {
@@ -632,15 +627,11 @@ export default class SummaryMetadata {
                         notFiltered: true,
                         data: [
                             {
-                                name: "Non Drug",
+                                name: "",
                                 headings: ["Allergy", "Severity", "Effects"],
-                                itemsFunction: this.getItemListForNonDrugAllergies
-                            },
-                            {
-                                name: "Drug",
-                                headings: ["Allergy", "Severity", "Effects"],
-                                itemsFunction: this.getItemListForDrugAllergies
-                            },
+                                itemsFunction: this.getItemListForAllergies,
+                                preTableCount: "allergies",
+                            }
                         ]
                     },
                     {
@@ -731,23 +722,11 @@ export default class SummaryMetadata {
         });
     }
 
-    getItemListForNonDrugAllergies = (patient, currentConditionEntry) => {
+    getItemListForAllergies = (patient, currentConditionEntry) => {
         if (Lang.isNull(patient) || Lang.isNull(currentConditionEntry)) return [];
-        const allergies = patient.getNonDrugAllergies();
+        const allergies = patient.getAllergyIntolerances();
         return allergies.map((a) => {
-            if (a instanceof FluxAllergyIntolerance) 
-                return [{value: a.name}, a.severity, "Causes Hives"];
-            return [{value: a.noKnownAllergy}];
-        });
-    }
-
-    getItemListForDrugAllergies = (patient, currentConditionEntry) => {
-        if (Lang.isNull(patient) || Lang.isNull(currentConditionEntry)) return [];
-        const allergies = patient.getDrugAllergies();
-        return allergies.map((a) => {
-            if (a instanceof FluxAllergyIntolerance) 
-                return [{value: a.name}, a.severity, "Causes Hives"];
-            return [{value: a.noKnownAllergy}, " ", " "];
+            return [{value: a.name}, a.severity, "Causes Hives"];
         });
     }
 

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -1,6 +1,5 @@
 import FluxHistologicGrade from '../model/oncology/FluxHistologicGrade';
 import FluxTumorDimensions from '../model/oncology/FluxTumorDimensions';
-import FluxAllergyIntolerance from '../model/allergy/FluxAllergyIntolerance';
 import Lang from 'lodash'
 import moment from 'moment';
 
@@ -484,27 +483,27 @@ export default class SummaryMetadata {
                             {
                                 name: "Food",
                                 headings: ["Allergy", "Severity"],
-                                itemsFunction: this.getItemListForAllergies
+                                itemsFunction: this.getItemListForFoodAllergies
                             },
                             {
                                 name: "Medication",
                                 headings: ["Allergy", "Severity"],
-                                itemsFunction: this.getItemListForAllergies
+                                itemsFunction: this.getItemListForMedicationAllergies
                             },
                             {
                                 name: "Environment",
                                 headings: ["Allergy", "Severity"],
-                                itemsFunction: this.getItemListForAllergies
+                                itemsFunction: this.getItemListForEnvironmentAllergies
                             },
                             {
                                 name: "Biologic",
                                 headings: ["Allergy", "Severity"],
-                                itemsFunction: this.getItemListForAllergies
+                                itemsFunction: this.getItemListForBiologicAllergies
                             },
                             {
                                 name: "Other",
                                 headings: ["Allergy", "Severity"],
-                                itemsFunction: this.getItemListForAllergies
+                                itemsFunction: this.getItemListForOtherAllergies
                             },
                         ]
                     },
@@ -647,10 +646,30 @@ export default class SummaryMetadata {
                         notFiltered: true,
                         data: [
                             {
-                                name: "",
-                                headings: ["Allergy"],
-                                itemsFunction: this.getItemListForAllergies
-                            }
+                                name: "Food",
+                                headings: ["Allergy", "Severity"],
+                                itemsFunction: this.getItemListForFoodAllergies
+                            },
+                            {
+                                name: "Medication",
+                                headings: ["Allergy", "Severity"],
+                                itemsFunction: this.getItemListForMedicationAllergies
+                            },
+                            {
+                                name: "Environment",
+                                headings: ["Allergy", "Severity"],
+                                itemsFunction: this.getItemListForEnvironmentAllergies
+                            },
+                            {
+                                name: "Biologic",
+                                headings: ["Allergy", "Severity"],
+                                itemsFunction: this.getItemListForBiologicAllergies
+                            },
+                            {
+                                name: "Other",
+                                headings: ["Allergy", "Severity"],
+                                itemsFunction: this.getItemListForOtherAllergies
+                            },
                         ]
                     },
                     {
@@ -741,13 +760,43 @@ export default class SummaryMetadata {
         });
     }
 
-    getItemListForAllergies = (patient, currentConditionEntry) => {
+    getItemListForFoodAllergies = (patient, currentConditionEntry) => {
         if (Lang.isNull(patient) || Lang.isNull(currentConditionEntry)) return [];
-        const allergies = patient.getAllAllergies();
-        return allergies.filter((a) => {
-            return a instanceof FluxAllergyIntolerance;
-        }).map((a) => {
-            return [{value: a.allergyIntolerance}, a.severity];
+        const allergies = patient.getAllergiesByCategory("food");
+        return allergies.map((a) => {
+            return [{value: a.name}, a.severity];
+        });
+    }
+
+    getItemListForMedicationAllergies = (patient, currentConditionEntry) => {
+        if (Lang.isNull(patient) || Lang.isNull(currentConditionEntry)) return [];
+        const allergies = patient.getAllergiesByCategory("medication");
+        return allergies.map((a) => {
+            return [{value: a.name}, a.severity];
+        });
+    }
+
+    getItemListForEnvironmentAllergies = (patient, currentConditionEntry) => {
+        if (Lang.isNull(patient) || Lang.isNull(currentConditionEntry)) return [];
+        const allergies = patient.getAllergiesByCategory("environment");
+        return allergies.map((a) => {
+            return [{value: a.name}, a.severity];
+        });
+    }
+
+    getItemListForBiologicAllergies = (patient, currentConditionEntry) => {
+        if (Lang.isNull(patient) || Lang.isNull(currentConditionEntry)) return [];
+        const allergies = patient.getAllergiesByCategory("biologic");
+        return allergies.map((a) => {
+            return [{value: a.name}, a.severity];
+        });
+    }
+
+    getItemListForOtherAllergies = (patient, currentConditionEntry) => {
+        if (Lang.isNull(patient) || Lang.isNull(currentConditionEntry)) return [];
+        const allergies = patient.getAllergiesByCategory("other");
+        return allergies.map((a) => {
+            return [{value: a.name}, a.severity];
         });
     }
 

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -1,8 +1,8 @@
-import Lang from 'lodash'
-import moment from 'moment';
-
 import FluxHistologicGrade from '../model/oncology/FluxHistologicGrade';
 import FluxTumorDimensions from '../model/oncology/FluxTumorDimensions';
+import FluxAllergyIntolerance from '../model/allergy/FluxAllergyIntolerance';
+import Lang from 'lodash'
+import moment from 'moment';
 
 /*
     Each section has the following properties:
@@ -476,6 +476,19 @@ export default class SummaryMetadata {
                         ]
                     },
                     {
+                        name: "Allergies",
+                        clinicalEvents: ["pre-encounter"],
+                        type: "Columns",
+                        notFiltered: true,
+                        data: [
+                            {
+                                name: "",
+                                headings: ["Allergy"],
+                                itemsFunction: this.getItemListForAllergies
+                            }
+                        ]
+                    },
+                    {
                         name: "Timeline",
                         shortName: "Timeline",
                         type: "Events",
@@ -608,6 +621,19 @@ export default class SummaryMetadata {
                         ]
                     },
                     {
+                        name: "Allergies",
+                        clinicalEvents: ["pre-encounter"],
+                        type: "Columns",
+                        notFiltered: true,
+                        data: [
+                            {
+                                name: "",
+                                headings: ["Allergy"],
+                                itemsFunction: this.getItemListForAllergies
+                            }
+                        ]
+                    },
+                    {
                         name: "Timeline",
                         shortName: "Timeline",
                         type: "Events",
@@ -695,7 +721,17 @@ export default class SummaryMetadata {
         });
     }
 
-    getTestsForSubSection = (patient, currentConditionEntry, subsection) => {
+    getItemListForAllergies = (patient, currentConditionEntry) => {
+        if (Lang.isNull(patient) || Lang.isNull(currentConditionEntry)) return [];
+        const allergies = patient.getAllergies();
+        return allergies.filter((a) => {
+            return a instanceof FluxAllergyIntolerance;
+        }).map((a) => {
+            return [{value: a.allergyIntolerance}];
+        });
+    }
+
+    getTestsForSubSection = (patient, currentConditionEntry, subsection) => { 
         if (Lang.isNull(patient) || Lang.isNull(currentConditionEntry)) return [];
         const labResults = currentConditionEntry.getTests();
         labResults.sort(currentConditionEntry._labResultsTimeSorter);

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -476,6 +476,7 @@ export default class SummaryMetadata {
                     },
                     {
                         name: "Allergies",
+                        shortName: "Allergies",
                         clinicalEvents: ["pre-encounter"],
                         type: "Columns",
                         notFiltered: true,
@@ -736,7 +737,7 @@ export default class SummaryMetadata {
         if (Lang.isNull(patient) || Lang.isNull(currentConditionEntry)) return [];
         let noKnownAllergies = patient.getNoKnownAllergies();
         return noKnownAllergies.map((a) => {
-            return [{value: a.noKnownAllergy}];
+            return {value: a.noKnownAllergy};
         });
     }
 
@@ -753,10 +754,10 @@ export default class SummaryMetadata {
             processedLab[subsection.name] = lab.quantity.number;
             processedLab["unit"] = lab.quantity.unit;
 
-            return processedLab
+            return processedLab;
         });
 
-        return labs
+        return labs;
     }
 
     getProgressions = (patient, condition, subsection) => {

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -724,7 +724,7 @@ export default class SummaryMetadata {
 
     getItemListForAllergies = (patient, currentConditionEntry) => {
         if (Lang.isNull(patient) || Lang.isNull(currentConditionEntry)) return [];
-        const allergies = patient.getAllergyIntolerances();
+        const allergies = patient.getAllAllergiesSortedBySeverity();
         return allergies.map((a) => {
             return [{value: a.name}, a.severity, a.manifestation];
         });

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -482,10 +482,30 @@ export default class SummaryMetadata {
                         notFiltered: true,
                         data: [
                             {
-                                name: "",
-                                headings: ["Allergy"],
+                                name: "Food",
+                                headings: ["Allergy", "Severity"],
                                 itemsFunction: this.getItemListForAllergies
-                            }
+                            },
+                            {
+                                name: "Medication",
+                                headings: ["Allergy", "Severity"],
+                                itemsFunction: this.getItemListForAllergies
+                            },
+                            {
+                                name: "Environment",
+                                headings: ["Allergy", "Severity"],
+                                itemsFunction: this.getItemListForAllergies
+                            },
+                            {
+                                name: "Biologic",
+                                headings: ["Allergy", "Severity"],
+                                itemsFunction: this.getItemListForAllergies
+                            },
+                            {
+                                name: "Other",
+                                headings: ["Allergy", "Severity"],
+                                itemsFunction: this.getItemListForAllergies
+                            },
                         ]
                     },
                     {
@@ -723,11 +743,11 @@ export default class SummaryMetadata {
 
     getItemListForAllergies = (patient, currentConditionEntry) => {
         if (Lang.isNull(patient) || Lang.isNull(currentConditionEntry)) return [];
-        const allergies = patient.getAllergies();
+        const allergies = patient.getAllAllergies();
         return allergies.filter((a) => {
             return a instanceof FluxAllergyIntolerance;
         }).map((a) => {
-            return [{value: a.allergyIntolerance}];
+            return [{value: a.allergyIntolerance}, a.severity];
         });
     }
 

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -2,6 +2,7 @@ import FluxHistologicGrade from '../model/oncology/FluxHistologicGrade';
 import FluxTumorDimensions from '../model/oncology/FluxTumorDimensions';
 import Lang from 'lodash'
 import moment from 'moment';
+import FluxAllergyIntolerance from '../model/allergy/FluxAllergyIntolerance';
 
 /*
     Each section has the following properties:
@@ -481,29 +482,14 @@ export default class SummaryMetadata {
                         notFiltered: true,
                         data: [
                             {
-                                name: "Food",
-                                headings: ["Allergy", "Severity"],
-                                itemsFunction: this.getItemListForFoodAllergies
+                                name: "Non Drug",
+                                headings: ["Allergy", "Severity", "Effects"],
+                                itemsFunction: this.getItemListForNonDrugAllergies
                             },
                             {
-                                name: "Medication",
-                                headings: ["Allergy", "Severity"],
-                                itemsFunction: this.getItemListForMedicationAllergies
-                            },
-                            {
-                                name: "Environment",
-                                headings: ["Allergy", "Severity"],
-                                itemsFunction: this.getItemListForEnvironmentAllergies
-                            },
-                            {
-                                name: "Biologic",
-                                headings: ["Allergy", "Severity"],
-                                itemsFunction: this.getItemListForBiologicAllergies
-                            },
-                            {
-                                name: "Other",
-                                headings: ["Allergy", "Severity"],
-                                itemsFunction: this.getItemListForOtherAllergies
+                                name: "Drug",
+                                headings: ["Allergy", "Severity", "Effects"],
+                                itemsFunction: this.getItemListForDrugAllergies
                             },
                         ]
                     },
@@ -646,29 +632,14 @@ export default class SummaryMetadata {
                         notFiltered: true,
                         data: [
                             {
-                                name: "Food",
-                                headings: ["Allergy", "Severity"],
-                                itemsFunction: this.getItemListForFoodAllergies
+                                name: "Non Drug",
+                                headings: ["Allergy", "Severity", "Effects"],
+                                itemsFunction: this.getItemListForNonDrugAllergies
                             },
                             {
-                                name: "Medication",
-                                headings: ["Allergy", "Severity"],
-                                itemsFunction: this.getItemListForMedicationAllergies
-                            },
-                            {
-                                name: "Environment",
-                                headings: ["Allergy", "Severity"],
-                                itemsFunction: this.getItemListForEnvironmentAllergies
-                            },
-                            {
-                                name: "Biologic",
-                                headings: ["Allergy", "Severity"],
-                                itemsFunction: this.getItemListForBiologicAllergies
-                            },
-                            {
-                                name: "Other",
-                                headings: ["Allergy", "Severity"],
-                                itemsFunction: this.getItemListForOtherAllergies
+                                name: "Drug",
+                                headings: ["Allergy", "Severity", "Effects"],
+                                itemsFunction: this.getItemListForDrugAllergies
                             },
                         ]
                     },
@@ -760,43 +731,23 @@ export default class SummaryMetadata {
         });
     }
 
-    getItemListForFoodAllergies = (patient, currentConditionEntry) => {
+    getItemListForNonDrugAllergies = (patient, currentConditionEntry) => {
         if (Lang.isNull(patient) || Lang.isNull(currentConditionEntry)) return [];
-        const allergies = patient.getAllergiesByCategory("food");
+        const allergies = patient.getNonDrugAllergies();
         return allergies.map((a) => {
-            return [{value: a.name}, a.severity];
+            if (a instanceof FluxAllergyIntolerance) 
+                return [{value: a.name}, a.severity, "Causes Hives"];
+            return [{value: a.noKnownAllergy}];
         });
     }
 
-    getItemListForMedicationAllergies = (patient, currentConditionEntry) => {
+    getItemListForDrugAllergies = (patient, currentConditionEntry) => {
         if (Lang.isNull(patient) || Lang.isNull(currentConditionEntry)) return [];
-        const allergies = patient.getAllergiesByCategory("medication");
+        const allergies = patient.getDrugAllergies();
         return allergies.map((a) => {
-            return [{value: a.name}, a.severity];
-        });
-    }
-
-    getItemListForEnvironmentAllergies = (patient, currentConditionEntry) => {
-        if (Lang.isNull(patient) || Lang.isNull(currentConditionEntry)) return [];
-        const allergies = patient.getAllergiesByCategory("environment");
-        return allergies.map((a) => {
-            return [{value: a.name}, a.severity];
-        });
-    }
-
-    getItemListForBiologicAllergies = (patient, currentConditionEntry) => {
-        if (Lang.isNull(patient) || Lang.isNull(currentConditionEntry)) return [];
-        const allergies = patient.getAllergiesByCategory("biologic");
-        return allergies.map((a) => {
-            return [{value: a.name}, a.severity];
-        });
-    }
-
-    getItemListForOtherAllergies = (patient, currentConditionEntry) => {
-        if (Lang.isNull(patient) || Lang.isNull(currentConditionEntry)) return [];
-        const allergies = patient.getAllergiesByCategory("other");
-        return allergies.map((a) => {
-            return [{value: a.name}, a.severity];
+            if (a instanceof FluxAllergyIntolerance) 
+                return [{value: a.name}, a.severity, "Causes Hives"];
+            return [{value: a.noKnownAllergy}, " ", " "];
         });
     }
 

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -20,6 +20,8 @@ import moment from 'moment';
                                 code            Indicates a code to be used by an itemsFunction. This allows multiple sections to share the same
                                                 itemsFunction
                                 bands           Indicates a set of value ranges and the assessment for that range. Some visualizers display bands
+                                preTableCount   Indicates type of items in table, e.g. Allergies.  Will show count of number of items in table.
+                                postTableList   Provide list of structured data to be displayed after the table.
         defaultVisualizer   Indicates the visualizer type for the default visualizer to use for the section. The following ways to specify the
                             default are supported:
                                 "tabular"                                               The specified visualizer type will be the default

--- a/src/summary/TabularListVisualizer.css
+++ b/src/summary/TabularListVisualizer.css
@@ -49,6 +49,17 @@
     cursor: pointer;
 }
 
+.tabular-list ul {
+    list-style-type: none;
+    padding: 0;
+}
+
+.tabular-list ul li {
+    font-size: 0.8rem;
+    text-decoration: underline blue;
+    cursor: pointer;
+}
+
 /* Heading of column*/
 .tabular-list .list-column-heading {
     color: #000;

--- a/src/summary/TabularListVisualizer.css
+++ b/src/summary/TabularListVisualizer.css
@@ -54,4 +54,5 @@
     color: #000;
     background-color: #ffffff;
     padding: 8px 10px;
+    border-bottom: 1px solid lightgray;
 }

--- a/src/summary/TabularListVisualizer.jsx
+++ b/src/summary/TabularListVisualizer.jsx
@@ -132,7 +132,7 @@ class TabularListVisualizer extends Component {
             subsectionname = <tr><td className="list-subsection-header">{transformedSubsection.name}</td></tr>;
         }
         if (list.length <= 0) {
-            return <div>{subsectionname}<h2 style={{paddingTop: '10px'}} key={subsectionindex}>None</h2></div>;
+            return <div key={subsectionindex}>{subsectionname}<h2 style={{paddingTop: '10px'}}>None</h2></div>;
         }
         let headings = null;
         if (transformedSubsection.headings) {
@@ -142,8 +142,12 @@ class TabularListVisualizer extends Component {
             });
             headings = <tr>{renderedColumnHeadings}</tr>;
         }
-        
-        
+
+        let postList = [];
+        if (transformedSubsection.postTableList) {
+            const {patient, condition} = this.props;
+            postList = transformedSubsection.postTableList(patient, condition);
+        }
 
         // TODO: temp variable for now to limit number of columns to be displayed to just the number of headings. Eventually remove this
         const numberOfHeadings = transformedSubsection.headings ? transformedSubsection.headings.length : list[0].length;
@@ -156,6 +160,11 @@ class TabularListVisualizer extends Component {
                     {headings}
                         {subsectionname}
                         {this.renderedListItems(subsectionindex, list, numberOfHeadings)}
+                    </tbody>
+                </table>
+                <table>
+                    <tbody>
+                        {this.renderedListItems(`${subsectionindex}-post`, postList, 1)}
                     </tbody>
                 </table>
             </div>

--- a/src/summary/TabularListVisualizer.jsx
+++ b/src/summary/TabularListVisualizer.jsx
@@ -143,12 +143,6 @@ class TabularListVisualizer extends Component {
             headings = <tr>{renderedColumnHeadings}</tr>;
         }
 
-        let postList = [];
-        if (transformedSubsection.postTableList) {
-            const {patient, condition} = this.props;
-            postList = transformedSubsection.postTableList(patient, condition);
-        }
-
         // TODO: temp variable for now to limit number of columns to be displayed to just the number of headings. Eventually remove this
         const numberOfHeadings = transformedSubsection.headings ? transformedSubsection.headings.length : list[0].length;
 
@@ -163,7 +157,7 @@ class TabularListVisualizer extends Component {
                     </tbody>
                 </table>
                 <ul>
-                    {this.renderedPostTableList(postList)}
+                    {this.renderedPostTableList(transformedSubsection.postTableList)}
                 </ul>
             </div>
         );
@@ -208,7 +202,11 @@ class TabularListVisualizer extends Component {
         });
     }
 
-    renderedPostTableList(list) {
+    renderedPostTableList(itemsFunction) {
+        const {patient, condition} = this.props;
+        if (patient == null || condition == null || Lang.isUndefined(itemsFunction)) return [];
+
+        const list = itemsFunction(patient, condition);
         return list.map((element, index) => {
             const elementId = `post-item-${index}`;
             const elementText = Lang.isNull(element) ? null : (Lang.isObject(element) ? element.value : element);

--- a/src/summary/TabularListVisualizer.jsx
+++ b/src/summary/TabularListVisualizer.jsx
@@ -124,9 +124,12 @@ class TabularListVisualizer extends Component {
     renderedSubsection(transformedSubsection, subsectionindex) {
 
         const list = this.getList(transformedSubsection);
-
+        let subsectionname = null;
+        if (transformedSubsection.name && transformedSubsection.name.length > 0) {
+            subsectionname = <tr><td className="list-subsection-header">{transformedSubsection.name}</td></tr>;
+        }
         if (list.length <= 0) {
-            return <h2 style={{paddingTop: '10px'}} key={subsectionindex}>None</h2>;
+            return <div>{subsectionname}<h2 style={{paddingTop: '10px'}} key={subsectionindex}>None</h2></div>;
         }
         let headings = null;
         if (transformedSubsection.headings) {
@@ -137,10 +140,7 @@ class TabularListVisualizer extends Component {
             headings = <tr>{renderedColumnHeadings}</tr>;
         }
         
-        let subsectionname = null;
-        if (transformedSubsection.name && transformedSubsection.name.length > 0) {
-            subsectionname = <tr><td className="list-subsection-header">{transformedSubsection.name}</td></tr>;
-        }
+        
 
         // TODO: temp variable for now to limit number of columns to be displayed to just the number of headings. Eventually remove this
         const numberOfHeadings = transformedSubsection.headings ? transformedSubsection.headings.length : list[0].length;

--- a/src/summary/TabularListVisualizer.jsx
+++ b/src/summary/TabularListVisualizer.jsx
@@ -122,8 +122,11 @@ class TabularListVisualizer extends Component {
     
     // Render each subsection as a table of values 
     renderedSubsection(transformedSubsection, subsectionindex) {
-
         const list = this.getList(transformedSubsection);
+        let preTableCount = null;
+        if (transformedSubsection.preTableCount) {
+            preTableCount = `${list.length} total ${transformedSubsection.preTableCount}`;
+        }
         let subsectionname = null;
         if (transformedSubsection.name && transformedSubsection.name.length > 0) {
             subsectionname = <tr><td className="list-subsection-header">{transformedSubsection.name}</td></tr>;
@@ -146,13 +149,16 @@ class TabularListVisualizer extends Component {
         const numberOfHeadings = transformedSubsection.headings ? transformedSubsection.headings.length : list[0].length;
 
         return (
-            <table key={subsectionindex}>
-                <tbody>
-                {headings}
-                    {subsectionname}
-                    {this.renderedListItems(subsectionindex, list, numberOfHeadings)}
-                </tbody>
-            </table>
+            <div key={subsectionindex}>
+                {preTableCount}
+                <table>
+                    <tbody>
+                    {headings}
+                        {subsectionname}
+                        {this.renderedListItems(subsectionindex, list, numberOfHeadings)}
+                    </tbody>
+                </table>
+            </div>
         );
     }
 

--- a/src/summary/TabularListVisualizer.jsx
+++ b/src/summary/TabularListVisualizer.jsx
@@ -162,11 +162,9 @@ class TabularListVisualizer extends Component {
                         {this.renderedListItems(subsectionindex, list, numberOfHeadings)}
                     </tbody>
                 </table>
-                <table>
-                    <tbody>
-                        {this.renderedListItems(`${subsectionindex}-post`, postList, 1)}
-                    </tbody>
-                </table>
+                <ul>
+                    {this.renderedPostTableList(postList)}
+                </ul>
             </div>
         );
     }
@@ -210,22 +208,74 @@ class TabularListVisualizer extends Component {
         });
     }
 
+    renderedPostTableList(list) {
+        return list.map((element, index) => {
+            const elementId = `post-item-${index}`;
+            const elementText = Lang.isNull(element) ? null : (Lang.isObject(element) ? element.value : element);
+            if (this.props.allowItemClick) {
+                return (
+                    <li key={elementId}>
+                        {this.renderedStructuredData(elementText, element, elementId, elementText)}
+                    </li>
+                );
+            } else {
+                return (
+                    <li key={elementId}>
+                        <span>
+                            {elementText}
+                        </span>
+                    </li>
+                );
+            }
+        });
+    }
+
+    renderedStructuredData(item, element, elementId, elementText) {
+        const {
+            elementToDisplayMenu,
+            positionLeft,
+            positionTop,
+        } = this.state;
+
+        const insertItem = (element) => {
+            const callback = () => { 
+                this.props.onItemClicked(element);
+            };
+            this.closeInsertionMenu(callback);
+        };
+        return (
+            <div>
+                <span
+                    data-test-summary-item={item} 
+                    onClick={(event) => this.openInsertionMenu(event, elementId)}
+                >
+                    {elementText}
+                </span>
+                <Menu
+                    open={elementToDisplayMenu === elementId}
+                    anchorReference="anchorPosition"
+                    anchorPosition={{ top: positionTop, left: positionLeft }}
+                    onClose={(event) => this.closeInsertionMenu()}
+                    className="narrative-inserter-tooltip"
+                >
+                    <MenuItem   
+                        onClick={() => insertItem(element)}
+                        className="narrative-inserter-box"
+                    >
+                        <ListItemIcon>
+                            <FontAwesome name="plus"/>
+                        </ListItemIcon>
+                        <ListItemText className='narrative-inserter-menu-item' inset primary={`Insert "${elementText}"`} />
+                    </MenuItem>
+                </Menu>
+            </div>
+        );
+    }
+
     // Render a given list item as a cell in a table
     renderedListItem(item, subsectionindex, index, rowClass, itemClass, onClick, hoverClass) {
             // Array of all columns
             const renderedColumns = [];
-            const {
-              elementToDisplayMenu,
-              positionLeft,
-              positionTop,
-            } = this.state;
-
-            const insertItem = (element) => {
-                const callback = () => { 
-                    this.props.onItemClicked(element);
-                };
-                this.closeInsertionMenu(callback);
-            };
             
             let isInsertable, elementText;
             const numColumns = item.length;
@@ -259,29 +309,7 @@ class TabularListVisualizer extends Component {
                             className={itemClass} 
                             key={elementId}
                         >   
-                            <span
-                                data-test-summary-item={item[0].value} 
-                                onClick={(event) => this.openInsertionMenu(event, elementId)}
-                            >
-                                {elementText}
-                            </span>
-                            <Menu
-                                open={elementToDisplayMenu === elementId}
-                                anchorReference="anchorPosition"
-                                anchorPosition={{ top: positionTop, left: positionLeft }}
-                                onClose={(event) => this.closeInsertionMenu()}
-                                className="narrative-inserter-tooltip"
-                            >
-                                <MenuItem   
-                                    onClick={() => insertItem(element)}
-                                    className="narrative-inserter-box"
-                                >
-                                    <ListItemIcon>
-                                        <FontAwesome name="plus"/>
-                                    </ListItemIcon>
-                                    <ListItemText className='narrative-inserter-menu-item' inset primary={`Insert "${elementText}"`} />
-                                </MenuItem>
-                            </Menu>
+                        {this.renderedStructuredData(item[0].value, element, elementId, elementText)}
                         </td>
                     );
                 } else if (!isInsertable) {


### PR DESCRIPTION
Addresses JIRA-909.

![image](https://user-images.githubusercontent.com/6588796/36437473-11b703c2-1635-11e8-9cdb-10be769bdacf.png)

Received input from Edwin on how to display the allergies.  Instead of separating the allergies into different categories, all allergies are displayed in one table with a count of the total number of allergies before the table and a list of the no known allergies displayed after the table.  The allergies in the table are sorted by severity.

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
-  Cheat sheet is updated
-  Demo script is updated 
-  Documentation on Wiki has been updated 
-  Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

-  Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
-  Added UI tests for slim mode 
-  Added UI tests for full mode
-  Added backend tests for fluxNotes code
-  Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
