### PR TITLE
Font fixes

### DIFF
--- a/src/summary/NarrativeNameValuePairsVisualizer.css
+++ b/src/summary/NarrativeNameValuePairsVisualizer.css
@@ -1,5 +1,6 @@
 .narrative-subsections { 
     margin-bottom: 20px;
+    font-size: 0.8rem;
 }
 
 .narrative-inserter-tooltip { 

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -364,7 +364,7 @@ export default class SummaryMetadata {
                         ]
                     },
                     {
-                        name: "Pathology Results",
+                        name: "Pathology",
                         shortName: "Pathology",
                         type: "NameValuePairs",
                         /*eslint no-template-curly-in-string: "off"*/

--- a/src/summary/TabularListVisualizer.css
+++ b/src/summary/TabularListVisualizer.css
@@ -16,6 +16,7 @@
 
 .tabular-list .list-subsection-header {
     color: #333 !important;
+    /*font-style: italic;*/
     font-weight: 600;
     border-top: 0;
 }

--- a/src/summary/TabularListVisualizer.css
+++ b/src/summary/TabularListVisualizer.css
@@ -7,6 +7,7 @@
     width: 98%;
     margin-top: 10px;
     /*table-layout: fixed;*/
+    margin-bottom: 30px !important;
 }
 
 .tabular-list table, tr, td {
@@ -16,9 +17,21 @@
 
 .tabular-list .list-subsection-header {
     color: #333 !important;
-    /*font-style: italic;*/
     font-weight: 600;
-    border-top: 0;
+}
+
+h2.subsection {
+    width:98%;
+    text-align:left;
+    border-bottom: 1px solid #cccccc;
+    line-height:0.1em;
+    margin:20px 10px 10px 0px !important;
+}
+
+h2.subsection span {
+    background:#fff;
+    font-size: 0.8rem;
+    padding-right: 10px;
 }
 
 .tabular-list tr:nth-child(even) { 

--- a/src/summary/TabularListVisualizer.css
+++ b/src/summary/TabularListVisualizer.css
@@ -16,8 +16,7 @@
 
 .tabular-list .list-subsection-header {
     color: #333 !important;
-    font-style: italic;
-    font-weight: bold;
+    font-weight: 600;
     border-top: 0;
 }
 
@@ -74,4 +73,5 @@
     background-color: #ffffff;
     padding: 8px 10px;
     border-bottom: 1px solid lightgray;
+    font-weight: 600 !important;
 }

--- a/src/summary/TabularListVisualizer.jsx
+++ b/src/summary/TabularListVisualizer.jsx
@@ -129,7 +129,7 @@ class TabularListVisualizer extends Component {
         }
         let subsectionname = null;
         if (transformedSubsection.name && transformedSubsection.name.length > 0) {
-            subsectionname = <tr><td className="list-subsection-header">{transformedSubsection.name}</td></tr>;
+            subsectionname = <h2 className="subsection list-subsection-header"><span>{transformedSubsection.name}</span></h2>;
         }
         if (list.length <= 0) {
             return <div key={subsectionindex}><table><tbody>{subsectionname}</tbody></table><h2 style={{paddingTop: '10px'}}>None</h2></div>;
@@ -147,10 +147,10 @@ class TabularListVisualizer extends Component {
         return (
             <div key={subsectionindex}>
                 {preTableCount}
+                {subsectionname}
                 <table>
                     <tbody>
-                    {headings}
-                        {subsectionname}
+                    {headings ? headings : <tr></tr>}
                         {this.renderedListItems(subsectionindex, list, numberOfHeadings)}
                     </tbody>
                 </table>

--- a/src/summary/TargetedDataSection.css
+++ b/src/summary/TargetedDataSection.css
@@ -3,7 +3,7 @@
     flex-wrap: nowrap;
     align-items: center;
     justify-content: space-between;
-    font-weight: bold;
+    font-weight: 600;
     color: #333;
 }
 

--- a/src/summary/TargetedDataSubpanel.css
+++ b/src/summary/TargetedDataSubpanel.css
@@ -39,7 +39,7 @@ tr.existing-note-entry td:last-child {
 }
 
 #condition-summary-section h2.section-header{
-    font-weight: bold;
+    /*font-weight: bold;*/
     color: #333;
 }
 


### PR DESCRIPTION
This PR addresses the following jira issues: 992, 997, and 1003.

- Made text size same for narrative and tabular
- Renamed "Pathology Results" section to "Pathology"
- For issue 1003, after talking with @gregquinn2001 , @Dtphelan1 , @jafeltra , and Edwin, removed italics and instead made the section identifiers have a horizontal line to separate the sections. Decreased weight of section and column headers


_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- N/A Cheat sheet is updated
- N/A Demo script is updated 
- N/A Documentation on Wiki has been updated 
- N/A Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- N/A Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- N/A Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- N/A Added UI tests for slim mode 
- N/A Added UI tests for full mode
- N/A Added backend tests for fluxNotes code
- N/A Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
