### PR TITLE
Make Person a separate entry in hardcoded patients

### DIFF
--- a/src/dataaccess/HardCodedPatient.json
+++ b/src/dataaccess/HardCodedPatient.json
@@ -4,31 +4,11 @@
         "shr.base.EntryId": "1",
         "shr.base.EntryType":{ "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},
         "Value":{
-            "shr.base.EntryType":{ "Value": "http://standardhealthrecord.org/spec/shr/entity/Person"},
-            "shr.base.HumanName": "Debra Hernandez672",
-            "shr.base.DateOfBirth": "5 APR 1966",
-            "shr.base.AdministrativeGender": "female",
-            "shr.core.Address": { 
-                "shr.core.AddressLine": [{ "Value": "123 Main Street"}], 
-                "shr.core.City": { "Value": "Boston"}, 
-                "shr.core.State": { "Value": "MA"}, 
-                "shr.core.Country": { "Value": "US"}, 
-                "shr.entity.Purpose": { "Value": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding": {"Value": "primary_residence" }}}
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Person"
             },
-            "shr.entity.LanguageUsed": [{ "Value": { "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/Language"}, "Value": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding": [{ "Value": "en-US", "shr.core.DisplayText": {"Value": "English (United States)"}}]}}}],
-            "shr.core.ContactPoint": [
-                { 
-                    "shr.core.TelecomNumberOrAddress":{"Value": "999-555-5555"}, 
-                    "shr.entity.Type": { "Value": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{"Value": "phone"}]}},
-                    "shr.entity.Purpose": { "Value": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding": {"Value":"home"}}}
-                },
-                {
-                    "shr.core.TelecomNumberOrAddress":{ "Value":"999-555-4444"},
-                    "shr.entity.Type": { "Value": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{"Value": "phone"}]}},
-                    "shr.entity.Purpose": { "Value": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding": {"Value":"mobile"}}}
-                }
-            ],
-            "shr.entity.Headshot": {"shr.core.Attachment": {"shr.core.ResourceLocation": {"Value": "./DebraHernandez672.png"}}}
+            "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+            "EntryId": "2"
         },           
         "shr.entity.PlaceOfBirth": { "Value": "US" },
         "shr.entity.BirthSex": { "Value": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{"Value": "F", "shr.core.DisplayText":{ "Value": "Female"}}]}},
@@ -39,6 +19,133 @@
         "shr.entity.FathersName": { "Value": "Jose Hernandez672" },
         "shr.core.CreationTime": { "Value": "13 JAN 2012"},
         "shr.base.LastUpdated": { "Value": "13 JAN 2012"} 
