### PR TITLE
Select notes button

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ In addition, a no-patient version of the above concept has been created for situ
 * In a terminal navigate into the flux folder (stay at the project root)
 * Enter 'yarn install'
 * Enter 'yarn start' to launch the development web server and open a browser to view the application
-* To view patient mode, append patient to the end of the default url (result url would be http://localhost:3000/#/patient)
+* To view patient mode, append patient to the end of the default url (result url would be http://localhost:3000/patient)
 
 
 ## Technical Details

--- a/src/notes/FluxNotesEditor.css
+++ b/src/notes/FluxNotesEditor.css
@@ -117,10 +117,14 @@
     color: #fff;
 }
 
-.more-notes-btn {
-    background-color: red !important;
+.close-note-btn {
+    background-color: white !important;
     padding: 0px !important;
     margin-top: 0px !important;
-    text-transform: capitalize !important;
-    font-size: .8rem;
+    text-transform: none !important;
 }
+
+.close-note-btn:hover {
+    background: #E6E6E6 !important;
+}
+

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -678,7 +678,7 @@ class FluxNotesEditor extends React.Component {
                         <Col xs={4}>
                             <Button
                                 raised 
-                                className="more-notes-btn"
+                                className="close-note-btn"
                                 disabled={this.context_disabled}
                                 onClick={this.props.closeNote}
                                 style={{

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -105,6 +105,7 @@ export default class NoteAssistant extends Component {
     }
 
     onNotesToggleButtonClicked() {
+        console.log("notes toggle button selected");
         this.notes_btn_classname = "toggle-button-selected";
         this.notes_stroke = "#FFFFFF";
         this.notes_disabled = false;
@@ -123,6 +124,9 @@ export default class NoteAssistant extends Component {
     }
 
     disableContextToggleButton() {
+        this.notes_btn_classname = "toggle-button-selected";
+        this.notes_stroke = "#FFFFFF";
+        this.notes_disabled = false;
         this.context_btn_classname = "toggle-button-disabled";
         this.context_disabled = true;
         this.context_fill = "#FFFFFF";

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -124,7 +124,6 @@ export default class NoteAssistant extends Component {
     }
 
     disableContextToggleButton() {
-        // added this for selecting notes button
         this.notes_btn_classname = "toggle-button-selected";
         this.notes_stroke = "#FFFFFF";
         this.notes_disabled = false;

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -105,7 +105,6 @@ export default class NoteAssistant extends Component {
     }
 
     onNotesToggleButtonClicked() {
-        console.log("notes toggle button selected");
         this.notes_btn_classname = "toggle-button-selected";
         this.notes_stroke = "#FFFFFF";
         this.notes_disabled = false;

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -124,6 +124,7 @@ export default class NoteAssistant extends Component {
     }
 
     disableContextToggleButton() {
+        // added this for selecting notes button
         this.notes_btn_classname = "toggle-button-selected";
         this.notes_stroke = "#FFFFFF";
         this.notes_disabled = false;


### PR DESCRIPTION
Fixed bug so notes button is selected when app starts in pre-encounter mode. Added small styling fixes (@jafeltra made these fixes) so that notes line up correctly 


_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [ ] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [ ] This pull request describes why these changes were made
- [ ] Recognizes any potential shortcomings/bugs in the description 
- [ ] Cheat sheet is updated
- [ ] Demo script is updated 
- [ ] Documentation on Wiki has been updated 
- [ ] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [ ] Note parser has been updated if structured phrases change

**Code Quality**

- [ ] 4-space indents - convert any tabs to spaces
- [ ] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [ ] Code is commented

**Tests**

- [ ] Existing tests passed
- [ ] Added UI tests for slim mode 
- [ ] Added UI tests for full mode
- [ ] Added backend tests for fluxNotes code
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
