### PR TITLE
Added support for multiple conditions in the context tray

### DIFF
--- a/src/containers/FullApp.jsx
+++ b/src/containers/FullApp.jsx
@@ -157,23 +157,21 @@ export default class FullApp extends Component {
             if (Lang.isArray(item) && arrayIndex >= 0) {
                 // If the object to insert has an associated shortcut, is will be an object like {name: x, shortcut: z}
                 if(Lang.isObject(item[arrayIndex])){
-                    this.setState({SummaryItemToInsert: `${item[arrayIndex].shortcut}[[${item[arrayIndex].name}]]`});
+                    this.setState({ SummaryItemToInsert: `${item[arrayIndex].shortcut}[[${item[arrayIndex].name}]]` });
                 } else {
-                    this.setState({SummaryItemToInsert: item[arrayIndex]});
+                    this.setState({ SummaryItemToInsert: item[arrayIndex]});
                 }
             } else if (item.shortcut) {
-                this.setState({summaryItemToInsert: `${item.shortcut}[[${item.value}]]`});
+                this.setState({ summaryItemToInsert: `${item.shortcut}[[${item.value}]]` });
             } else if (item.value) {
-                this.setState({summaryItemToInsert: item.value});
+                this.setState({ summaryItemToInsert: item.value });
             } else {
-                this.setState({summaryItemToInsert: item});
+                this.setState({ summaryItemToInsert: item });
             }
         }
     }
 
     render() {
-
-
         // Get the Current Dashboard based on superRole of user
         const CurrentDashboard = this.dashboardManager.getDashboardForSuperRole(this.state.superRole);
 

--- a/src/context/Context.jsx
+++ b/src/context/Context.jsx
@@ -4,11 +4,12 @@ export default class Context {
 	constructor() {
 		this.children = [];
 	}
+
 	initialize(contextManager, trigger = undefined, updatePatient = true) {
         this.contextManager = contextManager;
         this.isInContext = false;
 	}
-    
+
     getId() {
         throw new Error("implement getId in all Context implementations. not done in " + constructor.name);
     }
@@ -16,11 +17,11 @@ export default class Context {
 	getValidChildShortcuts(recurse = false) {
 		return [];
 	}
-    
+
     addChild(shortcut) {
         this.children.push(shortcut);
     }
-    
+
     removeChild(shortcut) {
         var indexToDelete = -1;
         this.children.forEach((item, i) => {
@@ -30,33 +31,39 @@ export default class Context {
         });
         this.children.splice(indexToDelete, 1);
     }
-    
+
     hasChildren() {
         return (this.children.length > 0);
     }
-	
+
 	getChildren() {
 		return this.children;
 	}
-	
+
 	getLabel() {
 		throw new Error("Invalid context. " + this.constructor.name);
 	}
+
 	getValueObject() {
 		return this.valueObject;
 	}
+
 	setValueObject(valueObject) {
 		this.valueObject = valueObject;
 	}
+
 	getAttributeValue(name) {
 		throw new Error("[getAttributeValue]Unsupported attribute " + name + " for context shortcut " + this.constructor.name);
 	}
+
 	setAttributeValue(name, value, publishChanges, updatePatient = true) {
 		throw new Error("[setAttributeValue]Unsupported attribute " + name + " for context shortcut " + this.constructor.name);
 	}
+
     shouldBeInContext() {
         return true;
     }
+
 	onValueChange(name, handleValueChange) {
 		let l = this.valueChangeHandlers[name];
 		if (Lang.isUndefined(l) || Lang.isNull(l)) {
@@ -64,7 +71,8 @@ export default class Context {
 			this.valueChangeHandlers[name] = l;
 		}
 		l.push(handleValueChange);
-	}	
+	}
+
 	notifyValueChangeHandlers(name) {
 		let l = this.valueChangeHandlers[name];
         if (Lang.isUndefined(l)) return;
@@ -72,7 +80,7 @@ export default class Context {
 			h(this.getAttributeValue(name));
 		});
 	}
-	
+
     updateContextStatus() {
         if (this.contextManager) {
             const shouldBeInContext = this.shouldBeInContext();
@@ -88,10 +96,11 @@ export default class Context {
             }
         }
     }
-    
+
     getKey() {
         return this.key;
     }
+
     setKey(key) {
         //console.log("setKey: " + this.constructor.name + " to " + key);
         this.key = key;

--- a/src/context/ContextOptions.css
+++ b/src/context/ContextOptions.css
@@ -1,8 +1,8 @@
 .context-option {
-    margin: 10px 20px;
+    margin: 5px 0 5px 26px;
     cursor: pointer;
     font-size: 0.9em;
-    color: #999;
+    color: #888;
 }
 
 .context-option:hover,

--- a/src/context/ContextOptions.jsx
+++ b/src/context/ContextOptions.jsx
@@ -10,8 +10,6 @@ import './ContextOptions.css'
 export default class ContextOptions extends Component {
     constructor(props) {
         super(props);
-        this._handleClick = this._handleClick.bind(this);
-        this._handleSearch = this._handleSearch.bind(this);
 
         this.state = {
             searchString: "",
@@ -19,10 +17,14 @@ export default class ContextOptions extends Component {
         }
     }
 
-    _handleClick(e, i) {
+    handleClick = (e, i) => {
         e.preventDefault();
         this.setState({ searchString: "", tooltipVisibility: 'hidden' });
         this.props.handleClick(i);
+    }
+
+    handleSearch = (value) => {
+        this.setState({ searchString: value });
     }
 
     mouseLeave = () => {
@@ -31,10 +33,6 @@ export default class ContextOptions extends Component {
 
     mouseEnter = () => {
         this.setState({ tooltipVisibility: 'visible' })
-    }
-
-    _handleSearch(value) {
-        this.setState({ searchString: value });
     }
 
     render() {
@@ -111,7 +109,7 @@ export default class ContextOptions extends Component {
                             className="shortcut-search-text"
                             label="Search shortcuts"
                             value={this.state.searchString}
-                            onChange={(event) => this._handleSearch(event.target.value)}
+                            onChange={(event) => this.handleSearch(event.target.value)}
                         />
                     </div>
                 </div>
@@ -133,19 +131,24 @@ export default class ContextOptions extends Component {
                     {groupList.map((groupObj, i) => {
                         return (
                         <div key={`group-${i}`}>
-                            {groupObj.groupName != null ? <div id="data-element-description">{groupObj.groupName}</div> : <div className="hidden"></div>}
+                            {groupObj.groupName != null ?
+                                <div id="data-element-description">{groupObj.groupName}</div>
+                            :
+                                <div className="hidden"></div>
+                            }
 
                             <div key={i}>
                                 {groupObj.triggers.map((trigger, i) => {
-                                    const tooltipClass = (trigger.description.length > 100) ? "context-panel-tooltip large" : "context-panel-tooltip";
+                                    const largeTrigger = trigger.description.length > 100;
                                     const text = <span>{trigger.description}</span>
+                                    const selected = activeContextTriggers.indexOf(trigger.name) > -1;
 
                                     return (
                                         <Tooltip
                                             key={trigger.name}
                                             overlayStyle={{'visibility': this.state.tooltipVisibility}}
                                             placement="left"
-                                            overlayClassName={tooltipClass}
+                                            overlayClassName={`context-panel-tooltip${largeTrigger ? ' large' : ''}`}
                                             overlay={text}
                                             destroyTooltipOnHide={true}
                                             mouseEnterDelay={0.5}
@@ -153,9 +156,9 @@ export default class ContextOptions extends Component {
                                             onMouseLeave={this.mouseLeave}
                                         >
                                             <div
-                                                className={`context-option${activeContextTriggers.indexOf(trigger.name) > -1 ? ' selected' : ''}`}
+                                                className={`context-option${selected ? ' selected' : ''}`}
                                                 key={trigger.name}
-                                                onClick={(e) => this._handleClick(e, trigger.name)}
+                                                onClick={(e) => this.handleClick(e, trigger.name)}
                                             >
                                                 {trigger.name}
                                             </div>

--- a/src/context/ContextTray.css
+++ b/src/context/ContextTray.css
@@ -1,5 +1,6 @@
 .context-tray {
   margin: 20px 0;
+  color: #888;
 }
 
 .context-tray section {
@@ -8,12 +9,21 @@
 }
 
 .context-tray .section-item {
-  padding: 5px 20px;
+  margin: 3px 0;
   font-size: 0.9em;
   cursor: pointer;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .context-tray .section-item:hover,
 .context-tray .section-item.selected {
   font-weight: bold;
+  color: #333;
+}
+
+.context-tray .fa {
+  font-size: 1.4em;
+  color: #aaa;
 }

--- a/src/context/ContextTray.jsx
+++ b/src/context/ContextTray.jsx
@@ -84,7 +84,7 @@ export default class ContextTray extends Component {
     renderParentContexts(contexts) {
         const activeContextIndex = this.state.value - 2;
         const activeContext = contexts[activeContextIndex];
-        const parentContexts = contexts.filter((context) => context.parentContext == null && context.initiatingTrigger === '@condition');
+        const parentContexts = contexts.filter((context) => context.parentContext == null);
 
         if (parentContexts.length === 0) {
             return null;
@@ -183,7 +183,6 @@ export default class ContextTray extends Component {
 
         return (
             <div className="context-tray">
-                {/* TEMPLATES and PATIENT selectors - default */}
                 <section>
                     <div
                         className={`section-item${value === 0 ? ' selected' : ''}`}
@@ -202,7 +201,6 @@ export default class ContextTray extends Component {
                     </div>
                 </section>
 
-                {/* Templates list */}
                 {value === 0 &&
                     <section>
                         <TemplateForm

--- a/src/forms/TemplateForm.css
+++ b/src/forms/TemplateForm.css
@@ -1,7 +1,7 @@
 .template {
-  padding: 5px 20px;
+  margin: 5px 0 5px 26px;
   font-size: 0.9em;
-  color: #999;
+  color: #888;
   cursor: pointer;
 }
 

--- a/test/ui/FullApp.js
+++ b/test/ui/FullApp.js
@@ -515,7 +515,68 @@ test('Clicking "@condition", "#disease status", "#stable", "#as of", "#date" and
     // Assert that the number of progressions is correct
     await t
         .expect(expectedNumItems).eql(numItems, 'There should be ' + expectedNumItems + ' progression items on the timeline.');
+});
 
+test('Clicking "@condition" and choosing "Invasive ductal carcinoma of breast" creates a new condition section in the context tray.', async t => {
+    const contextPanelElements = Selector(".context-options-list").find('.context-option');
+    const conditionButton = await contextPanelElements.withText(/@condition/ig);
+
+    await t
+        .click(conditionButton);
+    const selectedCondition = Selector('.context-portal').find('li').withText('Invasive ductal carcinoma of breast');
+    await t
+        .click(selectedCondition);
+    const conditionSection = Selector('.context-tray').find('div').withAttribute('title', 'Invasive ductal carcinoma of breast');
+    await t
+        .expect(conditionSection.exists)
+        .ok();
+    const conditionSectionSnapshot = await conditionSection();
+    await t
+        .expect(conditionSectionSnapshot.hasClass('selected'))
+        .ok();
+});
+
+test('Clicking "@condition" and choosing multiple conditions creates condition sections for each in the context tray.', async t => {
+    const contextPanelElements = Selector('.context-options-list').find('.context-option');
+    const sectionItemElements = Selector('.context-tray').find('.section-item');
+    const conditionButton = await contextPanelElements.withText(/@condition/ig);
+    const patientButton = await sectionItemElements.withText(/Patient/g);
+
+    // first condition
+    await t
+        .click(conditionButton);
+    const selectedConditionInvasive = Selector('.context-portal').find('li').withText('Invasive ductal carcinoma of breast');
+    await t
+        .click(selectedConditionInvasive);
+    const conditionSectionInvasive = Selector('.context-tray').find('div').withAttribute('title', 'Invasive ductal carcinoma of breast');
+    await t
+        .expect(conditionSectionInvasive.exists)
+        .ok();
+    let conditionSectionInvasiveSnapshot = await conditionSectionInvasive();
+    await t
+        .expect(conditionSectionInvasiveSnapshot.hasClass('selected'))
+        .ok();
+
+    // second condition
+    await t
+        .click(patientButton);
+    await t
+        .click(conditionButton);
+    const selectedConditionFracture = Selector('.context-portal').find('li').withText('Fracture');
+    await t
+        .click(selectedConditionFracture);
+    const conditionSectionFracture = Selector('.context-tray').find('div').withAttribute('title', 'Fracture');
+    await t
+        .expect(conditionSectionFracture.exists)
+        .ok();
+    const conditionSectionFractureSnapshot = await conditionSectionFracture();
+    await t
+        .expect(conditionSectionFractureSnapshot.hasClass('selected'))
+        .ok();
+    conditionSectionInvasiveSnapshot = await conditionSectionInvasive();
+    await t
+        .expect(conditionSectionInvasiveSnapshot.hasClass('selected'))
+        .notOk();
 });
 
 
@@ -755,7 +816,6 @@ test('Contents of in-progress note saved when switching to a completed note and 
         .notEql("");
 });
 
-
 test('Clicking on an in-progress note in post encounter mode puts the NotesPanel in edit mode with the context tray displayed', async t => {
     const editor = Selector("div[data-slate-editor='true']");
     const clinicalNotesButton = Selector('#notes-btn');
@@ -936,6 +996,7 @@ test('Clicking the data visualization buttons changes the visualizer used', asyn
         }
     }
 });
+
 
 fixture('Patient Mode - Timeline')
     .page(startPage);


### PR DESCRIPTION
# Added support for multiple conditions in the context tray

Selecting a condition will now show a section for the selected condition in the context tray with child context sections below. Selecting a second condition will add it to the context tray below the first condition with its child context sections below instead. Added arrows to denote collapsing of context sections not currently displayed. New functionality matches designs from `shr_fluxnotes_concept_v12.6_selected_concepts_screens.pdf` section 4.

Added UI tests. Tested in Chrome and IE. Other minor changes due to code and editor whitespace cleanup.

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter: Noranda

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- Cheat sheet is updated
- Demo script is updated 
- Documentation on Wiki has been updated 
- Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- Added UI tests for slim mode 
- [x] Added UI tests for full mode
- Added backend tests for fluxNotes code
- Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
