### PR TITLE
Fix lab result graphs

### DIFF
--- a/src/model/condition/FluxCondition.js
+++ b/src/model/condition/FluxCondition.js
@@ -87,10 +87,11 @@ class FluxCondition {
     // This method takes in a sinceDate, oldest date acceptable. All results returned must be more recent than sinceDate
     getLabResultsChronologicalOrder(sinceDate) {
         let results = this.getTests();
-        let sortedResults = results.sort(this._observationsTimeSorter);
-        let mostRecentLabResults = sortedResults;
+        results.sort(this._observationsTimeSorter);
+        
+        let mostRecentLabResults = results;
         if (sinceDate && !Lang.isNull(sinceDate)) {
-            mostRecentLabResults = this.getMostRecentLabResults(sortedResults, sinceDate);
+            mostRecentLabResults = this.getMostRecentLabResults(results, sinceDate);
         }
 
         return mostRecentLabResults;
@@ -242,7 +243,7 @@ class FluxCondition {
         if (recentProgression) {
             events.push(recentProgression);
         }
-        events = events.sort(this._eventsTimeSorter);
+        events.sort(this._eventsTimeSorter);
 
         const procedureTemplates = {
             range: 'Patient underwent {0} from {1} to {2}',

--- a/src/model/condition/FluxCondition.js
+++ b/src/model/condition/FluxCondition.js
@@ -88,7 +88,7 @@ class FluxCondition {
     getLabResultsChronologicalOrder(sinceDate) {
         let results = this.getTests();
         results.sort(this._observationsTimeSorter);
-        
+
         let mostRecentLabResults = results;
         if (sinceDate && !Lang.isNull(sinceDate)) {
             mostRecentLabResults = this.getMostRecentLabResults(results, sinceDate);

--- a/src/model/condition/FluxCondition.js
+++ b/src/model/condition/FluxCondition.js
@@ -87,11 +87,10 @@ class FluxCondition {
     // This method takes in a sinceDate, oldest date acceptable. All results returned must be more recent than sinceDate
     getLabResultsChronologicalOrder(sinceDate) {
         let results = this.getTests();
-        results.sort(this._observationsTimeSorter);
-
-        let mostRecentLabResults = results;
+        let sortedResults = results.sort(this._observationsTimeSorter);
+        let mostRecentLabResults = sortedResults;
         if (sinceDate && !Lang.isNull(sinceDate)) {
-            mostRecentLabResults = this.getMostRecentLabResults(results, sinceDate);
+            mostRecentLabResults = this.getMostRecentLabResults(sortedResults, sinceDate);
         }
 
         return mostRecentLabResults;
@@ -243,7 +242,7 @@ class FluxCondition {
         if (recentProgression) {
             events.push(recentProgression);
         }
-        events.sort(this._eventsTimeSorter);
+        events = events.sort(this._eventsTimeSorter);
 
         const procedureTemplates = {
             range: 'Patient underwent {0} from {1} to {2}',

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -789,7 +789,7 @@ export default class SummaryMetadata {
     getTestsForSubSection = (patient, currentConditionEntry, subsection) => { 
         if (Lang.isNull(patient) || Lang.isNull(currentConditionEntry)) return [];
         const labResults = currentConditionEntry.getTests();
-        labResults.sort(currentConditionEntry._labResultsTimeSorter);
+        labResults.sort(currentConditionEntry._observationsTimeSorter);
 
         const labs = labResults.filter((lab, i) => {
             return lab.codeableConceptCode === subsection.code;


### PR DESCRIPTION
Fix JIRA 979 so lab graphs don't look awful for mid-year demo.

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [ ] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [ ] This pull request describes why these changes were made
- [ ] Recognizes any potential shortcomings/bugs in the description 
- [ ] Cheat sheet is updated
- [ ] Demo script is updated 
- [ ] Documentation on Wiki has been updated 
- [ ] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [ ] Note parser has been updated if structured phrases change

**Code Quality**

- [ ] 4-space indents - convert any tabs to spaces
- [ ] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [ ] Code is commented

**Tests**

- [ ] Existing tests passed
- [ ] Added UI tests for slim mode 
- [ ] Added UI tests for full mode
- [ ] Added backend tests for fluxNotes code
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