+    },
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "shr.base.EntryId": "2",
+        "shr.base.EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/entity/Person"
+        },
+        "shr.base.HumanName": "Debra Hernandez672",
+        "shr.base.DateOfBirth": "5 APR 1966",
+        "shr.base.AdministrativeGender": "female",
+        "shr.core.Address": {
+            "shr.core.AddressLine": [
+                {
+                    "Value": "123 Main Street"
+                }
+            ],
+            "shr.core.City": {
+                "Value": "Boston"
+            },
+            "shr.core.State": {
+                "Value": "MA"
+            },
+            "shr.core.Country": {
+                "Value": "US"
+            },
+            "shr.entity.Purpose": {
+                "Value": {
+                    "shr.base.EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                    },
+                    "shr.core.Coding": {
+                        "Value": "primary_residence"
+                    }
+                }
+            }
+        },
+        "shr.entity.LanguageUsed": [
+            {
+                "Value": {
+                    "shr.base.EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/base/Language"
+                    },
+                    "Value": {
+                        "shr.base.EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                        },
+                        "shr.core.Coding": [
+                            {
+                                "Value": "en-US",
+                                "shr.core.DisplayText": {
+                                    "Value": "English (United States)"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "shr.core.ContactPoint": [
+            {
+                "shr.core.TelecomNumberOrAddress": {
+                    "Value": "999-555-5555"
+                },
+                "shr.entity.Type": {
+                    "Value": {
+                        "shr.base.EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                        },
+                        "shr.core.Coding": [
+                            {
+                                "Value": "phone"
+                            }
+                        ]
+                    }
+                },
+                "shr.entity.Purpose": {
+                    "Value": {
+                        "shr.base.EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                        },
+                        "shr.core.Coding": {
+                            "Value": "home"
+                        }
+                    }
+                }
+            },
+            {
+                "shr.core.TelecomNumberOrAddress": {
+                    "Value": "999-555-4444"
+                },
+                "shr.entity.Type": {
+                    "Value": {
+                        "shr.base.EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                        },
+                        "shr.core.Coding": [
+                            {
+                                "Value": "phone"
+                            }
+                        ]
+                    }
+                },
+                "shr.entity.Purpose": {
+                    "Value": {
+                        "shr.base.EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                        },
+                        "shr.core.Coding": {
+                            "Value": "mobile"
+                        }
+                    }
+                }
+            }
+        ],
+        "shr.entity.Headshot": {
+            "shr.core.Attachment": {
+                "shr.core.ResourceLocation": {
+                    "Value": "./DebraHernandez672.png"
+                }
+            }
+        },
+        "shr.core.CreationTime": {
+            "Value": "13 JAN 2012"
+        },
+        "shr.base.LastUpdated": {
+            "Value": "13 JAN 2012"
+        }
     },
     {
         "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",

--- a/src/dataaccess/HardCodedPatientMidYearDemo18.json
+++ b/src/dataaccess/HardCodedPatientMidYearDemo18.json
@@ -7,7 +7,7 @@
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Person"
             },
-            "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+            "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "EntryId": "2"
         },           
         "shr.entity.PlaceOfBirth": { "Value": "US" },
@@ -1229,10 +1229,10 @@
 
 
     {
-        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "shr.base.EntryId": "15",
         "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationRequested"},
-        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"}, "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1" },
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"}, "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1" },
         "shr.entity.MedicationOrCode": {
             "Value": {
                 "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
@@ -1302,7 +1302,7 @@
                 "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Reason" },
                 "Value": {
                         "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition" },
-                        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
                         "EntryId": "8"
                 }
             }]
@@ -1312,10 +1312,10 @@
         "shr.base.LastUpdated": {"Value": "15 FEB 2016"}
     },
     {
-        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "shr.base.EntryId": "16",
         "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationRequested"},
-        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"}, "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1" },
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"}, "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1" },
         "shr.entity.MedicationOrCode": {
             "Value": {
                 "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
@@ -1397,7 +1397,7 @@
                 "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Reason" },
                 "Value": {
                         "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition" },
-                        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
                         "EntryId": "8"
                 }
             }]
@@ -1407,10 +1407,10 @@
         "shr.base.LastUpdated": {"Value": "15 FEB 2016"}
     },
     {
-        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "shr.base.EntryId": "17",
         "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationRequested"},
-        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"}, "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1" },
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"}, "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1" },
         "shr.entity.MedicationOrCode": {
             "Value": {
                 "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
@@ -1487,7 +1487,7 @@
                 "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Reason" },
                 "Value": {
                         "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition" },
-                        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
                         "EntryId": "8"
                 }
             }]
@@ -1497,10 +1497,10 @@
         "shr.base.LastUpdated": {"Value": "15 FEB 2016"}
     },
     {
-        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "shr.base.EntryId": "18",
         "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/oncology/BreastCancerGeneticAnalysisPanel"},
-        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"}, "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1" },
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"}, "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1" },
         "shr.finding.Members" : {
             "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Members"},
             "Value": [
@@ -2491,10 +2491,10 @@
         "shr.base.LastUpdated": {"Value": "28 FEB 2018"}
     },
     {
-        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "shr.base.EntryId": "234",
         "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer" },
-        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1"},
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1"},
         "shr.finding.ObservationCode": {
             "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
             "shr.core.Coding": [{"Value": "C95618", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
@@ -2504,77 +2504,77 @@
             "Value": [
                 {
                     "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"},
-                    "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                    "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
                     "EntryId": "235"
                 },
                 {
                     "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"},
-                    "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                    "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
                     "EntryId": "236"
                 },
                 {
                     "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"},
-                    "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                    "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
                     "EntryId": "237"
                 },
                 {
                     "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"},
-                    "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                    "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
                     "EntryId": "238"
                 },
                 {
                     "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"},
-                    "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                    "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
                     "EntryId": "239"
                 },
                 {
                     "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"},
-                    "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                    "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
                     "EntryId": "240"
                 },
                 {
                     "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"},
