### PR TITLE
Updated calculations for staging.

### DIFF
--- a/src/lib/staging.jsx
+++ b/src/lib/staging.jsx
@@ -6,70 +6,63 @@ const Lang = require('lodash/lang');
 // https://cancerstaging.org/references-tools/quickreferences/Documents/BreastMedium.pdf
 
 exports.breastCancerPrognosticStage = (t, n, m) => {
-  // Regardless of edition, metastatic cancer is always stage IV
-  if (Lang.isUndefined(t) || Lang.isUndefined(n) || Lang.isUndefined(m)) {
-    return null;
-  }
-  const M = m.toString().toUpperCase();
-  if (M === 'M1') {
-    return 'IV';
-  }
+    // Regardless of edition, metastatic cancer is always stage IV
 
-  // M must be either 'M1' or 'M0'. Anything else is invalid.
-  if (M !== 'M0') {
-    return null;
-  }
+    // if m === M1, return stage IV, n and t values do not need to be set
+    if (!Lang.isUndefined(m) && !Lang.isNull(m) && m.length > 0 && m.toUpperCase() === 'M1') return 'IV';
 
-  // 7th edition staging, lookup[T][N]
-  // null return values mean the staging is undefined for those T,N,M values
-  const ni = (lookup.getNsNamesForEdition(7)).indexOf(titlecase(n.toString()));
-  const ti = (lookup.getTsNamesForEdition(7)).indexOf(titlecase(t.toString()));
-  if (ti === -1 || ni === -1) {
-    // Unrecognized T or N value
-    return null;
-  }
-  return lookup.getTableForEdition(7)[ti][ni];
+    // 7th edition staging, lookup[T][N]
+    // null return values mean the staging is undefined for those T,N,M values
+    if (Lang.isUndefined(n) || Lang.isUndefined(t) || Lang.isNull(n) || Lang.isNull(t) || n.length === 0 || t.length === 0) return '';
+    const ni = (lookup.getNsNamesForEdition(7)).indexOf(titlecase(n.toString()));
+    const ti = (lookup.getTsNamesForEdition(7)).indexOf(titlecase(t.toString()));
+    if (ti === -1 || ni === -1) {
+        // Unrecognized T or N value
+        return '';
+    }
+
+    return lookup.getTableForEdition(7)[ti][ni];
 }
 
 
 // Converts a prognostic stage (e.g. 'IIIA') into a list of possible T,N,M
 // values based on the specified staging edition. If none specified, defaults
 // to the 7th edition.
-exports.breastCancerPossibleTNM = (prognosticStage, edition=7) => {
-  let values = [];
+exports.breastCancerPossibleTNM = (prognosticStage, edition = 7) => {
+    let values = [];
 
-  // Lookup the needed values for the specified edition
-  const ed = parseInt(edition, 10);
-  const ts = lookup.getTsForEdition(ed);
-  const ns = lookup.getNsForEdition(ed);
-  const table = lookup.getTableForEdition(ed);
+    // Lookup the needed values for the specified edition
+    const ed = parseInt(edition, 10);
+    const ts = lookup.getTsForEdition(ed);
+    const ns = lookup.getNsForEdition(ed);
+    const table = lookup.getTableForEdition(ed);
 
-  // Regardless of edition, stage IV is handled the same way
-  const stage = prognosticStage.toString().toUpperCase();
+    // Regardless of edition, stage IV is handled the same way
+    const stage = prognosticStage.toString().toUpperCase();
 
-  if (stage === 'IV') {
-    ts.forEach((t) => {
-      ns.forEach((n)=> {
-        values.push([t.name, n.name, 'M1']);
-      });
+    if (stage === 'IV') {
+        ts.forEach((t) => {
+            ns.forEach((n) => {
+                values.push([t.name, n.name, 'M1']);
+            });
+        });
+        return values;
+    }
+
+    // No lookup means an invalid or unsupported edition
+    if (!table) {
+        return [];
+    }
+
+    // Find all T,N,M matches for the prognostic stage specified
+    table.forEach((row, t) => {
+        row.forEach((el, n) => {
+            if (el === stage) {
+                values.push([ts[t].name, ns[n].name, 'M0']);
+            }
+        });
     });
     return values;
-  }
-
-  // No lookup means an invalid or unsupported edition
-  if (!table) {
-    return [];
-  }
-
-  // Find all T,N,M matches for the prognostic stage specified
-  table.forEach((row, t) => {
-    row.forEach((el, n) => {
-      if (el === stage) {
-        values.push([ts[t].name, ns[n].name, 'M0']);
-      }
-    });
-  });
-  return values;
 }
 
 function titlecase(label) {

--- a/src/model/oncology/FluxTNMStage.js
+++ b/src/model/oncology/FluxTNMStage.js
@@ -160,11 +160,7 @@ class FluxTNMStage {
         const t = this.t_Stage;
         const n = this.n_Stage;
         const m = this.m_Stage;
-        // console.log("calculateStage: " + t + " " + n + " " + m);
-        if (t.length === 0 || n.length === 0 || m.length === 0) {
-            this.stage = '';
-            return; // not complete value
-        }
+
         this.stage = staging.breastCancerPrognosticStage(t, n, m);
     }
 }

--- a/test/backend/lib/staging.test.js
+++ b/test/backend/lib/staging.test.js
@@ -36,9 +36,11 @@ describe('breastCancerPrognosticStage', () => {
 
     it('should return null for invalid T, N, M values', () => {
         expect(staging.breastCancerPrognosticStage(1,2,0))
-            .to.be.null;
+            .to.be.a('string')
+            .and.to.be.empty;
         expect(staging.breastCancerPrognosticStage('foo','bar',11.5))
-            .to.be.null;
+            .to.be.a('string')
+            .and.to.be.empty;
     });
 
     it('should return null for undefined staging given T, N, M', () => {
@@ -63,9 +65,10 @@ describe('breastCancerPrognosticStage', () => {
             .and.to.equal('IB');
     });
 
-    it('should reject invalid M values', () => {
-        expect(staging.breastCancerPrognosticStage('T1', 'N1', 'M?'))
-            .to.be.null;
+    it('should return "IIA" with T1, N1, and no M value', () => {
+        expect(staging.breastCancerPrognosticStage('T1', 'N1'))
+            .to.be.a('string')
+            .and.to.equal('IIA');
     });
 });
 


### PR DESCRIPTION
Addresses JIRA-975.

- Supports #staging #m1 without providing t and n values.
- Supports #staging when t and n values are set(m value assumed to be m0).
- Updated backend staging tests.

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
-  Cheat sheet is updated
-  Demo script is updated 
-  Documentation on Wiki has been updated 
-  Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

-  Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
-  Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
-  Added UI tests for slim mode 
-  Added UI tests for full mode
- [x] Added backend tests for fluxNotes code
-  Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
