### PR TITLE
Note disappearing when changing encounter modes

### DIFF
--- a/src/containers/FullApp.jsx
+++ b/src/containers/FullApp.jsx
@@ -67,6 +67,7 @@ export default class FullApp extends Component {
             summaryItemToInsert: '',
             summaryMetadata: this.summaryMetadata.getMetadata(),
             noteClosed: false,
+            currentlyEditingEntryId: -1,
 
         };
     }

--- a/src/dashboard/ClinicianDashboard.jsx
+++ b/src/dashboard/ClinicianDashboard.jsx
@@ -11,9 +11,9 @@ export default class ClinicianDashboard extends Component {
 
         this.state = {
             targetedDataPanelSize: "default",
-            notesPanelSize: "default"
+            notesPanelSize: "default",
+            currentClinicalEvent: "pre-encounter"
         };
-        this.openNoteByIdGrandParent = this.openNoteByIdGrandParent.bind(this);
     }
 
     // Performs any initialization that needs to happen when the component mounts, specifically:
@@ -96,28 +96,22 @@ export default class ClinicianDashboard extends Component {
         switch (currentClinicalEvent) {
             case "pre-encounter":
                 this.props.setFullAppState('isNoteViewerVisible', false);
+                this.setState({currentClinicalEvent: "pre-encounter"});
                 break;
             case "encounter":
                 this.props.setFullAppState('isNoteViewerVisible', true);
-                // In the cases where the note viewer is visible, re-load the current note after switching clinical event
-                this.props.openNoteByIdGrandParent(this.props.appState.currentlyEditingEntryId);
+                this.setState({currentClinicalEvent: "encounter"});
                 break;
             case "post-encounter":
                 this.props.setFullAppState('isNoteViewerVisible', true);
-                console.log(this.props.appState.currentlyEditingEntryId + "; going to POST: " + this.props.appState.documentText); // 
-                // In the cases where the note viewer is visible, re-load the current note after switching clinical event
-                this.props.openNoteByIdGrandParent(this.props.appState.currentlyEditingEntryId);
+                this.setState({currentClinicalEvent: "post-encounter"});
                 break;
             default:
                 console.warn(`The task provided, ${currentClinicalEvent}, does not have a defined noteViewerBasedOnClinicalEvent value.`);
                 this.props.setFullAppState('isNoteViewerVisible', false);
+                this.setState({currentClinicalEvent: "default"});
                 return;
         }
-    }
-    // This function invokes the note opening logic in NoteAssistant
-    openNoteByIdGrandParent(id) {
-        console.log("ClinicianDashboard.openNoteById " + id);
-        this.openNoteByIdParent(id);
     }
 
     // Based on currentClinicalEvent, determines if a note should be editable
@@ -207,7 +201,7 @@ export default class ClinicianDashboard extends Component {
                         setFullAppStateWithCallback={this.props.setFullAppStateWithCallback}
                         noteClosed={this.props.appState.noteClosed}
                         appState={this.props.appState}
-                        openNoteById={click => this.openNoteByIdParent = click}
+                        currentClinicalEvent={this.state.currentClinicalEvent}
                     />
                 </div>
             </div>

--- a/src/dashboard/ClinicianDashboard.jsx
+++ b/src/dashboard/ClinicianDashboard.jsx
@@ -13,6 +13,7 @@ export default class ClinicianDashboard extends Component {
             targetedDataPanelSize: "default",
             notesPanelSize: "default"
         };
+        this.openNoteByIdGrandParent = this.openNoteByIdGrandParent.bind(this);
     }
 
     // Performs any initialization that needs to happen when the component mounts, specifically:
@@ -98,15 +99,25 @@ export default class ClinicianDashboard extends Component {
                 break;
             case "encounter":
                 this.props.setFullAppState('isNoteViewerVisible', true);
+                // In the cases where the note viewer is visible, re-load the current note after switching clinical event
+                this.props.openNoteByIdGrandParent(this.props.appState.currentlyEditingEntryId);
                 break;
             case "post-encounter":
                 this.props.setFullAppState('isNoteViewerVisible', true);
+                console.log(this.props.appState.currentlyEditingEntryId + "; going to POST: " + this.props.appState.documentText); // 
+                // In the cases where the note viewer is visible, re-load the current note after switching clinical event
+                this.props.openNoteByIdGrandParent(this.props.appState.currentlyEditingEntryId);
                 break;
             default:
                 console.warn(`The task provided, ${currentClinicalEvent}, does not have a defined noteViewerBasedOnClinicalEvent value.`);
                 this.props.setFullAppState('isNoteViewerVisible', false);
                 return;
         }
