### PR TITLE
Clinical trials section

### DIFF
--- a/src/clinicalTrials/ClinicalTrialsList.jsx
+++ b/src/clinicalTrials/ClinicalTrialsList.jsx
@@ -34,7 +34,8 @@ class ClinicalTrialsList {
     
     getClinicalTrialByName(name){
         let clinicalTrials = this.clinicalTrials.filter((trial) => {
-            return trial.name === name;});
+            return trial.name === name;
+        });
         if (clinicalTrials.length === 0){
             return null;
         }

--- a/src/clinicalTrials/ClinicalTrialsList.jsx
+++ b/src/clinicalTrials/ClinicalTrialsList.jsx
@@ -31,6 +31,16 @@ class ClinicalTrialsList {
                 return null;
         }
     }
+    
+    getClinicalTrialByName(name){
+        let clinicalTrials = this.clinicalTrials.filter((trial) => {
+            return trial.name === name;});
+        if (clinicalTrials.length === 0){
+            return null;
+        }
+
+        return clinicalTrials[0];
+    }
 }
 
 export default ClinicalTrialsList;

--- a/src/model/research/FluxStudy.js
+++ b/src/model/research/FluxStudy.js
@@ -1,5 +1,6 @@
 import Study from '../shr/research/Study';
 import Title from '../shr/core/Title';
+import Details from '../shr/core/Details';
 import Identifier from '../shr/core/Identifier';
 import Entry from '../shr/base/Entry';
 import EntryType from '../shr/base/EntryType';
@@ -31,7 +32,7 @@ class FluxStudy {
         if (this._study.title) {
             return this._study.title.value;
         } else {
-            return null;
+            return "";
         }
     }
 
@@ -46,6 +47,29 @@ class FluxStudy {
         titleObj.value = title; 
         this._study.title = titleObj;
     }
