### PR TITLE
tooltip now appears for long descriptions in summary panel

### DIFF
--- a/src/summary/TabularListVisualizer.css
+++ b/src/summary/TabularListVisualizer.css
@@ -74,6 +74,13 @@ h2.subsection span {
     padding: 0;
 }
 
+.tabular-list-tooltip .rc-tooltip-inner{
+    width: 200px;
+    min-height: 22px;
+    text-align: center;
+    border-radius: 6px;
+}
+
 .tabular-list ul li {
     font-size: 0.8rem;
     text-decoration: underline #0182D7;

--- a/src/summary/TabularListVisualizer.jsx
+++ b/src/summary/TabularListVisualizer.jsx
@@ -285,78 +285,77 @@ class TabularListVisualizer extends Component {
                 let columnItem = null;
                 isInsertable = (Lang.isNull(element) ? false : (Lang.isUndefined(element.isInsertable) ? true : element.IsInsertable));
                 elementText = Lang.isNull(element) ? null : (Lang.isObject(element) ? element.value : element);
-                let longElementText = elementText;
-                if(!Lang.isNull(elementText) && elementText.length > 100) elementText = elementText.substring(0, 100) + "...";
-                if(Lang.isNull(element) || Lang.isUndefined(elementText) || elementText.length === 0) {
+                const longElementText = elementText;
+                if (!Lang.isNull(elementText) && elementText.length > 100) elementText = elementText.substring(0, 100) + "...";
+                if (Lang.isNull(element) || Lang.isUndefined(elementText) || elementText.length === 0) {
                     columnItem = (
-                        <td 
-                            className={"list-missing"} 
-                            data-test-summary-item={item[0]} 
+                        <td
+                            className={"list-missing"}
+                            data-test-summary-item={item[0]}
                             key={elementId}
-                        >   
+                        >
                             <span>
                                 Missing Data
                             </span>
                         </td>
                     );
-                }
-                else if (this.props.allowItemClick && isInsertable) {
-                        // Get value off of element given two cases:
-                        // 1. Element type is shortcut, value is returned by element.value()
-                        // 2. Element type is string, the value is just the string
+                } else if (this.props.allowItemClick && isInsertable) {
+                    // Get value off of element given two cases:
+                    // 1. Element type is shortcut, value is returned by element.value()
+                    // 2. Element type is string, the value is just the string
 
-                        // Make unique id for each value
-                        columnItem = (
-                            <td width={colSize}
-                                className={itemClass}
-                                key={elementId}
-                            >
+                    // Make unique id for each value
+                    columnItem = (
+                        <td width={colSize}
+                            className={itemClass}
+                            key={elementId}
+                        >
                             {this.renderedStructuredData(item[0].value, element, elementId, elementText)}
-                            </td>
+                        </td>
 
-                        );
-                    } else if (!isInsertable) {
-                        columnItem = (
-                            <td width={colSize}
-                                key={elementId}
-                            >
-                                <span>
-                                    {elementText}
-                                </span>
-                            </td>
-                        );
-                    } else {
-                        columnItem = (
-                            <td width={colSize}
-                                className={itemClass}
-                                data-test-summary-item={item[0].value}
-                                key={elementId}
-                            >
-                                <span>
-                                    {elementText}
-                                </span>
-                            </td>
-                        );
-                    }
+                    );
+                } else if (!isInsertable) {
+                    columnItem = (
+                        <td width={colSize}
+                            key={elementId}
+                        >
+                            <span>
+                                {elementText}
+                            </span>
+                        </td>
+                    );
+                } else {
+                    columnItem = (
+                        <td width={colSize}
+                            className={itemClass}
+                            data-test-summary-item={item[0].value}
+                            key={elementId}
+                        >
+                            <span>
+                                {elementText}
+                            </span>
+                        </td>
+                    );
+                }
 
-                    if(!Lang.isNull(elementText) && elementText.length > 100){
-                        const text = <span>{longElementText}</span>
-                        columnItem = (
-                            <Tooltip
-                                key={elementId}
-                                overlayStyle={{'visibility': true}}
-                                placement="top"
-                                overlayClassName={`context-panel-tooltip large`}
-                                overlay={text}
-                                destroyTooltipOnHide={true}
-                                mouseEnterDelay={0.5}
-                                onMouseEnter={this.mouseEnter}
-                                onMouseLeave={this.mouseLeave}
-                            >
+                if (!Lang.isNull(elementText) && elementText.length > 100) {
+                    const text = <span>{longElementText}</span>
+                    columnItem = (
+                        <Tooltip
+                            key={elementId}
+                            overlayStyle={{ 'visibility': true }}
+                            placement="top"
+                            overlayClassName={`context-panel-tooltip large`}
+                            overlay={text}
+                            destroyTooltipOnHide={true}
+                            mouseEnterDelay={0.5}
+                            onMouseEnter={this.mouseEnter}
+                            onMouseLeave={this.mouseLeave}
+                        >
                             {columnItem}
-                            </Tooltip>
-                    )}
-
+                        </Tooltip>
+                    )
+                }
                 renderedColumns.push(columnItem);
             });
 