+    }
+    // This function invokes the note opening logic in NoteAssistant
+    openNoteByIdGrandParent(id) {
+        console.log("ClinicianDashboard.openNoteById " + id);
+        this.openNoteByIdParent(id);
     }
 
     // Based on currentClinicalEvent, determines if a note should be editable
@@ -195,6 +206,8 @@ export default class ClinicianDashboard extends Component {
                         setFullAppState={this.props.setFullAppState}
                         setFullAppStateWithCallback={this.props.setFullAppStateWithCallback}
                         noteClosed={this.props.appState.noteClosed}
+                        appState={this.props.appState}
+                        openNoteById={click => this.openNoteByIdParent = click}
                     />
                 </div>
             </div>

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -69,7 +69,6 @@ class FluxNotesEditor extends React.Component {
     constructor(props) {
         super(props);
 
-        console.log(this.props.documentText);
         this.contextManager = this.props.contextManager;
         this.updateErrors = this.props.updateErrors;
 
@@ -423,13 +422,6 @@ class FluxNotesEditor extends React.Component {
         this.contextManager.contextUpdated();
     }
 
-    // doesn't fire when switch from pre to post encounter
-    componentWillMount = () => {
-        console.log(this.props.documentText);
-        this.props.setFullAppStateWithCallback(function(prevState, props){
-            return {documentText: this.props.documentText};
-        });
-    }
 
     // This gets called before the component receives new properties
     componentWillReceiveProps = (nextProps) => {

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -69,6 +69,7 @@ class FluxNotesEditor extends React.Component {
     constructor(props) {
         super(props);
 
+        console.log(this.props.documentText);
         this.contextManager = this.props.contextManager;
         this.updateErrors = this.props.updateErrors;
 
@@ -422,9 +423,17 @@ class FluxNotesEditor extends React.Component {
         this.contextManager.contextUpdated();
     }
 
+    // doesn't fire when switch from pre to post encounter
+    componentWillMount = () => {
+        console.log(this.props.documentText);
+        this.props.setFullAppStateWithCallback(function(prevState, props){
+            return {documentText: this.props.documentText};
+        });
+    }
+
     // This gets called before the component receives new properties
     componentWillReceiveProps = (nextProps) => {
-
+        
         // Check if the item to be inserted is updated
         if (this.props.summaryItemToInsert !== nextProps.summaryItemToInsert && nextProps.summaryItemToInsert.length > 0) {
             if (this.props.isNoteViewerEditable) {

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -65,8 +65,17 @@ export default class NoteAssistant extends Component {
         // set callback so the editor can signal a change and this class can save the note
         this.props.saveNote(this.saveNoteOnKeypress);
         this.props.closeNote(this.closeNote);
-        this.props.openNoteByIdChild(this.openNoteById);
     }
+
+    componentWillReceiveProps(nextProps) {
+            const currentEvent = this.props.currentClinicalEvent;
+            const nextEvent = nextProps.currentClinicalEvent;
+
+            if (currentEvent !== nextEvent) {
+                const note = this.props.patient.getEntryById(nextProps.currentlyEditingEntryId);
+                this.openNote(!note.signed, note);
+            }
+        }
 
     // Sorts the lab results in chronological order with the most recent first (so that it shows up first in the clinical notes list)
     notesTimeSorter(a, b) {
@@ -221,10 +230,6 @@ export default class NoteAssistant extends Component {
         }
     }
 
-    openNoteById(id){
-        // Gets the note object associated with this entryId and calls openNote below
-        console.log("in openNoteById with: " + id);
-    }
 
     // Gets called when clicking on one of the notes in the clinical notes view
     openNote = (isInProgressNote, note) => {
@@ -537,5 +542,5 @@ NoteAssistant.propTypes = {
     closeNote: PropTypes.func,
     handleSummaryItemSelected: PropTypes.func,
     updateCurrentlyEditingEntryId: PropTypes.func,
-    openNoteByIdChild: PropTypes.func
+    currentClinicalEvent: PropTypes.string,
 };

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -34,7 +34,6 @@ export default class NoteAssistant extends Component {
             this.onNotesToggleButtonClicked();
             this.disableContextToggleButton();
         }
-        console.log("NoteAssistant constructor " + this.props.appState.currentlyEditingEntryId);
     }
 
     notesNotDisplayed = null;
@@ -229,7 +228,6 @@ export default class NoteAssistant extends Component {
             }
         }
     }
-
 
     // Gets called when clicking on one of the notes in the clinical notes view
     openNote = (isInProgressNote, note) => {

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -72,7 +72,9 @@ export default class NoteAssistant extends Component {
 
             if (currentEvent !== nextEvent) {
                 const note = this.props.patient.getEntryById(nextProps.currentlyEditingEntryId);
-                this.openNote(!note.signed, note);
+                if(!Lang.isUndefined(note)){
+                    this.openNote(!note.signed, note);
+                }
             }
         }
 

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -34,6 +34,7 @@ export default class NoteAssistant extends Component {
             this.onNotesToggleButtonClicked();
             this.disableContextToggleButton();
         }
+        console.log("NoteAssistant constructor " + this.props.appState.currentlyEditingEntryId);
     }
 
     notesNotDisplayed = null;
@@ -64,6 +65,7 @@ export default class NoteAssistant extends Component {
         // set callback so the editor can signal a change and this class can save the note
         this.props.saveNote(this.saveNoteOnKeypress);
         this.props.closeNote(this.closeNote);
+        this.props.openNoteByIdChild(this.openNoteById);
     }
 
     // Sorts the lab results in chronological order with the most recent first (so that it shows up first in the clinical notes list)
@@ -217,6 +219,11 @@ export default class NoteAssistant extends Component {
                 this.updateExistingNote();
             }
         }
+    }
+
+    openNoteById(id){
+        // Gets the note object associated with this entryId and calls openNote below
+        console.log("in openNoteById with: " + id);
     }
 
     // Gets called when clicking on one of the notes in the clinical notes view
@@ -529,5 +536,6 @@ NoteAssistant.propTypes = {
     saveNote: PropTypes.func,
     closeNote: PropTypes.func,
     handleSummaryItemSelected: PropTypes.func,
-    updateCurrentlyEditingEntryId: PropTypes.func
+    updateCurrentlyEditingEntryId: PropTypes.func,
+    openNoteByIdChild: PropTypes.func
 };

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -26,12 +26,6 @@ export default class NotesPanel extends Component {
         this.saveNoteUponKeypress = this.saveNoteUponKeypress.bind(this);
         this.closeNote = this.closeNote.bind(this);
         this.handleUpdateCurrentlyEditingEntryId = this.handleUpdateCurrentlyEditingEntryId.bind(this);
-        this.openNoteByIdParent = this.openNoteByIdParent.bind(this);
-    }
-    // This function invokes the note opening logic in NoteAssistant
-    openNoteByIdParent(id) {
-        console.log("NotesPanel.openNoteByIdParent " + id);
-        this.openNoteByIdChild(id);
     }
 
     updateNoteAssistantMode(mode) {
@@ -231,7 +225,7 @@ export default class NotesPanel extends Component {
                     updateCurrentlyEditingEntryId={this.handleUpdateCurrentlyEditingEntryId}
                     currentlyEditingEntryId={this.state.currentlyEditingEntryId}
                     appState={this.props.appState}
-                    openNoteByIdChild={click => this.openNoteById = click}
+                    currentClinicalEvent={this.props.currentClinicalEvent}
                 />
             </div>
         );
@@ -263,4 +257,5 @@ NotesPanel.propTypes = {
     handleSelectionChange: PropTypes.func,
     setFullAppState: PropTypes.func,
     summaryItemToInsert: PropTypes.string,
+    currentClinicalEvent: PropTypes.string,
 };

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -26,6 +26,12 @@ export default class NotesPanel extends Component {
         this.saveNoteUponKeypress = this.saveNoteUponKeypress.bind(this);
         this.closeNote = this.closeNote.bind(this);
         this.handleUpdateCurrentlyEditingEntryId = this.handleUpdateCurrentlyEditingEntryId.bind(this);
+        this.openNoteByIdParent = this.openNoteByIdParent.bind(this);
+    }
+    // This function invokes the note opening logic in NoteAssistant
+    openNoteByIdParent(id) {
+        console.log("NotesPanel.openNoteByIdParent " + id);
+        this.openNoteByIdChild(id);
     }
 
     updateNoteAssistantMode(mode) {
@@ -57,8 +63,14 @@ export default class NotesPanel extends Component {
                     this.setState({selectedNote: note});
                     if (!note) {
                         this.setState({currentlyEditingEntryId: -1});
+        this.props.setFullAppStateWithCallback(function(prevState, props){
+            return {currentlyEditingEntryId: -1}; 
+            }); //duplicate data for now to see if this should be brought up to FullApp
                     } else {
                         this.setState({currentlyEditingEntryId: note.entryInfo.entryId});
+        this.props.setFullAppStateWithCallback(function(prevState, props){
+            return {currentlyEditingEntryId: note.entryInfo.entryId}; 
+            });//duplicate data for now to see if this should be brought up to FullApp
                     }
                 }
             });
@@ -72,7 +84,11 @@ export default class NotesPanel extends Component {
     }
 
     handleUpdateCurrentlyEditingEntryId(id) {
+        console.log("Setting fullappstate to ID " + id);
         this.setState({currentlyEditingEntryId: id});
+                this.props.setFullAppStateWithCallback(function(prevState, props){
+            return {currentlyEditingEntryId: id};
+        });//duplicate data for now to see if this should be brought up to FullApp
     }
 
     // Save the note after every keypress. This function invokes the note saving logic in NoteAssistant
@@ -186,6 +202,7 @@ export default class NotesPanel extends Component {
 
                     currentViewMode={this.props.currentViewMode}
                     updateSelectedNote={this.updateSelectedNote}
+                    appState={this.props.appState}
                 />
             </div>
         );
@@ -213,6 +230,8 @@ export default class NotesPanel extends Component {
                     noteClosed={this.props.noteClosed}
                     updateCurrentlyEditingEntryId={this.handleUpdateCurrentlyEditingEntryId}
                     currentlyEditingEntryId={this.state.currentlyEditingEntryId}
+                    appState={this.props.appState}
+                    openNoteByIdChild={click => this.openNoteById = click}
                 />
             </div>
         );

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -57,14 +57,14 @@ export default class NotesPanel extends Component {
                     this.setState({selectedNote: note});
                     if (!note) {
                         this.setState({currentlyEditingEntryId: -1});
-        this.props.setFullAppStateWithCallback(function(prevState, props){
-            return {currentlyEditingEntryId: -1}; 
-            }); //duplicate data for now to see if this should be brought up to FullApp
+                        this.props.setFullAppStateWithCallback(function(prevState, props){
+                            return {currentlyEditingEntryId: -1}; 
+                        });
                     } else {
                         this.setState({currentlyEditingEntryId: note.entryInfo.entryId});
-        this.props.setFullAppStateWithCallback(function(prevState, props){
-            return {currentlyEditingEntryId: note.entryInfo.entryId}; 
-            });//duplicate data for now to see if this should be brought up to FullApp
+                        this.props.setFullAppStateWithCallback(function(prevState, props){
+                            return {currentlyEditingEntryId: note.entryInfo.entryId}; 
+                        });
                     }
                 }
             });
@@ -78,11 +78,10 @@ export default class NotesPanel extends Component {
     }
 
     handleUpdateCurrentlyEditingEntryId(id) {
-        console.log("Setting fullappstate to ID " + id);
         this.setState({currentlyEditingEntryId: id});
-                this.props.setFullAppStateWithCallback(function(prevState, props){
+        this.props.setFullAppStateWithCallback(function(prevState, props){
             return {currentlyEditingEntryId: id};
-        });//duplicate data for now to see if this should be brought up to FullApp
+        });
     }
 
     // Save the note after every keypress. This function invokes the note saving logic in NoteAssistant

--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -716,6 +716,12 @@ class PatientRecord {
         });
     }
 
+    getEntryById(id){
+        return this.entries.find((item) => {
+            return Lang.isEqual(item.entryInfo.entryId, id);
+        });
+    }
+
     static getMostRecentEntryFromList(list) {
         if (list.length === 0) return null;
         if (list.length === 1) return list[0];


### PR DESCRIPTION
Switching the Workflow dropdown to Post-encounter or Pre-encounter used to cause the editor contents to disappear. This PR resolves that so the editor does not lose contents. Communication between components is accomplished by adding a couple more props at the FullApp level - using global state seems less than ideal to me, there may be a better way to accomplish this.

Running tests now.

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [X] Manually tested in Chrome
- [X] Manually tested in IE

**Documentation**

- [X] This pull request describes why these changes were made
- [X] Recognizes any potential shortcomings/bugs in the description 
- [**N/A**] Cheat sheet is updated
- [**N/A**] Demo script is updated 
- [**N/A**] Documentation on Wiki has been updated 
- [**N/A**] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [**N/A**] Note parser has been updated if structured phrases change

**Code Quality**

- [X] 4-space indents - convert any tabs to spaces
- [X] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [X] Code is commented

**Tests**

- [X] Existing tests passed
- [**N/A**] Added UI tests for slim mode 
- [**N/A**] Added UI tests for full mode
- [**N/A**] Added backend tests for fluxNotes code
- [**N/A**] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