+    /**
+     *  Getter for detail
+     *  This will return the displayText value from the Detail object
+     */    
+    get details() {
+        if (this._study.details) {
+            return this._study.details.value;
+        } else {
+            return "";
+        }
+    }
+
+    /**
+     *  Setter for details
+     *  The setter method is expecting a details sting
+     *  The method will create a Details object and set the value to the detail string
+     */
+    set details(details) {
+        if (Lang.isNull(details)) return;
+        let detailsObj = new Details();
+        detailsObj.value = details; 
+        this._study.details = detailsObj;
+    }    
 
     /**
      *  Getter for identifier

--- a/src/model/research/FluxStudy.js
+++ b/src/model/research/FluxStudy.js
@@ -49,7 +49,7 @@ class FluxStudy {
     }
     /**
      *  Getter for detail
-     *  This will return the displayText value from the Detail object
+     *  This will return the displayText value from the Details object
      */    
     get details() {
         if (this._study.details) {

--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -249,8 +249,7 @@ class PatientRecord {
         
         return result + ".";
     }
-       
-    
+           
     getClinicalTrials(){
         let clinicalTrialList = new ClinicalTrialsList();
         let result = this.getEntriesOfType(FluxStudy);
@@ -258,11 +257,8 @@ class PatientRecord {
         result.forEach((study) => {
             let trial = clinicalTrialList.getClinicalTrialByName(study.title);
             if (trial) {
-                
                 study.details = trial.description;
             }
-            
-
         });
         
         return result;

--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -13,14 +13,13 @@ import FluxPatientIdentifier from '../model/base/FluxPatientIdentifier';
 import FluxProcedureRequested from '../model/procedure/FluxProcedureRequested';
 import FluxQuestionAnswer from '../model/finding/FluxQuestionAnswer';
 import FluxStudy from '../model/research/FluxStudy';
-import ClinicalTrialsList from '../clinicalTrials/ClinicalTrialsList';
+import ClinicalTrialsList from '../clinicalTrials/ClinicalTrialsList.jsx'; // put jsx because yarn test-ui errors on this import otherwise
 import CreationTime from '../model/shr/core/CreationTime';
 import LastUpdated from '../model/shr/base/LastUpdated';
 import mapper from '../lib/FHIRMapper';
 import Lang from 'lodash';
 import moment from 'moment';
 import Guid from 'guid';
-
 
 class PatientRecord {
     constructor(shrJson = null) {

--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -12,12 +12,14 @@ import FluxPatient from '../model/entity/FluxPatient';
 import FluxPatientIdentifier from '../model/base/FluxPatientIdentifier';
 import FluxProcedureRequested from '../model/procedure/FluxProcedureRequested';
 import FluxQuestionAnswer from '../model/finding/FluxQuestionAnswer';
+import FluxStudy from '../model/research/FluxStudy';
 import CreationTime from '../model/shr/core/CreationTime';
 import LastUpdated from '../model/shr/base/LastUpdated';
 import mapper from '../lib/FHIRMapper';
 import Lang from 'lodash';
 import moment from 'moment';
 import Guid from 'guid';
+
 
 class PatientRecord {
     constructor(shrJson = null) {
@@ -246,6 +248,15 @@ class PatientRecord {
         }
         
         return result + ".";
+    }
+    
+    getClinicalTrails(){
+        return this.getEntriesOfType(FluxStudy);
+    }
+    
+    getEnrolledClinicalTrials(){
+        let enrolled = this.getClinicalTrails();
+        return enrolled.title;
     }
 
     getConditions() {

--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -13,6 +13,7 @@ import FluxPatientIdentifier from '../model/base/FluxPatientIdentifier';
 import FluxProcedureRequested from '../model/procedure/FluxProcedureRequested';
 import FluxQuestionAnswer from '../model/finding/FluxQuestionAnswer';
 import FluxStudy from '../model/research/FluxStudy';
+import ClinicalTrialsList from '../clinicalTrials/ClinicalTrialsList';
 import CreationTime from '../model/shr/core/CreationTime';
 import LastUpdated from '../model/shr/base/LastUpdated';
 import mapper from '../lib/FHIRMapper';
@@ -249,15 +250,25 @@ class PatientRecord {
         
         return result + ".";
     }
+       
     
-    getClinicalTrails(){
-        return this.getEntriesOfType(FluxStudy);
+    getClinicalTrials(){
+        let clinicalTrialList = new ClinicalTrialsList();
+        let result = this.getEntriesOfType(FluxStudy);
+            
+        result.forEach((study) => {
+            let trial = clinicalTrialList.getClinicalTrialByName(study.title);
+            if (trial) {
+                
+                study.details = trial.description;
+            }
+            
+
+        });
+        
+        return result;
     }
-    
-    getEnrolledClinicalTrials(){
-        let enrolled = this.getClinicalTrails();
-        return enrolled.title;
-    }
+   
 
     getConditions() {
         return this.getEntriesIncludingType(FluxCondition);

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -491,7 +491,7 @@ export default class SummaryMetadata {
                         data: [
                             {
                                 name: "",
-                                headings: ["Name", "Date of Enrollment", "Description"],
+                                headings: ["Name", "Date of Enrollment", "Date of Unenrollment", "Description"],
                                 itemsFunction: this.getItemListForEnrolledClinicalTrials
                             }
                         ]
@@ -759,8 +759,9 @@ export default class SummaryMetadata {
                     {
                         value: c.title,
                     },
-                    c.enrollmentDate, 
-                    c.details
+                    c.enrollmentDate,
+                    c.endDate,
+                    c.details                  
                 ]; 
             }); 
         }

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -751,23 +751,21 @@ export default class SummaryMetadata {
         if (Lang.isNull(patient) || Lang.isNull(currentConditionEntry)) return [];
 
         const clinicalTrials = patient.getClinicalTrials(currentConditionEntry);
-        if (clinicalTrials.length === 0){
+        if (clinicalTrials.length === 0) {
             return [];
-        }
-        else {        
-        
+        } else {        
             return clinicalTrials.map((c, i) => {
-                return[
+                return [
                     {
                         value: c.title,
                     },
-                 c.enrollmentDate, c.details
+                    c.enrollmentDate, 
+                    c.details
                 ]; 
             }); 
         }
     }       
         
-
     getItemListForAllergies = (patient, currentConditionEntry) => {
         if (Lang.isNull(patient) || Lang.isNull(currentConditionEntry)) return [];
         const allergies = patient.getAllergyIntolerancesSortedBySeverity();

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -491,7 +491,7 @@ export default class SummaryMetadata {
                         data: [
                             {
                                 name: "",
-                                headings: ["Name", "Description"],
+                                headings: ["Name", "Date of Enrollment", "Description"],
                                 itemsFunction: this.getItemListForEnrolledClinicalTrials
                             }
                         ]
@@ -761,7 +761,7 @@ export default class SummaryMetadata {
                     {
                         value: c.title,
                     },
-                c.details
+                 c.enrollmentDate, c.details
                 ]; 
             }); 
         }

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -193,6 +193,20 @@ export default class SummaryMetadata {
                                 ]
                             },
                             {
+                                name: "Clincal Trials",
+                                items: [
+                                    {
+                                        name: "Enrolled",
+                                        value: (patient, currentConditionEntry) => {
+                                            const clinicalTrials = patient.getEnrolledClinicalTrials();
+                                            if (Lang.isUndefined(clinicalTrials)) return "None";
+                                            return patient.getEnrolledClinicalTrials().title;
+                                            
+                                        }
+                                    },
+                                ]
+                            },                            
+                            {
                                 name: "Recent Lab Results",
                                 itemsFunction: this.getItemListForLabResults
                             },

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -223,6 +223,7 @@ export default class SummaryMetadata {
                     {
                         name: "Clinical Trials",
                         shortName: "Trials",
+                        clinicalEvents: ["pre-encounter"],
                         type: "Columns",
                         notFiltered: true,
                         data: [

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -219,21 +219,7 @@ export default class SummaryMetadata {
                             }
 
                         ]
-                    },
-                    {
-                        name: "Clinical Trials",
-                        shortName: "Trials",
-                        clinicalEvents: ["pre-encounter"],
-                        type: "Columns",
-                        notFiltered: true,
-                        data: [
-                            {
-                                name: "Enrolled",
-                                headings: ["Name", "Description"],
-                                itemsFunction: this.getItemListForEnrolledClinicalTrials
-                            }
-                        ]
-                    },                    
+                    },                   
                     {
                         name: "Procedures",
                         shortName: "Procedures",
@@ -496,6 +482,20 @@ export default class SummaryMetadata {
                             }
                         ]
                     },
+                    {
+                        name: "Clinical Trials",
+                        shortName: "Trials",
+                        clinicalEvents: ["pre-encounter"],
+                        type: "Columns",
+                        notFiltered: true,
+                        data: [
+                            {
+                                name: "",
+                                headings: ["Name", "Description"],
+                                itemsFunction: this.getItemListForEnrolledClinicalTrials
+                            }
+                        ]
+                    }, 
                     {
                         name: "Allergies",
                         shortName: "Allergies",

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -191,21 +191,7 @@ export default class SummaryMetadata {
                                         }
                                     }
                                 ]
-                            },
-                            {
-                                name: "Clincal Trials",
-                                items: [
-                                    {
-                                        name: "Enrolled",
-                                        value: (patient, currentConditionEntry) => {
-                                            const clinicalTrials = patient.getEnrolledClinicalTrials();
-                                            if (Lang.isUndefined(clinicalTrials)) return "None";
-                                            return patient.getEnrolledClinicalTrials().title;
-                                            
-                                        }
-                                    },
-                                ]
-                            },                            
+                            },                           
                             {
                                 name: "Recent Lab Results",
                                 itemsFunction: this.getItemListForLabResults
@@ -234,6 +220,19 @@ export default class SummaryMetadata {
 
                         ]
                     },
+                    {
+                        name: "Clinical Trials",
+                        shortName: "Trials",
+                        type: "Columns",
+                        notFiltered: true,
+                        data: [
+                            {
+                                name: "Enrolled",
+                                headings: ["Name", "Description"],
+                                itemsFunction: this.getItemListForEnrolledClinicalTrials
+                            }
+                        ]
+                    },                    
                     {
                         name: "Procedures",
                         shortName: "Procedures",
@@ -746,6 +745,27 @@ export default class SummaryMetadata {
             };
         });
     }
+        
+    getItemListForEnrolledClinicalTrials = (patient, currentConditionEntry) => {
+        if (Lang.isNull(patient) || Lang.isNull(currentConditionEntry)) return [];
+
+        const clinicalTrials = patient.getClinicalTrials(currentConditionEntry);
+        if (clinicalTrials.length === 0){
+            return [];
+        }
+        else {        
+        
+            return clinicalTrials.map((c, i) => {
+                return[
+                    {
+                        value: c.title,
+                    },
+                c.details
+                ]; 
+            }); 
+        }
+    }       
+        
 
     getItemListForAllergies = (patient, currentConditionEntry) => {
         if (Lang.isNull(patient) || Lang.isNull(currentConditionEntry)) return [];


### PR DESCRIPTION
Created a clinical trial section in pre-encounter mode. Best way to test that the values are being updated is to go to post encounter and select #enrolled #PATINA #date and going back to pre-encounter and seeing the name, date of enrollment and description being pulled from the clinical trial list in out clinical trials folder. 


## Submitter: Laura Clark

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- NA Cheat sheet is updated
- NA Demo script is updated 
- NA Documentation on Wiki has been updated 
- NA Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- NA Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- NA Existing tests passed
- NA Added UI tests for slim mode 
- NA Added UI tests for full mode
- NA Added backend tests for fluxNotes code
- NA Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
