### PR TITLE
Non scrollable editor header and editor toolbar

### DIFF
--- a/src/notes/FluxNotesEditor.css
+++ b/src/notes/FluxNotesEditor.css
@@ -128,3 +128,10 @@
     background: #E6E6E6 !important;
 }
 
+.editor-panel {
+    /* 106px is the height of the Patient Control Panel, 16px is the height of the top margin of post encounter view content, 130px accounts for the editor header and editor toolbar plus margins, 76px is the height of the sign button */
+    height: calc(100vh - 106px - 16px - 130px - 76px) !important;
+    overflow-y: scroll;
+    overflow-x: hidden;
+    text-align: left;
+}

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -736,6 +736,7 @@ class FluxNotesEditor extends React.Component {
                         isReadOnly={!this.props.isNoteViewerEditable}
                     />
                     <Slate.Editor
+                        className="editor-panel"
                         placeholder={'Enter your clinical note here or choose a template to start from...'}
                         plugins={this.plugins}
                         readOnly={!this.props.isNoteViewerEditable}

--- a/src/panels/NotesPanel.css
+++ b/src/panels/NotesPanel.css
@@ -16,11 +16,3 @@
     min-width: 90% !important;
     margin: 20px 20px 20px 20px;
 }
-
-.editor-panel {
-    /* 106px is the height of the Patient Control Panel, 16px is the height of the top margin of post encounter view content, 76px is the height of the sign button */
-    height: calc(100vh - 106px - 16px - 76px) !important;
-    overflow-y: scroll;
-    overflow-x: hidden;
-    text-align: left;
-}

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -161,7 +161,7 @@ export default class NotesPanel extends Component {
 
     renderFluxNotesEditor() {
         return (
-            <div className="panel-content dashboard-panel editor-panel">
+            <div className="panel-content dashboard-panel">
                 <FluxNotesEditor
                     onSelectionChange={this.props.handleSelectionChange}
                     newCurrentShortcut={this.props.newCurrentShortcut}


### PR DESCRIPTION
This PR addresses issue: 985. 

Moved scrolling css from FluxNotesEditor to slate editor in order to keep the editor header and editor toolbar from scrolling

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- N/A Cheat sheet is updated
- N/A Demo script is updated 
- N/A Documentation on Wiki has been updated 
- N/A Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- N/A Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- N/A Added UI tests for slim mode 
- N/A Added UI tests for full mode
- N/A Added backend tests for fluxNotes code
- N/A Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
