### PR TITLE
Updated urls and landing page link to full mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ In addition, a no-patient version of the above concept has been created for situ
 * In a terminal navigate into the flux folder (stay at the project root)
 * Enter 'yarn install'
 * Enter 'yarn start' to launch the development web server and open a browser to view the application
-* To view patient mode, append patient to the end of the default url (result url would be http://localhost:3000/patient)
+* To view patient mode, append patient to the end of the default url (result url would be http://localhost:3000/demo1)
 
 
 ## Technical Details

--- a/src/apps/AppManager.jsx
+++ b/src/apps/AppManager.jsx
@@ -84,7 +84,7 @@ export default class AppManager {
                 }
             },
             {
-                path: '/patient',
+                path: '/demo1',
                 display: 'Flux Notes™',
                 app: FullApp,
                 isExact: true,
@@ -92,7 +92,7 @@ export default class AppManager {
                 shortcuts: []
             },
             {
-                path: '/myd18',
+                path: '/demo2',
                 display: 'Flux Notes™',
                 app: FullApp,
                 isExact: true,

--- a/src/components/LandingPage.jsx
+++ b/src/components/LandingPage.jsx
@@ -184,7 +184,7 @@ export default class LandingPage extends Component {
 
                     <div className="landing-products-full">
                         <Paper className="landing-products-interaction">
-                            <a href="/patient" id="link-to-full">
+                            <a href="/demo2" id="link-to-full">
                                 <div className="landing-products-image">
                                     <img src="./landing/Fluxnotes_full_animation.gif" alt="Flux Notes Full" />
                                 </div>

--- a/test/ui/FullApp.js
+++ b/test/ui/FullApp.js
@@ -6,7 +6,7 @@ import moment from 'moment';
 
 const pageDomain = "http://localhost";
 const pagePort = "3000";
-const pageRoute = "/patient"
+const pageRoute = "/demo1"
 const startPage = `${pageDomain}:${pagePort}${pageRoute}`;
 
 fixture('Patient Mode - Patient Control Panel')

--- a/test/ui/Landing.js
+++ b/test/ui/Landing.js
@@ -28,7 +28,7 @@ test('Links on landing page work', async t => {
         .click(fullModeLink);
     pathname = await t.eval(() => window.location).pathname ;
     await t
-        .expect(pathname === '/patient');
+        .expect(pathname === '/demo2');
 
     await t
         .navigateTo(landingPage);


### PR DESCRIPTION
This PR address jira 1005. After talking with @gregquinn2001 decided to use "demo" in the instead of "patient". The url to /patient is now /demo1. The url to /myd18 is now /demo2. The link on the landing page for full mode now redirects to the mid year demo version of the app. Updated UI tests with the new urls

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- N/A Cheat sheet is updated
- N/A Demo script is updated 
- N/A Documentation on Wiki has been updated 
- N/A Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- N/A Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- N/A Added UI tests for slim mode 
- N/A Added UI tests for full mode
- N/A Added backend tests for fluxNotes code
- N/A Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