--- a/src/summary/TabularListVisualizer.jsx
+++ b/src/summary/TabularListVisualizer.jsx
@@ -6,6 +6,7 @@ import { ListItemIcon, ListItemText } from 'material-ui/List';
 import Menu, { MenuItem } from 'material-ui/Menu';
 import FontAwesome from 'react-fontawesome';
 import './TabularListVisualizer.css';
+import Tooltip from 'rc-tooltip';
 
 
 /*
@@ -167,7 +168,6 @@ class TabularListVisualizer extends Component {
         if (patient == null || condition == null || conditionSection == null) {
             return [];
         }
-        
         const items = subsection.items;
         const itemsFunction = subsection.itemsFunction;
         let list;
@@ -285,6 +285,8 @@ class TabularListVisualizer extends Component {
                 let columnItem = null;
                 isInsertable = (Lang.isNull(element) ? false : (Lang.isUndefined(element.isInsertable) ? true : element.IsInsertable));
                 elementText = Lang.isNull(element) ? null : (Lang.isObject(element) ? element.value : element);
+                let longElementText = elementText;
+                if(!Lang.isNull(elementText) && elementText.length > 100) elementText = elementText.substring(0, 100) + "...";
                 if(Lang.isNull(element) || Lang.isUndefined(elementText) || elementText.length === 0) {
                     columnItem = (
                         <td 
@@ -297,43 +299,64 @@ class TabularListVisualizer extends Component {
                             </span>
                         </td>
                     );
-                } else if (this.props.allowItemClick && isInsertable) {
-                    // Get value off of element given two cases: 
-                    // 1. Element type is shortcut, value is returned by element.value()
-                    // 2. Element type is string, the value is just the string
-
-                    // Make unique id for each value
-                    columnItem = (
-                        <td width={colSize}
-                            className={itemClass} 
-                            key={elementId}
-                        >   
-                        {this.renderedStructuredData(item[0].value, element, elementId, elementText)}
-                        </td>
-                    );
-                } else if (!isInsertable) {
-                    columnItem = (
-                        <td width={colSize}
-                            key={elementId}
-                        >
-                            <span>
-                                {elementText}
-                            </span>
-                        </td>
-                    );
-                } else {
-                    columnItem = (
-                        <td width={colSize}
-                            className={itemClass} 
-                            data-test-summary-item={item[0].value} 
-                            key={elementId}
-                        >
-                            <span>
-                                {elementText}
-                            </span>
-                        </td>
-                    );
                 }
+                else if (this.props.allowItemClick && isInsertable) {
+                        // Get value off of element given two cases:
+                        // 1. Element type is shortcut, value is returned by element.value()
+                        // 2. Element type is string, the value is just the string
+
+                        // Make unique id for each value
+                        columnItem = (
+                            <td width={colSize}
+                                className={itemClass}
+                                key={elementId}
+                            >
+                            {this.renderedStructuredData(item[0].value, element, elementId, elementText)}
+                            </td>
+
+                        );
+                    } else if (!isInsertable) {
+                        columnItem = (
+                            <td width={colSize}
+                                key={elementId}
+                            >
+                                <span>
+                                    {elementText}
+                                </span>
+                            </td>
+                        );
+                    } else {
+                        columnItem = (
+                            <td width={colSize}
+                                className={itemClass}
+                                data-test-summary-item={item[0].value}
+                                key={elementId}
+                            >
+                                <span>
+                                    {elementText}
+                                </span>
+                            </td>
+                        );
+                    }
+
+                    if(!Lang.isNull(elementText) && elementText.length > 100){
+                        const text = <span>{longElementText}</span>
+                        columnItem = (
+                            <Tooltip
+                                key={elementId}
+                                overlayStyle={{'visibility': true}}
+                                placement="top"
+                                overlayClassName={`context-panel-tooltip large`}
+                                overlay={text}
+                                destroyTooltipOnHide={true}
+                                mouseEnterDelay={0.5}
+                                onMouseEnter={this.mouseEnter}
+                                onMouseLeave={this.mouseLeave}
+                            >
+                            {columnItem}
+                            </Tooltip>
+                    )}
+
                 renderedColumns.push(columnItem);
             });
 

--- a/src/summary/TabularListVisualizer.jsx
+++ b/src/summary/TabularListVisualizer.jsx
@@ -345,7 +345,7 @@ class TabularListVisualizer extends Component {
                             key={elementId}
                             overlayStyle={{ 'visibility': true }}
                             placement="top"
-                            overlayClassName={`context-panel-tooltip large`}
+                            overlayClassName={`tabular-list-tooltip`}
                             overlay={text}
                             destroyTooltipOnHide={true}
                             mouseEnterDelay={0.5}


### PR DESCRIPTION
The TabularListVizulizer has now been updated so that if something is a string longer then 100 it will be turn into a subset of that string with a "..." at the end and a tooltip is created so when you put the mouse over it you can see the full description. I am planning on email Edwin to see if this is they best way to handle this or if he has another idea.  You can test this by enrolling in the patina clinical trail and looking at description in the clinical trail section.


## Submitter: Laura Clark

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- NA Cheat sheet is updated
- NA Demo script is updated 
- NA Documentation on Wiki has been updated 
- NA Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- NA Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- NA Added UI tests for slim mode 
- NA Added UI tests for full mode
- NA Added backend tests for fluxNotes code
- NA Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