-                    "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                    "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
                     "EntryId": "241"
                 },
                 {
                     "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"},
-                    "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                    "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
                     "EntryId": "242"
                 },
                 {
                     "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"},
-                    "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                    "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
                     "EntryId": "243"
                 },
                 {
                     "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"},
-                    "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                    "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
                     "EntryId": "244"
                 },
                 {
                     "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"},
-                    "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                    "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
                     "EntryId": "245"
                 },
                 {
                     "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"},
-                    "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                    "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
                     "EntryId": "246"
                 },
                 {
                     "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"},
-                    "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                    "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
                     "EntryId": "247"
                 },
                 {
                     "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"},
-                    "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                    "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
                     "EntryId": "248"
                 },
                 {
                     "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"},
-                    "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                    "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
                     "EntryId": "249"
                 }
             ]
@@ -2583,10 +2583,10 @@
         "shr.base.LastUpdated": {"Value": "01 JAN 2018"}
     },
     {
-        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "shr.base.EntryId": "235",
         "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer" },
-        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1"},
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1"},
         "shr.finding.ObservationCode": {
             "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
             "shr.core.Coding": [{"Value": "C50575", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
@@ -2597,10 +2597,10 @@
         "shr.base.LastUpdated": {"Value": "01 JAN 2018"}
     },
     {
-        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "shr.base.EntryId": "236",
         "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer" },
-        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1"},
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1"},
         "shr.finding.ObservationCode": {
             "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
             "shr.core.Coding": [{"Value": "C61443", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
@@ -2611,10 +2611,10 @@
         "shr.base.LastUpdated": {"Value": "01 JAN 2018"}
     },
     {
-        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "shr.base.EntryId": "237",
         "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer" },
-        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1"},
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1"},
         "shr.finding.ObservationCode": {
             "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
             "shr.core.Coding": [{"Value": "C118263", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
@@ -2625,10 +2625,10 @@
         "shr.base.LastUpdated": {"Value": "01 JAN 2018"}
     },
     {
-        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "shr.base.EntryId": "238",
         "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer" },
-        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1"},
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1"},
         "shr.finding.ObservationCode": {
             "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
             "shr.core.Coding": [{"Value": "foo", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
@@ -2639,10 +2639,10 @@
         "shr.base.LastUpdated": {"Value": "01 JAN 2018"}
     },
     {
-        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "shr.base.EntryId": "239",
         "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer" },
-        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1"},
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1"},
         "shr.finding.ObservationCode": {
             "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
             "shr.core.Coding": [{"Value": "foo", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
@@ -2653,10 +2653,10 @@
         "shr.base.LastUpdated": {"Value": "01 JAN 2018"}
     },
     {
-        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "shr.base.EntryId": "240",
         "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer" },
-        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1"},
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1"},
         "shr.finding.ObservationCode": {
             "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
             "shr.core.Coding": [{"Value": "foo", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
@@ -2667,10 +2667,10 @@
         "shr.base.LastUpdated": {"Value": "01 JAN 2018"}
     },
     {
-        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "shr.base.EntryId": "241",
         "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer" },
-        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1"},
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1"},
         "shr.finding.ObservationCode": {
             "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
             "shr.core.Coding": [{"Value": "foo", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
@@ -2681,10 +2681,10 @@
         "shr.base.LastUpdated": {"Value": "01 JAN 2018"}
     },
     {
-        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "shr.base.EntryId": "242",
         "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer" },
-        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1"},
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1"},
         "shr.finding.ObservationCode": {
             "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
             "shr.core.Coding": [{"Value": "foo", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
@@ -2695,10 +2695,10 @@
         "shr.base.LastUpdated": {"Value": "01 JAN 2018"}
     },
     {
-        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "shr.base.EntryId": "243",
         "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer" },
-        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1"},
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1"},
         "shr.finding.ObservationCode": {
             "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
             "shr.core.Coding": [{"Value": "foo", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
@@ -2709,10 +2709,10 @@
         "shr.base.LastUpdated": {"Value": "01 JAN 2018"}
     },
     {
-        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "shr.base.EntryId": "244",
         "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer" },
-        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1"},
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1"},
         "shr.finding.ObservationCode": {
             "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
             "shr.core.Coding": [{"Value": "foo", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
@@ -2723,10 +2723,10 @@
         "shr.base.LastUpdated": {"Value": "01 JAN 2018"}
     },
     {
-        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "shr.base.EntryId": "245",
         "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer" },
-        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1"},
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1"},
         "shr.finding.ObservationCode": {
             "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
             "shr.core.Coding": [{"Value": "foo", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
@@ -2737,10 +2737,10 @@
         "shr.base.LastUpdated": {"Value": "01 JAN 2018"}
     },
     {
-        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "shr.base.EntryId": "246",
         "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer" },
-        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1"},
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1"},
         "shr.finding.ObservationCode": {
             "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
             "shr.core.Coding": [{"Value": "foo", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
@@ -2751,10 +2751,10 @@
         "shr.base.LastUpdated": {"Value": "01 JAN 2018"}
     },
     {
-        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "shr.base.EntryId": "247",
         "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer" },
-        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1"},
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1"},
         "shr.finding.ObservationCode": {
             "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
             "shr.core.Coding": [{"Value": "foo", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
@@ -2765,10 +2765,10 @@
         "shr.base.LastUpdated": {"Value": "01 JAN 2018"}
     },
     {
-        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "shr.base.EntryId": "248",
         "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer" },
-        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1"},
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1"},
         "shr.finding.ObservationCode": {
             "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
             "shr.core.Coding": [{"Value": "foo", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
@@ -2779,10 +2779,10 @@
         "shr.base.LastUpdated": {"Value": "01 JAN 2018"}
     },
     {
-        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "shr.base.EntryId": "249",
         "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer" },
-        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1"},
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1"},
         "shr.finding.ObservationCode": {
             "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
             "shr.core.Coding": [{"Value": "foo", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
@@ -2796,8 +2796,8 @@
         "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "shr.base.EntryId": "500",
         "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/condition/Injury" },
-        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"}, "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1" },
-        "shr.base.Subject": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1"},
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"}, "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1" },
+        "shr.base.Subject": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1"},
         "Value" : {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0016658", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value": "Fracture"}}]},
         "shr.core.Category": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "#structural_abnormality"}]},
         "shr.condition.ClinicalStatus": {"Value": "active"},
@@ -2817,8 +2817,8 @@
         "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "shr.base.EntryId": "501",
         "shr.base.EntryType":{ "Value": "http://standardhealthrecord.org/spec/shr/procedure/ProcedureRequested"},
-        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"}, "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1"},
-        "shr.base.Subject": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1"},
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"}, "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1"},
+        "shr.base.Subject": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1"},
         "shr.entity.Type" : {"Value": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
             "shr.core.Coding":[{ "Value": "433341001", "shr.core.CodeSystem": {"Value": "http://snomed.info/sct"}, 
                 "shr.core.DisplayText": {"Value": "Application of long leg splint"}}]}},
@@ -2830,7 +2830,7 @@
                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Reason" },
                "Value": {
                        "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/condition/Injury" },
-                       "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                       "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
                        "EntryId": "500"
                }
            }]},

--- a/src/dataaccess/HardCodedPatientMidYearDemo18.json
+++ b/src/dataaccess/HardCodedPatientMidYearDemo18.json
@@ -3,32 +3,12 @@
         "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "shr.base.EntryId": "1",
         "shr.base.EntryType":{ "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},
-        "Value":{
-            "shr.base.EntryType":{ "Value": "http://standardhealthrecord.org/spec/shr/entity/Person"},
-            "shr.base.HumanName": "Ella Ortiz111",
-            "shr.base.DateOfBirth": "15 DEC 1974",
-            "shr.base.AdministrativeGender": "female",
-            "shr.core.Address": { 
-                "shr.core.AddressLine": [{ "Value": "123 Other Street"}], 
-                "shr.core.City": { "Value": "Boston"}, 
-                "shr.core.State": { "Value": "MA"}, 
-                "shr.core.Country": { "Value": "US"}, 
-                "shr.entity.Purpose": { "Value": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding": {"Value": "primary_residence" }}}
+        "Value": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Person"
             },
-            "shr.entity.LanguageUsed": [{ "Value": { "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/Language"}, "Value": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding": [{ "Value": "en-US", "shr.core.DisplayText": {"Value": "English (United States)"}}]}}}],
-            "shr.core.ContactPoint": [
-                { 
-                    "shr.core.TelecomNumberOrAddress":{"Value": "999-555-5555"}, 
-                    "shr.entity.Type": { "Value": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{"Value": "phone"}]}},
-                    "shr.entity.Purpose": { "Value": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding": {"Value":"home"}}}
-                },
-                {
-                    "shr.core.TelecomNumberOrAddress":{ "Value":"999-555-4444"},
-                    "shr.entity.Type": { "Value": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{"Value": "phone"}]}},
-                    "shr.entity.Purpose": { "Value": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding": {"Value":"mobile"}}}
-                }
-            ],
-            "shr.entity.Headshot": {"shr.core.Attachment": {"shr.core.ResourceLocation": {"Value": "./EllaOrtiz111.png"}}}
+            "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+            "EntryId": "2"
         },           
         "shr.entity.PlaceOfBirth": { "Value": "US" },
         "shr.entity.BirthSex": { "Value": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{"Value": "F", "shr.core.DisplayText":{ "Value": "Female"}}]}},
@@ -39,6 +19,133 @@
         "shr.entity.FathersName": { "Value": "Jose Ortiz111" },
         "shr.core.CreationTime": { "Value": "13 JAN 2012"},
         "shr.base.LastUpdated": { "Value": "13 JAN 2012"} 
+    },
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "shr.base.EntryId": "2",
+        "shr.base.EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/entity/Person"
+        },
+        "shr.base.HumanName": "Ella Ortiz111",
+        "shr.base.DateOfBirth": "15 DEC 1974",
+        "shr.base.AdministrativeGender": "female",
+        "shr.core.Address": {
+            "shr.core.AddressLine": [
+                {
+                    "Value": "123 Other Street"
+                }
+            ],
+            "shr.core.City": {
+                "Value": "Boston"
+            },
+            "shr.core.State": {
+                "Value": "MA"
+            },
+            "shr.core.Country": {
+                "Value": "US"
+            },
+            "shr.entity.Purpose": {
+                "Value": {
+                    "shr.base.EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                    },
+                    "shr.core.Coding": {
+                        "Value": "primary_residence"
+                    }
+                }
+            }
+        },
+        "shr.entity.LanguageUsed": [
+            {
+                "Value": {
+                    "shr.base.EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/base/Language"
+                    },
+                    "Value": {
+                        "shr.base.EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                        },
+                        "shr.core.Coding": [
+                            {
+                                "Value": "en-US",
+                                "shr.core.DisplayText": {
+                                    "Value": "English (United States)"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "shr.core.ContactPoint": [
+            {
+                "shr.core.TelecomNumberOrAddress": {
+                    "Value": "999-555-5555"
+                },
+                "shr.entity.Type": {
+                    "Value": {
+                        "shr.base.EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                        },
+                        "shr.core.Coding": [
+                            {
+                                "Value": "phone"
+                            }
+                        ]
+                    }
+                },
+                "shr.entity.Purpose": {
+                    "Value": {
+                        "shr.base.EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                        },
+                        "shr.core.Coding": {
+                            "Value": "home"
+                        }
+                    }
+                }
+            },
+            {
+                "shr.core.TelecomNumberOrAddress": {
+                    "Value": "999-555-4444"
+                },
+                "shr.entity.Type": {
+                    "Value": {
+                        "shr.base.EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                        },
+                        "shr.core.Coding": [
+                            {
+                                "Value": "phone"
+                            }
+                        ]
+                    }
+                },
+                "shr.entity.Purpose": {
+                    "Value": {
+                        "shr.base.EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                        },
+                        "shr.core.Coding": {
+                            "Value": "mobile"
+                        }
+                    }
+                }
+            }
+        ],
+        "shr.entity.Headshot": {
+            "shr.core.Attachment": {
+                "shr.core.ResourceLocation": {
+                    "Value": "./EllaOrtiz111.png"
+                }
+            }
+        },
+        "shr.core.CreationTime": {
+            "Value": "13 JAN 2012"
+        },
+        "shr.base.LastUpdated": {
+            "Value": "13 JAN 2012"
+        }
     },
     {
         "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",

--- a/src/model/entity/FluxEntityObjectFactory.js
+++ b/src/model/entity/FluxEntityObjectFactory.js
@@ -2,6 +2,7 @@ import { getNamespaceAndName } from '../json-helper';
 import ShrEntityObjectFactory from '../shr/entity/ShrEntityObjectFactory';
 import FluxDeceased from './FluxDeceased';
 import FluxPatient from './FluxPatient';
+import FluxPerson from './FluxPerson';
 
 export default class FluxEntityObjectFactory {
     static createInstance(json, type) {
@@ -13,6 +14,7 @@ export default class FluxEntityObjectFactory {
         switch (elementName) {
             case 'Deceased': return new FluxDeceased(json);
             case 'Patient': return new FluxPatient(json);
+            case 'Person': return new FluxPerson(json);
             default: return ShrEntityObjectFactory.createInstance(json, type);
         }
     }

--- a/src/model/entity/FluxPatient.js
+++ b/src/model/entity/FluxPatient.js
@@ -1,7 +1,6 @@
 import Patient from "../shr/entity/Patient";
 import Deceased from "../shr/entity/Deceased";
 
-
 class FluxPatient {
     constructor(json) {
         this._patient = Patient.fromJSON(json);
@@ -11,13 +10,6 @@ class FluxPatient {
         return this._patient.entryInfo;
     }
 
-    get name() {
-        if (this._patient.party) {
-            return this._patient.party.humanName;
-        }
-        return null;
-    }
-
     get gender() {
         if (this._patient.birthSex) {
             return this._patient.birthSex.value.coding[0].displayText.value;
@@ -25,18 +17,8 @@ class FluxPatient {
         return null;
     }
 
-    get dateOfBirth() {
-        if (this._patient.party) {
-            return this._patient.party.dateOfBirth;
-        }
-        return null;
-    }
-
-    get address() {
-        if (this._patient.party) {
-            return this._patient.party.address;
-        }
-        return null;
+    get person() {
+        return this._patient.value;
     }
 
     get deceased() {
@@ -47,10 +29,6 @@ class FluxPatient {
         let deceased = new Deceased();
         deceased.value = val;
         this._patient.deceased = deceased;
-    }
-
-    get headshot() {
-        return this._patient.party.headshot.attachment.resourceLocation.uri;
     }
 }
 

--- a/src/model/entity/FluxPerson.js
+++ b/src/model/entity/FluxPerson.js
@@ -1,0 +1,29 @@
+import Person from "../shr/entity/Person";
+
+class FluxPerson {
+    constructor(json) {
+        this._person = Person.fromJSON(json);
+    }
+
+    get entryInfo() {
+        return this._person.entryInfo;
+    }
+
+    get name() {
+        return this._person.humanName;
+    }
+
+    get dateOfBirth() {
+        return this._person.dateOfBirth;
+    }
+
+    get address() {
+        return this._person.address;
+    }
+
+    get headshot() {
+        return this._person.headshot.attachment.resourceLocation.uri;
+    }
+}
+
+export default FluxPerson;

--- a/src/panels/PatientControlPanel.jsx
+++ b/src/panels/PatientControlPanel.jsx
@@ -12,7 +12,7 @@ class PatientControlPanel extends Component {
     render() {
         const { patient } = this.props;
         const login = (this.props.supportLogin) ? ( <Button style={{color: "#17263f"}}>{this.props.loginUser}</Button> ) : "";
-        const firstName = patient.getName().split(' ')[0];
+        const firstName = patient.getName() ? patient.getName().split(' ')[0] : "";
         const patientConditions = this.props.patient ? this.props.patient.getConditions() : [];
 
         return (

--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -26,6 +26,7 @@ class PatientRecord {
         if (!Lang.isNull(shrJson)) { // load existing from JSON
             this.entries = this._loadJSON(shrJson);
             this.patient = this.getPatient();
+            this.person = this.getPerson();
             //this.patientReference = new Reference(this.patient.entryInfo.shrId, this.patient.entryInfo.entryId, this.patient.entryInfo.entryType);
             this.shrId = this.patient.entryInfo.shrId;
             this.nextEntryId = Math.max.apply(Math, this.entries.map(function (o) {
@@ -34,6 +35,7 @@ class PatientRecord {
         } else { // create a new patient
             this.entries = [];
             this.patient = null;
+            this.person = null;
             this.shrId = Guid.raw();
             this.nextEntryId = 1;
             //this.patientReference = null;
@@ -152,22 +154,19 @@ class PatientRecord {
     }
 
     getName() {
-        let patient = this.getPatient();
-        if (Lang.isNull(patient)) return null;
-        return patient.name;
+        if (Lang.isNull(this.person)) return null;
+        return this.person.name;
     }
 
     getDateOfBirth() {
-        let patient = this.getPatient();
-        if (Lang.isNull(patient)) return null;
-        return patient.dateOfBirth;
+        if (Lang.isNull(this.person)) return null;
+        return this.person.dateOfBirth;
     }
 
     getAge() {
-        let patient = this.getPatient();
-        if (Lang.isNull(patient)) return null;
+        if (Lang.isNull(this.person)) return null;
         var today = new Date();
-        var birthDate = new Date(patient.dateOfBirth);
+        var birthDate = new Date(this.getDateOfBirth());
         var age = today.getFullYear() - birthDate.getFullYear();
         var m = today.getMonth() - birthDate.getMonth();
         if (m < 0 || (m === 0 && today.getDate() < birthDate.getDate())) {
@@ -177,13 +176,17 @@ class PatientRecord {
     }
 
     getGender() {
-        let patient = this.getPatient();
-        if (Lang.isNull(patient)) return null;
-        return patient.gender;
+        if (Lang.isNull(this.patient)) return null;
+        return this.patient.gender;
     }
 
     getPatient() {
         return this.getMostRecentEntryOfType(FluxPatient);
+    }
+
+    getPerson() {
+        if (Lang.isUndefined(this.patient.person)) return null;
+        return this.getEntryFromReference(this.patient.person);
     }
 
     getMRN() {
@@ -196,13 +199,12 @@ class PatientRecord {
     }
 
     getMostRecentPhoto() {
-        return this.patient.headshot;
+        return this.person.headshot;
     }
 
     getCurrentHomeAddress() {
-        let patient = this.getPatient();
-        if (Lang.isNull(patient) || !patient.address) return null;
-        return patient.address;
+        if (Lang.isNull(this.person)) return null;        
+        return this.person.address;
     }
 
     // return the soonest upcoming encounter. Includes encounters happening later today.

--- a/test/backend/patient/Patient.test.js
+++ b/test/backend/patient/Patient.test.js
@@ -20,6 +20,7 @@ const hardCodedPatientObj = new PatientRecord(hardCodedPatient);
 const hardCodedPatientEntries = hardCodedPatientObj.entries;
 // The patient record entry -- should be an shr object
 const hardCodedPatientRecord = hardCodedPatientObj.getPatient();
+const hardCodedPerson = hardCodedPatientObj.getPerson();
 
 // // Helpers
 // function getValidTypeFrom(patient) { 
@@ -80,7 +81,7 @@ describe('getName', function () {
         expect(hardCodedPatientRecord)
             .to.not.be.null;
         // Path to name based on SHR record api. 
-        const expectedName = hardCodedPatientRecord.name;
+        const expectedName = hardCodedPerson.name;
         expect(hardCodedPatientObj.getName())
             .to.be.a('string')
             .and.to.eql(expectedName);
@@ -98,7 +99,7 @@ describe('getDateOfBirth', function () {
         expect(hardCodedPatientObj)
             .to.not.be.null;
         // Path to date based on SHR record api, use to create moment obj. 
-        const expectedDate = new Moment(hardCodedPatient[0].Value['shr.base.DateOfBirth'], "D MMM YYYY").format("D MMM YYYY").toUpperCase();
+        const expectedDate = hardCodedPerson.dateOfBirth;
         expect(hardCodedPatientObj.getDateOfBirth())
             .to.be.a('string')
             .and.to.equal(expectedDate);


### PR DESCRIPTION
Addresses JIRA-989.

* Created Person entries in both hardcoded patients.
* Value field in Patient entries now a Reference to Person entry.
* Updated PatientRecord to correctly get Person object and get person data.
        - Created FluxPerson to wrap Person object.
* Updated backend tests for PatientRecord.

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
-  Recognizes any potential shortcomings/bugs in the description 
-  Cheat sheet is updated
-  Demo script is updated 
-  Documentation on Wiki has been updated 
-  Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

-  Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
-  Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
-  Added UI tests for slim mode 
-  Added UI tests for full mode
- [x] Added backend tests for fluxNotes code
-  Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
