### PR TITLE
Structured data fix

### DIFF
--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -223,20 +223,13 @@ class FluxNotesEditor extends React.Component {
         if (Lang.isUndefined(transform)) {
             transform = this.state.state.transform();
         }
-
-        let shortcut; 
+        
         // check if shortcutTrigger is currently valid
-        if (!this.shortcutTriggerCheck(shortcutTrigger)) {
-            shortcut = this.props.newCurrentShortcut(shortcutC, shortcutTrigger, updatePatient);
-            // if shortcut has a regexpTrigger, do not insert plain text
-            if (!Lang.isNull(shortcut) && !shortcut.metadata.regexpTrigger) {
-                return this.insertPlainText(transform, shortcutTrigger);
-            }
+        if (Lang.isNull(shortcutC) && !this.shortcutTriggerCheck(shortcutTrigger)) {
+            return this.insertPlainText(transform, shortcutTrigger);
         }
 
-        if (Lang.isUndefined(shortcut)) {
-            shortcut = this.props.newCurrentShortcut(shortcutC, shortcutTrigger, updatePatient);
-        }
+        let shortcut = this.props.newCurrentShortcut(shortcutC, shortcutTrigger, updatePatient);
         if (!Lang.isNull(shortcut) && shortcut.needToSelectValueFromMultipleOptions()) {
             if (text.length > 0) {
                 shortcut.setText(text);

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -245,8 +245,19 @@ class FluxNotesEditor extends React.Component {
     }
 
     autoReplaceTransform(def, transform, e, data, matches) {
-        // need to use Transform object provided to this method, which AutoReplace .apply()s after return.
-        return this.insertShortcut(def, matches.before[0], "", transform).insertText(' ');
+        const shortcuts = this.contextManager.getCurrentlyValidShortcuts(this.props.shortcutManager);
+        const shortcutTrigger = matches.before[0];
+
+        // Check if shortcutTrigger is a shortcut trigger in the list of currently valid shortcuts
+        const validShortcut = shortcuts.some((shortcut) => {
+            const triggers = this.props.shortcutManager.getTriggersForShortcut(shortcut);
+            return triggers.some((trigger) => {
+                return trigger.name.toLowerCase() === shortcutTrigger.toLowerCase();
+            });
+        });
+
+        // insert plain text if not a valid shortcut
+        return validShortcut ? this.insertShortcut(def, shortcutTrigger, "", transform).insertText(' ') : this.insertPlainText(transform, shortcutTrigger).insertText(' ');
     }
 
     getTextCursorPosition = () => {

--- a/src/shortcuts/CreatorBase.jsx
+++ b/src/shortcuts/CreatorBase.jsx
@@ -354,9 +354,11 @@ export default class CreatorBase extends Shortcut {
                 args.forEach((a) => list.push(a));
                 Lang.set(this.object, listAttribute, list);
             } else if (obj === "$parentValueObject") {
-                let list = Lang.get(this.parentContext.getValueObject(), listAttribute);
-                args.forEach((a) => list.push(a));
-                Lang.set(this.parentContext.getValueObject(), listAttribute, list);
+                if (!Lang.isUndefined(this.parentContext)) {
+                    let list = Lang.get(this.parentContext.getValueObject(), listAttribute);
+                    args.forEach((a) => list.push(a));
+                    Lang.set(this.parentContext.getValueObject(), listAttribute, list);
+                }
             } else {
                 console.error("unsupported object type: " + obj + " for updatePatient");
             }

--- a/test/ui/FullApp.js
+++ b/test/ui/FullApp.js
@@ -209,6 +209,19 @@ test('Typing an inserterShortcut in the editor results in a structured data inse
         .contains(new PatientRecord(hardCodedPatient).getName());
 });
 
+test('Typing an inserterShortcut that is not currently valid in the editor does not result in a structured data insertion ', async t => {
+    const clinicalEventSelector = Selector('.clinical-event-select');
+    await t
+        .click(clinicalEventSelector)
+        .click(Selector('[data-test-clinical-event-selector-item="Post-encounter"]'));
+    const editor = Selector("div[data-slate-editor='true']");
+    await t
+        .typeText(editor, "#imaging #staging ")
+    const structuredField = editor.find("span[class='structured-field']");
+    await t
+        .expect(structuredField.exists).notOk();
+});
+
 test('Typing a date in the editor results in a structured data insertion ', async t => {
     const clinicalEventSelector = Selector('.clinical-event-select');
     await t


### PR DESCRIPTION
Addresses JIRA-982.

- Previously when we entered '#imaging ' it would get translated into a structured phrase even if there was no #disease status.
- Added a shortcutTriggerCheck function in FluxNotesEditor.jsx to check whether a shortcut trigger is one of the triggers of the currently valid shortcuts.
- Invoked the shortTriggerCheck function in insertShortcut to make sure it is valid.  Will insert plain text instead if not valid.
- This also fixes the same issue when we copy and paste in shortcuts.
- Added UI test to make sure invalid shortcuts don't get translated into structured phrases.

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
-  Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
-  Recognizes any potential shortcomings/bugs in the description 
-  Cheat sheet is updated
-  Demo script is updated 
-  Documentation on Wiki has been updated 
-  Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

-  Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
-  Added UI tests for slim mode 
- [x] Added UI tests for full mode
-  Added backend tests for fluxNotes code
-  Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
