### PR TITLE
Evidence as entries

### DIFF
--- a/src/dataaccess/HardCodedPatient.json
+++ b/src/dataaccess/HardCodedPatient.json
@@ -252,331 +252,89 @@
         },
         "shr.finding.Evidence": [
             {
-                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
-                "shr.finding.ClinicallyRelevantTime": { "Value": "01 JAN 2018" },
-                "Value": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
-                    "Value": 15, 
-                    "shr.core.Units": {
-                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
-                        "Value": {
-                            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
-                            "Value": "%"
-                        }
-                    }
-                },
-                "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0019046", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value": "Hemoglobin"}}]},
-                "shr.finding.FindingStatus": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
-                }
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                "EntryId": "1000",
+                "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" }
             },
             {
-                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
-                "shr.finding.ClinicallyRelevantTime": { "Value": "19 DEC 2017" },
-                "Value": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
-                    "Value": 10.30, 
-                    "shr.core.Units": {
-                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
-                        "Value": {
-                            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
-                            "Value": "%"
-                        }
-                    }
-                },
-                "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0019046", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value": "Hemoglobin"}}]},
-                "shr.finding.FindingStatus": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
-                }
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                "EntryId": "1010",
+                "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" }
             },
             {
-                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
-                "shr.finding.ClinicallyRelevantTime": { "Value": "10 JAN 2018" },
-                "Value": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
-                    "Value": 14.50, 
-                    "shr.core.Units": {
-                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
-                        "Value": {
-                            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
-                            "Value": "%"
-                        }
-                    }
-                },
-                "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0019046", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value": "Hemoglobin"}}]},
-                "shr.finding.FindingStatus": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
-                }
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                "EntryId": "1020",
+                "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" }
             },
             {
-                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
-                "shr.finding.ClinicallyRelevantTime": { "Value": "25 NOV 2017" },
-                "Value": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
-                    "Value": 6.74, 
-                    "shr.core.Units": {
-                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
-                        "Value": {
-                            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
-                            "Value": "10^9/L"
-                        }
-                    }
-                },
-                "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0023508", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value": "White blood cell"}}]},
-                "shr.finding.FindingStatus": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
-                }
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                "EntryId": "1030",
+                "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" }
             },
             {
-                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
-                "shr.finding.ClinicallyRelevantTime": { "Value": "5 DEC 2017" },
-                "Value": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
-                    "Value": 3.37, 
-                    "shr.core.Units": {
-                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
-                        "Value": {
-                            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
-                            "Value": "10^9/L"
-                        }
-                    }
-                },
-                "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0023508", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value": "White blood cell"}}]},
-                "shr.finding.FindingStatus": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
-                }
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                "EntryId": "1040",
+                "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" }
             },
             {
-                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
-                "shr.finding.ClinicallyRelevantTime": { "Value": "12 DEC 2017" },
-                "Value": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
-                    "Value": 1.86, 
-                    "shr.core.Units": {
-                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
-                        "Value": {
-                            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
-                            "Value": "10^9/L"
-                        }
-                    }
-                },
-                "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0023508", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value": "White blood cell"}}]},
-                "shr.finding.FindingStatus": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
-                }
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                "EntryId": "1050",
+                "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" }
             },
             {
-                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
-                "shr.finding.ClinicallyRelevantTime": { "Value": "19 DEC 2017" },
-                "Value": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
-                    "Value": 4.72, 
-                    "shr.core.Units": {
-                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
-                        "Value": {
-                            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
-                            "Value": "10^9/L"
-                        }
-                    }
-                },
-                "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0023508", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value": "White blood cell"}}]},
-                "shr.finding.FindingStatus": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
-                }
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                "EntryId": "1060",
+                "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" }
             },
             {
-                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
-                "shr.finding.ClinicallyRelevantTime": { "Value": "27 DEC 2017" },
-                "Value": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
-                    "Value": 6.75, 
-                    "shr.core.Units": {
-                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
-                        "Value": {
-                            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
-                            "Value": "10^9/L"
-                        }
-                    }
-                },
-                "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0023508", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText":  {"Value": "White blood cell"}}]},
-                "shr.finding.FindingStatus": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": "Final"}]
-                }
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                "EntryId": "1070",
+                "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" }
             },
             {
-                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
-                "shr.finding.ClinicallyRelevantTime": { "Value": "02 JAN 2018" },
-                "Value": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
-                    "Value": 8.12, 
-                    "shr.core.Units": {
-                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
-                        "Value": {
-                            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
-                            "Value": "10^9/L"
-                        }
-                    }
-                },
-                "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0023508", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value": "White blood cell"}}]},
-                "shr.finding.FindingStatus": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
-                }
-            },
-            {                
-                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
-                "shr.finding.ClinicallyRelevantTime": { "Value": "25 NOV 2017" },
-                "Value": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
-                    "Value": 4.2, 
-                    "shr.core.Units": {
-                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
-                        "Value": {
-                            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
-                            "Value": "10^9/L"
-                        }
-                    }
-                },
-                "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0027950", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value": "Neutrophil"}}]},
-                "shr.finding.FindingStatus": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
-                }
-            },
-            {                
-                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
-                "shr.finding.ClinicallyRelevantTime": { "Value": "5 DEC 2017" },
-                "Value": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
-                    "Value": 2.3, 
-                    "shr.core.Units": {
-                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
-                        "Value": {
-                            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
-                            "Value": "10^9/L"
-                        }
-                    }
-                },
-                "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0027950", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value": "Neutrophil"}}]},
-                "shr.finding.FindingStatus": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
-                }
-            },
-            {                
-                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
-                "shr.finding.ClinicallyRelevantTime": { "Value": "12 DEC 2017" },
-                "Value": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
-                    "Value": 1.2, 
-                    "shr.core.Units": {
-                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
-                        "Value": {
-                            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
-                            "Value": "10^9/L"
-                        }
-                    }
-                },
-                "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0027950", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value": "Neutrophil"}}]},
-                "shr.finding.FindingStatus": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
-                }
-            },
-            {                
-                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
-                "shr.finding.ClinicallyRelevantTime": { "Value": "19 DEC 2017" },
-                "Value": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
-                    "Value": 1.9, 
-                    "shr.core.Units": {
-                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
-                        "Value": {
-                            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
-                            "Value": "10^9/L"
-                        }
-                    }
-                },
-                "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0027950", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value": "Neutrophil"}}]},
-                "shr.finding.FindingStatus": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
-                }
-            },
-            {                
-                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
-                "shr.finding.ClinicallyRelevantTime": { "Value": "27 DEC 2017" },
-                "Value": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
-                    "Value": 2.6, 
-                    "shr.core.Units": {
-                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
-                        "Value": {
-                            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
-                            "Value": "10^9/L"
-                        }
-                    }
-                },
-                "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0027950", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value": "Neutrophil"}}]},
-                "shr.finding.FindingStatus": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
-                }
-            },
-            {                
-                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
-                "shr.finding.ClinicallyRelevantTime": { "Value": "02 JAN 2018" },
-                "Value": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
-                    "Value": 4.3, 
-                    "shr.core.Units": {
-                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
-                        "Value": {
-                            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
-                            "Value": "10^9/L"
-                        }
-                    }
-                },
-                "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0027950", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value": "Neutrophil"}}]},
-                "shr.finding.FindingStatus": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
-                }
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                "EntryId": "1080",
+                "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" }
             },
             {
-                "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/oncology/HistologicGrade"},
-                "Value":  {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "369792005", "shr.core.CodeSystem": {"Value": "http://snomed.info/sct"}, "shr.core.DisplayText": {"Value": "High grade or poorly differentiated"}}]},
-                "shr.finding.FindingStatus": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
-                }
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                "EntryId": "1090",
+                "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" }
             },
             {
-                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/oncology/TumorDimensions" },
-                "Value": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
-                    "Value": 30.0, 
-                    "Units": {
-                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
-                        "Value": {
-                            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
-                            "Value": "mm"
-                        }
-                    }
-                },
-                "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0475440", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value": "Tumor Size"}}]},
-                "shr.finding.FindingStatus": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
-                }
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                "EntryId": "1100",
+                "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" }
+            },
+            {
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                "EntryId": "1110",
+                "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" }
+            },
+            {
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                "EntryId": "1120",
+                "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" }
+            },
+            {
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                "EntryId": "1130",
+                "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" }
+            },
+            {
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                "EntryId": "1140",
+                "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" }
+            },
+            {
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                "EntryId": "1150",
+                "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/oncology/HistologicGrade" }
+            },
+            {
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                "EntryId": "1160",
+                "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/oncology/TumorDimensions" }
             }
         ],
         "shr.core.CreationTime": {"Value": "13 JAN 2012"},
@@ -1886,5 +1644,420 @@
         "Value": false,
         "shr.core.CreationTime": {"Value": "01 JAN 2018"},
         "shr.base.LastUpdated": {"Value": "01 JAN 2018"}
+    },
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "shr.base.EntryId": "1000",
+        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1"},
+        "shr.finding.ClinicallyRelevantTime": { "Value": "01 JAN 2018" },
+        "Value": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
+            "Value": 15, 
+            "shr.core.Units": {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
+                "Value": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+                    "Value": "%"
+                }
+            }
+        },
+        "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0019046", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value": "Hemoglobin"}}]},
+        "shr.finding.FindingStatus": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
+        },
+        "shr.core.CreationTime": {"Value": "01 JAN 2018"},
+        "shr.base.LastUpdated": {"Value": "01 JAN 2018"}
+    },
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "shr.base.EntryId": "1010",
+        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1"},
+        "shr.finding.ClinicallyRelevantTime": { "Value": "19 DEC 2017" },
+        "Value": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
+            "Value": 10.30, 
+            "shr.core.Units": {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
+                "Value": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+                    "Value": "%"
+                }
+            }
+        },
+        "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0019046", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value": "Hemoglobin"}}]},
+        "shr.finding.FindingStatus": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
+        },
+        "shr.core.CreationTime": {"Value": "19 DEC 2017"},
+        "shr.base.LastUpdated": {"Value": "19 DEC 2017"}
+    },
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "shr.base.EntryId": "1020",
+        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1"},
+        "shr.finding.ClinicallyRelevantTime": { "Value": "10 JAN 2018" },
+        "Value": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
+            "Value": 14.50, 
+            "shr.core.Units": {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
+                "Value": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+                    "Value": "%"
+                }
+            }
+        },
+        "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0019046", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value": "Hemoglobin"}}]},
+        "shr.finding.FindingStatus": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
+        },
+        "shr.core.CreationTime": {"Value": "10 JAN 2018"},
+        "shr.base.LastUpdated": {"Value": "10 JAN 2018"}
+    },
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "shr.base.EntryId": "1030",
+        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1"},
+        "shr.finding.ClinicallyRelevantTime": { "Value": "25 NOV 2017" },
+        "Value": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
+            "Value": 6.74, 
+            "shr.core.Units": {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
+                "Value": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+                    "Value": "10^9/L"
+                }
+            }
+        },
+        "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0023508", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value": "White blood cell"}}]},
+        "shr.finding.FindingStatus": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
+        },
+        "shr.core.CreationTime": {"Value": "25 NOV 2017"},
+        "shr.base.LastUpdated": {"Value": "25 NOV 2017"}
+    },
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "shr.base.EntryId": "1040",
+        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1"},
+        "shr.finding.ClinicallyRelevantTime": { "Value": "5 DEC 2017" },
+        "Value": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
+            "Value": 3.37, 
+            "shr.core.Units": {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
+                "Value": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+                    "Value": "10^9/L"
+                }
+            }
+        },
+        "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0023508", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value": "White blood cell"}}]},
+        "shr.finding.FindingStatus": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
+        },
+        "shr.core.CreationTime": {"Value": "5 DEC 2017"},
+        "shr.base.LastUpdated": {"Value": "5 DEC 2017"}
+    },
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "shr.base.EntryId": "1050",
+        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1"},
+        "shr.finding.ClinicallyRelevantTime": { "Value": "12 DEC 2017" },
+        "Value": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
+            "Value": 1.86, 
+            "shr.core.Units": {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
+                "Value": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+                    "Value": "10^9/L"
+                }
+            }
+        },
+        "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0023508", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value": "White blood cell"}}]},
+        "shr.finding.FindingStatus": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
+        },
+        "shr.core.CreationTime": {"Value": "12 DEC 2017"},
+        "shr.base.LastUpdated": {"Value": "12 DEC 2017"}
+    },
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "shr.base.EntryId": "1060",
+        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1"},
+        "shr.finding.ClinicallyRelevantTime": { "Value": "19 DEC 2017" },
+        "Value": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
+            "Value": 4.72, 
+            "shr.core.Units": {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
+                "Value": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+                    "Value": "10^9/L"
+                }
+            }
+        },
+        "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0023508", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value": "White blood cell"}}]},
+        "shr.finding.FindingStatus": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
+        },
+        "shr.core.CreationTime": {"Value": "19 DEC 2017"},
+        "shr.base.LastUpdated": {"Value": "19 DEC 2017"}
+    },
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "shr.base.EntryId": "1070",
+        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1"},
+        "shr.finding.ClinicallyRelevantTime": { "Value": "27 DEC 2017" },
+        "Value": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
+            "Value": 6.75, 
+            "shr.core.Units": {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
+                "Value": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+                    "Value": "10^9/L"
+                }
+            }
+        },
+        "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0023508", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText":  {"Value": "White blood cell"}}]},
+        "shr.finding.FindingStatus": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": "Final"}]
+        },
+        "shr.core.CreationTime": {"Value": "27 DEC 2017"},
+        "shr.base.LastUpdated": {"Value": "27 DEC 2017"}
+    },
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "shr.base.EntryId": "1080",
+        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1"},
+        "shr.finding.ClinicallyRelevantTime": { "Value": "02 JAN 2018" },
+        "Value": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
+            "Value": 8.12, 
+            "shr.core.Units": {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
+                "Value": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+                    "Value": "10^9/L"
+                }
+            }
+        },
+        "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0023508", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value": "White blood cell"}}]},
+        "shr.finding.FindingStatus": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
+        },
+        "shr.core.CreationTime": {"Value": "02 JAN 2018"},
+        "shr.base.LastUpdated": {"Value": "02 JAN 2018"}
+    },
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "shr.base.EntryId": "1090",
+        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1"},
+        "shr.finding.ClinicallyRelevantTime": { "Value": "25 NOV 2017" },
+        "Value": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
+            "Value": 4.2, 
+            "shr.core.Units": {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
+                "Value": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+                    "Value": "10^9/L"
+                }
+            }
+        },
+        "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0027950", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value": "Neutrophil"}}]},
+        "shr.finding.FindingStatus": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
+        },
+        "shr.core.CreationTime": {"Value": "25 NOV 2017"},
+        "shr.base.LastUpdated": {"Value": "25 NOV 2017"}
+    },
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "shr.base.EntryId": "1100",
+        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1"},
+        "shr.finding.ClinicallyRelevantTime": { "Value": "5 DEC 2017" },
+        "Value": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
+            "Value": 2.3, 
+            "shr.core.Units": {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
+                "Value": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+                    "Value": "10^9/L"
+                }
+            }
+        },
+        "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0027950", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value": "Neutrophil"}}]},
+        "shr.finding.FindingStatus": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
+        },
+        "shr.core.CreationTime": {"Value": "5 DEC 2017"},
+        "shr.base.LastUpdated": {"Value": "5 DEC 2017"}
+    },
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "shr.base.EntryId": "1110",
+        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1"},
+        "shr.finding.ClinicallyRelevantTime": { "Value": "12 DEC 2017" },
+        "Value": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
+            "Value": 1.2, 
+            "shr.core.Units": {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
+                "Value": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+                    "Value": "10^9/L"
+                }
+            }
+        },
+        "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0027950", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value": "Neutrophil"}}]},
+        "shr.finding.FindingStatus": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
+        },
+        "shr.core.CreationTime": {"Value": "12 DEC 2017"},
+        "shr.base.LastUpdated": {"Value": "12 DEC 2017"}
+    },
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "shr.base.EntryId": "1120",
+        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1"},
+        "shr.finding.ClinicallyRelevantTime": { "Value": "19 DEC 2017" },
+        "Value": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
+            "Value": 1.9, 
+            "shr.core.Units": {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
+                "Value": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+                    "Value": "10^9/L"
+                }
+            }
+        },
+        "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0027950", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value": "Neutrophil"}}]},
+        "shr.finding.FindingStatus": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
+        },
+        "shr.core.CreationTime": {"Value": "19 DEC 2017"},
+        "shr.base.LastUpdated": {"Value": "19 DEC 2017"}
+    },
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "shr.base.EntryId": "1130",
+        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1"},
+        "shr.finding.ClinicallyRelevantTime": { "Value": "27 DEC 2017" },
+        "Value": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
+            "Value": 2.6, 
+            "shr.core.Units": {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
+                "Value": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+                    "Value": "10^9/L"
+                }
+            }
+        },
+        "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0027950", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value": "Neutrophil"}}]},
+        "shr.finding.FindingStatus": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
+        },
+        "shr.core.CreationTime": {"Value": "27 DEC 2017"},
+        "shr.base.LastUpdated": {"Value": "27 DEC 2017"}
+    },
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "shr.base.EntryId": "1140",
+        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1"},
+        "shr.finding.ClinicallyRelevantTime": { "Value": "02 JAN 2018" },
+        "Value": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
+            "Value": 4.3, 
+            "shr.core.Units": {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
+                "Value": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+                    "Value": "10^9/L"
+                }
+            }
+        },
+        "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0027950", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value": "Neutrophil"}}]},
+        "shr.finding.FindingStatus": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
+        },
+        "shr.core.CreationTime": {"Value": "02 JAN 2018"},
+        "shr.base.LastUpdated": {"Value": "02 JAN 2018"}
+    },
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "shr.base.EntryId": "1150",
+        "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/oncology/HistologicGrade"},
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1"},
+        "shr.finding.ClinicallyRelevantTime": { "Value": "13 JAN 2012" },
+        "Value":  {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "369792005", "shr.core.CodeSystem": {"Value": "http://snomed.info/sct"}, "shr.core.DisplayText": {"Value": "High grade or poorly differentiated"}}]},
+        "shr.finding.FindingStatus": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
+        },
+        "shr.core.CreationTime": {"Value": "13 JAN 2012"},
+        "shr.base.LastUpdated": {"Value": "13 JAN 2012"}
+    },
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "shr.base.EntryId": "1160",
+        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/oncology/TumorDimensions" },
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"},"ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d", "EntryId": "1"},
+        "shr.finding.ClinicallyRelevantTime": { "Value": "13 JAN 2012" },
+        "Value": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
+            "Value": 30.0, 
+            "Units": {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
+                "Value": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+                    "Value": "mm"
+                }
+            }
+        },
+        "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0475440", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, "shr.core.DisplayText": {"Value": "Tumor Size"}}]},
+        "shr.finding.FindingStatus": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
+        },
+        "shr.core.CreationTime": {"Value": "13 JAN 2012"},
+        "shr.base.LastUpdated": {"Value": "13 JAN 2012"}
     }
+
 ]

--- a/src/dataaccess/HardCodedPatientMidYearDemo18.json
+++ b/src/dataaccess/HardCodedPatientMidYearDemo18.json
@@ -309,9 +309,6 @@
             }
         },
         "shr.finding.Evidence": [
-
-
-
             {
                 "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
                 "EntryId": "2000",
@@ -432,11 +429,6 @@
                 "EntryId": "2240",
                 "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/oncology/HER2ReceptorStatus"}
             }
-
-
-
-
-
         ],
         "shr.core.CreationTime": {"Value": "29 NOV 2015"},
         "shr.base.LastUpdated": {"Value": "29 NOV 2015"}
@@ -2469,15 +2461,6 @@
         "shr.core.CreationTime": { "Value": "13 JAN 2018"},
         "shr.base.LastUpdated": { "Value": "13 JAN 2018"}
     },
-    
-    
-    
-    
-    
-    
-    
-    
-    
     {
         "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "shr.base.EntryId": "2000",

--- a/src/dataaccess/HardCodedPatientMidYearDemo18.json
+++ b/src/dataaccess/HardCodedPatientMidYearDemo18.json
@@ -309,502 +309,134 @@
             }
         },
         "shr.finding.Evidence": [
+
+
+
             {
-                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
-                "shr.finding.ClinicallyRelevantTime": { "Value": "01 DEC 2016" },
-                "Value": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
-                    "Value": 15, 
-                    "shr.core.Units": {
-                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
-                        "Value": {
-                            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
-                            "Value": "%"
-                        }
-                    }
-                },
-                "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0019046", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
-                    "shr.core.DisplayText": {"Value": "Hemoglobin"}}]},
-                "shr.finding.FindingStatus": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
-                }
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                "EntryId": "2000",
+                "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" }
             },
             {
-                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
-                "shr.finding.ClinicallyRelevantTime": { "Value": "19 DEC 2016" },
-                "Value": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
-                    "Value": 10.30, 
-                    "shr.core.Units": {
-                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
-                        "Value": {
-                            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
-                            "Value": "%"
-                        }
-                    }
-                },
-                "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0019046", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
-                    "shr.core.DisplayText": {"Value": "Hemoglobin"}}]},
-                "shr.finding.FindingStatus": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
-                }
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                "EntryId": "2010",
+                "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" }
             },
             {
-                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
-                "shr.finding.ClinicallyRelevantTime": { "Value": "10 JAN 2017" },
-                "Value": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
-                    "Value": 14.50, 
-                    "shr.core.Units": {
-                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
-                        "Value": {
-                            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
-                            "Value": "%"
-                        }
-                    }
-                },
-                "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0019046", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
-                    "shr.core.DisplayText": {"Value": "Hemoglobin"}}]},
-                "shr.finding.FindingStatus": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
-                }
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                "EntryId": "2020",
+                "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" }
             },
             {
-                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
-                "shr.finding.ClinicallyRelevantTime": { "Value": "25 NOV 2016" },
-                "Value": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
-                    "Value": 6.74, 
-                    "shr.core.Units": {
-                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
-                        "Value": {
-                            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
-                            "Value": "10^9/L"
-                        }
-                    }
-                },
-                "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0023508", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
-                    "shr.core.DisplayText": {"Value": "White blood cell"}}]},
-                "shr.finding.FindingStatus": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
-                }
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                "EntryId": "2030",
+                "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" }
             },
             {
-                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
-                "shr.finding.ClinicallyRelevantTime": { "Value": "5 DEC 2016" },
-                "Value": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
-                    "Value": 3.37, 
-                    "shr.core.Units": {
-                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
-                        "Value": {
-                            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
-                            "Value": "10^9/L"
-                        }
-                    }
-                },
-                "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0023508", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
-                    "shr.core.DisplayText": {"Value": "White blood cell"}}]},
-                "shr.finding.FindingStatus": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
-                }
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                "EntryId": "2040",
+                "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" }
             },
             {
-                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
-                "shr.finding.ClinicallyRelevantTime": { "Value": "12 DEC 2016" },
-                "Value": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
-                    "Value": 1.86, 
-                    "shr.core.Units": {
-                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
-                        "Value": {
-                            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
-                            "Value": "10^9/L"
-                        }
-                    }
-                },
-                "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0023508", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
-                    "shr.core.DisplayText": {"Value": "White blood cell"}}]},
-                "shr.finding.FindingStatus": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
-                }
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                "EntryId": "2050",
+                "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" }
             },
             {
-                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
-                "shr.finding.ClinicallyRelevantTime": { "Value": "19 DEC 2016" },
-                "Value": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
-                    "Value": 4.72, 
-                    "shr.core.Units": {
-                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
-                        "Value": {
-                            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
-                            "Value": "10^9/L"
-                        }
-                    }
-                },
-                "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0023508", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
-                    "shr.core.DisplayText": {"Value": "White blood cell"}}]},
-                "shr.finding.FindingStatus": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
-                }
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                "EntryId": "2060",
+                "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" }
             },
             {
-                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
-                "shr.finding.ClinicallyRelevantTime": { "Value": "27 DEC 2016" },
-                "Value": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
-                    "Value": 6.75, 
-                    "shr.core.Units": {
-                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
-                        "Value": {
-                            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
-                            "Value": "10^9/L"
-                        }
-                    }
-                },
-                "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0023508", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
-                    "shr.core.DisplayText":  {"Value": "White blood cell"}}]},
-                "shr.finding.FindingStatus": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": "Final"}]
-                }
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                "EntryId": "2070",
+                "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" }
             },
             {
-                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
-                "shr.finding.ClinicallyRelevantTime": { "Value": "02 JAN 2017" },
-                "Value": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
-                    "Value": 8.12, 
-                    "shr.core.Units": {
-                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
-                        "Value": {
-                            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
-                            "Value": "10^9/L"
-                        }
-                    }
-                },
-                "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0023508", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
-                    "shr.core.DisplayText": {"Value": "White blood cell"}}]},
-                "shr.finding.FindingStatus": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
-                }
-            },
-            {                
-                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
-                "shr.finding.ClinicallyRelevantTime": { "Value": "25 NOV 2016" },
-                "Value": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
-                    "Value": 4.2, 
-                    "shr.core.Units": {
-                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
-                        "Value": {
-                            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
-                            "Value": "10^9/L"
-                        }
-                    }
-                },
-                "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0027950", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
-                    "shr.core.DisplayText": {"Value": "Neutrophil"}}]},
-                "shr.finding.FindingStatus": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
-                }
-            },
-            {                
-                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
-                "shr.finding.ClinicallyRelevantTime": { "Value": "5 DEC 2016" },
-                "Value": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
-                    "Value": 2.3, 
-                    "shr.core.Units": {
-                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
-                        "Value": {
-                            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
-                            "Value": "10^9/L"
-                        }
-                    }
-                },
-                "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0027950", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
-                    "shr.core.DisplayText": {"Value": "Neutrophil"}}]},
-                "shr.finding.FindingStatus": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
-                }
-            },
-            {                
-                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
-                "shr.finding.ClinicallyRelevantTime": { "Value": "12 DEC 2016" },
-                "Value": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
-                    "Value": 1.2, 
-                    "shr.core.Units": {
-                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
-                        "Value": {
-                            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
-                            "Value": "10^9/L"
-                        }
-                    }
-                },
-                "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0027950", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
-                    "shr.core.DisplayText": {"Value": "Neutrophil"}}]},
-                "shr.finding.FindingStatus": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
-                }
-            },
-            {                
-                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
-                "shr.finding.ClinicallyRelevantTime": { "Value": "19 DEC 2016" },
-                "Value": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
-                    "Value": 1.9, 
-                    "shr.core.Units": {
-                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
-                        "Value": {
-                            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
-                            "Value": "10^9/L"
-                        }
-                    }
-                },
-                "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0027950", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
-                    "shr.core.DisplayText": {"Value": "Neutrophil"}}]},
-                "shr.finding.FindingStatus": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
-                }
-            },
-            {                
-                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
-                "shr.finding.ClinicallyRelevantTime": { "Value": "27 DEC 2016" },
-                "Value": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
-                    "Value": 2.6, 
-                    "shr.core.Units": {
-                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
-                        "Value": {
-                            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
-                            "Value": "10^9/L"
-                        }
-                    }
-                },
-                "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0027950", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
-                    "shr.core.DisplayText": {"Value": "Neutrophil"}}]},
-                "shr.finding.FindingStatus": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
-                }
-            },
-            {                
-                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
-                "shr.finding.ClinicallyRelevantTime": { "Value": "02 JAN 2017" },
-                "Value": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
-                    "Value": 4.3, 
-                    "shr.core.Units": {
-                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
-                        "Value": {
-                            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
-                            "Value": "10^9/L"
-                        }
-                    }
-                },
-                "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0027950", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
-                    "shr.core.DisplayText": {"Value": "Neutrophil"}}]},
-                "shr.finding.FindingStatus": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
-                }
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                "EntryId": "2080",
+                "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" }
             },
             {
-                "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/oncology/HistologicGrade"},
-                "shr.finding.ClinicallyRelevantTime": { "Value": "29 NOV 2015" },
-                "Value":  {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "369792005", "shr.core.CodeSystem": {"Value": "http://snomed.info/sct"}, 
-                    "shr.core.DisplayText": {"Value": "High grade or poorly differentiated"}}]},
-                "shr.finding.FindingStatus": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, 
-                        "shr.core.DisplayText": {"Value": "Final"}}]
-                }
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                "EntryId": "2100",
+                "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" }
             },
             {
-                "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/oncology/EstrogenReceptorStatus"},
-                "shr.finding.ClinicallyRelevantTime": { "Value": "29 NOV 2015" },
-                "Value":  {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{
-                        "Value": "C0205160", 
-                        "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
-                        "shr.core.DisplayText": {"Value": "Negative"}}]},
-                "shr.finding.FindingStatus": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, 
-                        "shr.core.DisplayText": {"Value": "Final"}}]
-                }
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                "EntryId": "2110",
+                "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" }
             },
             {
-                "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/oncology/ProgesteroneReceptorStatus"},
-                "shr.finding.ClinicallyRelevantTime": { "Value": "29 NOV 2015" },
-                "Value":  {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{
-                        "Value": "C1446409", 
-                        "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
-                        "shr.core.DisplayText": {"Value": "Positive"}}]},
-                "shr.finding.FindingStatus": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, 
-                        "shr.core.DisplayText": {"Value": "Final"}}]
-                }
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                "EntryId": "2120",
+                "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" }
             },
             {
-                "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/oncology/HER2ReceptorStatus"},
-                "shr.finding.ClinicallyRelevantTime": { "Value": "29 NOV 2015" },
-                "Value":  {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{
-                        "Value": "C0205160", 
-                        "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
-                        "shr.core.DisplayText": {"Value": "Negative"}}]},
-                "shr.finding.FindingStatus": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, 
-                        "shr.core.DisplayText": {"Value": "Final"}}]
-                }
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                "EntryId": "2130",
+                "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" }
             },
             {
-                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/oncology/TumorDimensions" },
-                "shr.finding.ClinicallyRelevantTime": { "Value": "29 NOV 2015" },
-                "Value": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
-                    "Value": 1.6, 
-                    "Units": {
-                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
-                        "Value": {
-                            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
-                            "Value": "cm"
-                        }
-                    }
-                },
-                "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0475440", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
-                    "shr.core.DisplayText": {"Value": "Tumor Size"}}]},
-                "shr.finding.FindingStatus": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
-                }
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                "EntryId": "2140",
+                "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" }
             },
             {
-                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/oncology/TNMStage" },
-                "shr.finding.ClinicallyRelevantTime": { "Value": "29 NOV 2015" },
-                "Value": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{
-                        "Value": "46333007", 
-                        "shr.core.CodeSystem": {"Value": "urn:oid:2.16.840.1.113883.6.96"}, 
-                        "shr.core.DisplayText": {"Value": "IA"}}]
-                },
-                "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
-                    "shr.core.DisplayText": {"Value": "Staging"}}]},
-                "shr.finding.FindingMethod": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/FindingMethod"},
-                    "Value": {
-                        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                        "shr.core.Coding": [{ "Value": "ajcc_v7", "shr.core.CodeSystem": {"Value": ""}, "shr.core.DisplayText": {"Value": "AJCC Breast Carcinoma Version 7"}}]
-                    }
-                },
-                "shr.finding.FindingStatus": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
-                },
-                "shr.finding.ObservationComponent": [
-                    {   "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/oncology/T_Stage" },
-                        "Value": {
-                            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                            "shr.core.Coding": [
-                                {   "Value": "433391000124107", 
-                                    "shr.core.CodeSystem": {"Value": "urn:oid:2.16.840.1.113883.6.96"}, 
-                                    "shr.core.DisplayText": {"Value": "T1c"}
-                                }
-                            ]
-                        }
-                    },
-                    {   "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/oncology/N_Stage" },
-                        "Value": {
-                            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                            "shr.core.Coding": [
-                                {   "Value": "436311000124105", 
-                                    "shr.core.CodeSystem": {"Value": "urn:oid:2.16.840.1.113883.6.96"}, 
-                                    "shr.core.DisplayText": {"Value": "N0"}
-                                }
-                            ]
-                        }
-                    },
-                    {   "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/oncology/M_Stage" },
-                        "Value": {
-                            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                            "shr.core.Coding": [
-                                {   "Value": "433581000124101", 
-                                    "shr.core.CodeSystem": {"Value": "urn:oid:2.16.840.1.113883.6.96"}, 
-                                    "shr.core.DisplayText": {"Value": "M0"}
-                                }
-                            ]
-                        }
-                    }
-                ]
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                "EntryId": "2150",
+                "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" }
             },
             {
-                "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/oncology/EstrogenReceptorStatus"},
-                "shr.finding.ClinicallyRelevantTime": { "Value": "20 SEP 2017" },
-                "Value":  {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{
-                        "Value": "C0205160", 
-                        "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
-                        "shr.core.DisplayText": {"Value": "Negative"}}]},
-                "shr.finding.FindingStatus": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, 
-                        "shr.core.DisplayText": {"Value": "Final"}}]
-                }
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                "EntryId": "2160",
+                "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/oncology/HistologicGrade"}
             },
             {
-                "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/oncology/ProgesteroneReceptorStatus"},
-                "shr.finding.ClinicallyRelevantTime": { "Value": "20 SEP 2017" },
-                "Value":  {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{
-                        "Value": "C1446409", 
-                        "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
-                        "shr.core.DisplayText": {"Value": "Positive"}}]},
-                "shr.finding.FindingStatus": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, 
-                        "shr.core.DisplayText": {"Value": "Final"}}]
-                }
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                "EntryId": "2170",
+                "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/oncology/EstrogenReceptorStatus"}
             },
             {
-                "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/oncology/HER2ReceptorStatus"},
-                "shr.finding.ClinicallyRelevantTime": { "Value": "20 SEP 2017" },
-                "Value":  {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{
-                        "Value": "C1446409", 
-                        "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
-                        "shr.core.DisplayText": {"Value": "Positive"}}]},
-                "shr.finding.FindingStatus": {
-                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
-                    "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, 
-                        "shr.core.DisplayText": {"Value": "Final"}}]
-                }
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                "EntryId": "2180",
+                "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/oncology/ProgesteroneReceptorStatus"}
+            },
+            {
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                "EntryId": "2190",
+                "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/oncology/HER2ReceptorStatus"}
+            },
+            {
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                "EntryId": "2200",
+                "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/oncology/TumorDimensions" }
+            },
+            {
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                "EntryId": "2210",
+                "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/oncology/TNMStage" }
+            },
+            {
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                "EntryId": "2220",
+                "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/oncology/EstrogenReceptorStatus"}
+            },
+            {
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                "EntryId": "2230",
+                "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/oncology/ProgesteroneReceptorStatus"}
+            },
+            {
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                "EntryId": "2240",
+                "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/oncology/HER2ReceptorStatus"}
             }
+
+
+
+
+
         ],
         "shr.core.CreationTime": {"Value": "29 NOV 2015"},
         "shr.base.LastUpdated": {"Value": "29 NOV 2015"}
@@ -2835,6 +2467,631 @@
                }
            }]},
         "shr.core.CreationTime": { "Value": "13 JAN 2018"},
-        "shr.base.LastUpdated": { "Value": "13 JAN 2018"}        
+        "shr.base.LastUpdated": { "Value": "13 JAN 2018"}
+    },
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "shr.base.EntryId": "2000",
+        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"}, "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1"},
+        "shr.finding.ClinicallyRelevantTime": { "Value": "01 DEC 2016" },
+        "Value": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
+            "Value": 15, 
+            "shr.core.Units": {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
+                "Value": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+                    "Value": "%"
+                }
+            }
+        },
+        "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0019046", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
+            "shr.core.DisplayText": {"Value": "Hemoglobin"}}]},
+        "shr.finding.FindingStatus": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
+        },
+        "shr.core.CreationTime": { "Value": "01 DEC 2016"},
+        "shr.base.LastUpdated": { "Value": "01 DEC 2016"}
+    },
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "shr.base.EntryId": "2010",
+        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"}, "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1"},
+        "shr.finding.ClinicallyRelevantTime": { "Value": "19 DEC 2016" },
+        "Value": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
+            "Value": 10.30, 
+            "shr.core.Units": {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
+                "Value": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+                    "Value": "%"
+                }
+            }
+        },
+        "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0019046", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
+            "shr.core.DisplayText": {"Value": "Hemoglobin"}}]},
+        "shr.finding.FindingStatus": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
+        },
+        "shr.core.CreationTime": { "Value": "19 DEC 2016"},
+        "shr.base.LastUpdated": { "Value": "19 DEC 2016"}
+    },
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "shr.base.EntryId": "2020",
+        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"}, "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1"},
+        "shr.finding.ClinicallyRelevantTime": { "Value": "10 JAN 2017" },
+        "Value": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
+            "Value": 14.50, 
+            "shr.core.Units": {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
+                "Value": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+                    "Value": "%"
+                }
+            }
+        },
+        "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0019046", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
+            "shr.core.DisplayText": {"Value": "Hemoglobin"}}]},
+        "shr.finding.FindingStatus": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
+        },
+        "shr.core.CreationTime": { "Value": "10 JAN 2017"},
+        "shr.base.LastUpdated": { "Value": "10 JAN 2017"}
+    },
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "shr.base.EntryId": "2030",
+        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"}, "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1"},
+        "shr.finding.ClinicallyRelevantTime": { "Value": "25 NOV 2016" },
+        "Value": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
+            "Value": 6.74, 
+            "shr.core.Units": {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
+                "Value": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+                    "Value": "10^9/L"
+                }
+            }
+        },
+        "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0023508", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
+            "shr.core.DisplayText": {"Value": "White blood cell"}}]},
+        "shr.finding.FindingStatus": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
+        },
+        "shr.core.CreationTime": { "Value": "25 NOV 2016"},
+        "shr.base.LastUpdated": { "Value": "25 NOV 2016"}
+    },
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "shr.base.EntryId": "2040",
+        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"}, "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1"},
+        "shr.finding.ClinicallyRelevantTime": { "Value": "5 DEC 2016" },
+        "Value": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
+            "Value": 3.37, 
+            "shr.core.Units": {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
+                "Value": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+                    "Value": "10^9/L"
+                }
+            }
+        },
+        "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0023508", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
+            "shr.core.DisplayText": {"Value": "White blood cell"}}]},
+        "shr.finding.FindingStatus": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
+        },
+        "shr.core.CreationTime": { "Value": "5 DEC 2016"},
+        "shr.base.LastUpdated": { "Value": "5 DEC 2016"}
+    },
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "shr.base.EntryId": "2050",
+        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"}, "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1"},
+        "shr.finding.ClinicallyRelevantTime": { "Value": "12 DEC 2016" },
+        "Value": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
+            "Value": 1.86, 
+            "shr.core.Units": {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
+                "Value": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+                    "Value": "10^9/L"
+                }
+            }
+        },
+        "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0023508", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
+            "shr.core.DisplayText": {"Value": "White blood cell"}}]},
+        "shr.finding.FindingStatus": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
+        },
+        "shr.core.CreationTime": { "Value": "12 DEC 2016"},
+        "shr.base.LastUpdated": { "Value": "12 DEC 2016"}
+    },
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "shr.base.EntryId": "2060",
+        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"}, "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1"},
+        "shr.finding.ClinicallyRelevantTime": { "Value": "19 DEC 2016" },
+        "Value": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
+            "Value": 4.72, 
+            "shr.core.Units": {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
+                "Value": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+                    "Value": "10^9/L"
+                }
+            }
+        },
+        "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0023508", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
+            "shr.core.DisplayText": {"Value": "White blood cell"}}]},
+        "shr.finding.FindingStatus": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
+        },
+        "shr.core.CreationTime": { "Value": "19 DEC 2016"},
+        "shr.base.LastUpdated": { "Value": "19 DEC 2016"}
+    },
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "shr.base.EntryId": "2070",
+        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"}, "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1"},
+        "shr.finding.ClinicallyRelevantTime": { "Value": "27 DEC 2016" },
+        "Value": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
+            "Value": 6.75, 
+            "shr.core.Units": {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
+                "Value": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+                    "Value": "10^9/L"
+                }
+            }
+        },
+        "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0023508", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
+            "shr.core.DisplayText":  {"Value": "White blood cell"}}]},
+        "shr.finding.FindingStatus": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": "Final"}]
+        },
+        "shr.core.CreationTime": { "Value": "27 DEC 2016"},
+        "shr.base.LastUpdated": { "Value": "27 DEC 2016"}
+    },
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "shr.base.EntryId": "2080",
+        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"}, "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1"},
+        "shr.finding.ClinicallyRelevantTime": { "Value": "02 JAN 2017" },
+        "Value": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
+            "Value": 8.12, 
+            "shr.core.Units": {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
+                "Value": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+                    "Value": "10^9/L"
+                }
+            }
+        },
+        "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0023508", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
+            "shr.core.DisplayText": {"Value": "White blood cell"}}]},
+        "shr.finding.FindingStatus": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
+        },
+        "shr.core.CreationTime": { "Value": "02 JAN 2017"},
+        "shr.base.LastUpdated": { "Value": "02 JAN 2017"}
+    },
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "shr.base.EntryId": "2100",
+        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"}, "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1"},
+        "shr.finding.ClinicallyRelevantTime": { "Value": "25 NOV 2016" },
+        "Value": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
+            "Value": 4.2, 
+            "shr.core.Units": {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
+                "Value": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+                    "Value": "10^9/L"
+                }
+            }
+        },
+        "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0027950", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
+            "shr.core.DisplayText": {"Value": "Neutrophil"}}]},
+        "shr.finding.FindingStatus": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
+        },
+        "shr.core.CreationTime": { "Value": "25 NOV 2016"},
+        "shr.base.LastUpdated": { "Value": "25 NOV 2016"}
+    },
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "shr.base.EntryId": "2110",
+        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"}, "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1"},
+        "shr.finding.ClinicallyRelevantTime": { "Value": "5 DEC 2016" },
+        "Value": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
+            "Value": 2.3, 
+            "shr.core.Units": {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
+                "Value": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+                    "Value": "10^9/L"
+                }
+            }
+        },
+        "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0027950", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
+            "shr.core.DisplayText": {"Value": "Neutrophil"}}]},
+        "shr.finding.FindingStatus": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
+        },
+        "shr.core.CreationTime": { "Value": "5 DEC 2016"},
+        "shr.base.LastUpdated": { "Value": "5 DEC 2016"}
+    },
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "shr.base.EntryId": "2120",
+        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"}, "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1"},
+        "shr.finding.ClinicallyRelevantTime": { "Value": "12 DEC 2016" },
+        "Value": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
+            "Value": 1.2, 
+            "shr.core.Units": {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
+                "Value": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+                    "Value": "10^9/L"
+                }
+            }
+        },
+        "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0027950", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
+            "shr.core.DisplayText": {"Value": "Neutrophil"}}]},
+        "shr.finding.FindingStatus": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
+        },
+        "shr.core.CreationTime": { "Value": "12 DEC 2016"},
+        "shr.base.LastUpdated": { "Value": "12 DEC 2016"}
+    },
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "shr.base.EntryId": "2130",
+        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"}, "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1"},
+        "shr.finding.ClinicallyRelevantTime": { "Value": "19 DEC 2016" },
+        "Value": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
+            "Value": 1.9, 
+            "shr.core.Units": {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
+                "Value": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+                    "Value": "10^9/L"
+                }
+            }
+        },
+        "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0027950", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
+            "shr.core.DisplayText": {"Value": "Neutrophil"}}]},
+        "shr.finding.FindingStatus": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
+        },
+        "shr.core.CreationTime": { "Value": "19 DEC 2016"},
+        "shr.base.LastUpdated": { "Value": "19 DEC 2016"}
+    },
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "shr.base.EntryId": "2140",
+        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"}, "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1"},
+        "shr.finding.ClinicallyRelevantTime": { "Value": "27 DEC 2016" },
+        "Value": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
+            "Value": 2.6, 
+            "shr.core.Units": {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
+                "Value": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+                    "Value": "10^9/L"
+                }
+            }
+        },
+        "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0027950", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
+            "shr.core.DisplayText": {"Value": "Neutrophil"}}]},
+        "shr.finding.FindingStatus": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
+        },
+        "shr.core.CreationTime": { "Value": "27 DEC 2016"},
+        "shr.base.LastUpdated": { "Value": "27 DEC 2016"}
+    },
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "shr.base.EntryId": "2150",
+        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation" },
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"}, "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1"},
+        "shr.finding.ClinicallyRelevantTime": { "Value": "02 JAN 2017" },
+        "Value": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
+            "Value": 4.3, 
+            "shr.core.Units": {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
+                "Value": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+                    "Value": "10^9/L"
+                }
+            }
+        },
+        "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0027950", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
+            "shr.core.DisplayText": {"Value": "Neutrophil"}}]},
+        "shr.finding.FindingStatus": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
+        },
+        "shr.core.CreationTime": { "Value": "02 JAN 2017"},
+        "shr.base.LastUpdated": { "Value": "02 JAN 2017"}
+    },
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "shr.base.EntryId": "2160",
+        "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/oncology/HistologicGrade"},
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"}, "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1"},
+        "shr.finding.ClinicallyRelevantTime": { "Value": "29 NOV 2015" },
+        "Value":  {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "369792005", "shr.core.CodeSystem": {"Value": "http://snomed.info/sct"}, 
+            "shr.core.DisplayText": {"Value": "High grade or poorly differentiated"}}]},
+        "shr.finding.FindingStatus": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, 
+                "shr.core.DisplayText": {"Value": "Final"}}]
+        },
+        "shr.core.CreationTime": { "Value": "29 NOV 2015"},
+        "shr.base.LastUpdated": { "Value": "29 NOV 2015"}
+    },
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "shr.base.EntryId": "2170",
+        "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/oncology/EstrogenReceptorStatus"},
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"}, "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1"},
+        "shr.finding.ClinicallyRelevantTime": { "Value": "29 NOV 2015" },
+        "Value":  {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{
+                "Value": "C0205160", 
+                "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
+                "shr.core.DisplayText": {"Value": "Negative"}}]},
+        "shr.finding.FindingStatus": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, 
+                "shr.core.DisplayText": {"Value": "Final"}}]
+        },
+        "shr.core.CreationTime": { "Value": "29 NOV 2015"},
+        "shr.base.LastUpdated": { "Value": "29 NOV 2015"}
+    },
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "shr.base.EntryId": "2180",
+        "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/oncology/ProgesteroneReceptorStatus"},
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"}, "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1"},
+        "shr.finding.ClinicallyRelevantTime": { "Value": "29 NOV 2015" },
+        "Value":  {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{
+                "Value": "C1446409", 
+                "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
+                "shr.core.DisplayText": {"Value": "Positive"}}]},
+        "shr.finding.FindingStatus": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, 
+                "shr.core.DisplayText": {"Value": "Final"}}]
+        },
+        "shr.core.CreationTime": { "Value": "29 NOV 2015"},
+        "shr.base.LastUpdated": { "Value": "29 NOV 2015"}
+    },
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "shr.base.EntryId": "2190",
+        "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/oncology/HER2ReceptorStatus"},
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"}, "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1"},
+        "shr.finding.ClinicallyRelevantTime": { "Value": "29 NOV 2015" },
+        "Value":  {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{
+                "Value": "C0205160", 
+                "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
+                "shr.core.DisplayText": {"Value": "Negative"}}]},
+        "shr.finding.FindingStatus": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, 
+                "shr.core.DisplayText": {"Value": "Final"}}]
+        },
+        "shr.core.CreationTime": { "Value": "29 NOV 2015"},
+        "shr.base.LastUpdated": { "Value": "29 NOV 2015"}
+    },
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "shr.base.EntryId": "2200",
+        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/oncology/TumorDimensions" },
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"}, "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1"},
+        "shr.finding.ClinicallyRelevantTime": { "Value": "29 NOV 2015" },
+        "Value": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity" },
+            "Value": 1.6, 
+            "Units": {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Units" },
+                "Value": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+                    "Value": "cm"
+                }
+            }
+        },
+        "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "C0475440", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
+            "shr.core.DisplayText": {"Value": "Tumor Size"}}]},
+        "shr.finding.FindingStatus": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
+        },
+        "shr.core.CreationTime": { "Value": "29 NOV 2015"},
+        "shr.base.LastUpdated": { "Value": "29 NOV 2015"}
+    },
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "shr.base.EntryId": "2210",
+        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/oncology/TNMStage" },
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"}, "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1"},
+        "shr.finding.ClinicallyRelevantTime": { "Value": "29 NOV 2015" },
+        "Value": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{
+                "Value": "46333007", 
+                "shr.core.CodeSystem": {"Value": "urn:oid:2.16.840.1.113883.6.96"}, 
+                "shr.core.DisplayText": {"Value": "IA"}}]
+        },
+        "shr.finding.ObservationCode": {"shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},"shr.core.Coding":[{ "Value": "", "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
+            "shr.core.DisplayText": {"Value": "Staging"}}]},
+        "shr.finding.FindingMethod": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/finding/FindingMethod"},
+            "Value": {
+                "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+                "shr.core.Coding": [{ "Value": "ajcc_v7", "shr.core.CodeSystem": {"Value": ""}, "shr.core.DisplayText": {"Value": "AJCC Breast Carcinoma Version 7"}}]
+            }
+        },
+        "shr.finding.FindingStatus": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, "shr.core.DisplayText": {"Value": "Final"}}]
+        },
+        "shr.finding.ObservationComponent": [
+            {   "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/oncology/T_Stage" },
+                "Value": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+                    "shr.core.Coding": [
+                        {   "Value": "433391000124107", 
+                            "shr.core.CodeSystem": {"Value": "urn:oid:2.16.840.1.113883.6.96"}, 
+                            "shr.core.DisplayText": {"Value": "T1c"}
+                        }
+                    ]
+                }
+            },
+            {   "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/oncology/N_Stage" },
+                "Value": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+                    "shr.core.Coding": [
+                        {   "Value": "436311000124105", 
+                            "shr.core.CodeSystem": {"Value": "urn:oid:2.16.840.1.113883.6.96"}, 
+                            "shr.core.DisplayText": {"Value": "N0"}
+                        }
+                    ]
+                }
+            },
+            {   "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/oncology/M_Stage" },
+                "Value": {
+                    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+                    "shr.core.Coding": [
+                        {   "Value": "433581000124101", 
+                            "shr.core.CodeSystem": {"Value": "urn:oid:2.16.840.1.113883.6.96"}, 
+                            "shr.core.DisplayText": {"Value": "M0"}
+                        }
+                    ]
+                }
+            }
+        ],
+        "shr.core.CreationTime": { "Value": "29 NOV 2015"},
+        "shr.base.LastUpdated": { "Value": "29 NOV 2015"}
+    },
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "shr.base.EntryId": "2220",
+        "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/oncology/EstrogenReceptorStatus"},
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"}, "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1"},
+        "shr.finding.ClinicallyRelevantTime": { "Value": "20 SEP 2017" },
+        "Value":  {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{
+                "Value": "C0205160", 
+                "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
+                "shr.core.DisplayText": {"Value": "Negative"}}]},
+        "shr.finding.FindingStatus": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, 
+                "shr.core.DisplayText": {"Value": "Final"}}]
+        },
+        "shr.core.CreationTime": { "Value": "20 SEP 2017"},
+        "shr.base.LastUpdated": { "Value": "20 SEP 2017"}
+    },
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "shr.base.EntryId": "2230",
+        "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/oncology/ProgesteroneReceptorStatus"},
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"}, "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1"},
+        "shr.finding.ClinicallyRelevantTime": { "Value": "20 SEP 2017" },
+        "Value":  {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{
+                "Value": "C1446409", 
+                "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
+                "shr.core.DisplayText": {"Value": "Positive"}}]},
+        "shr.finding.FindingStatus": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, 
+                "shr.core.DisplayText": {"Value": "Final"}}]
+        },
+        "shr.core.CreationTime": { "Value": "20 SEP 2017"},
+        "shr.base.LastUpdated": { "Value": "20 SEP 2017"}
+    },
+    {
+        "shr.base.ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "shr.base.EntryId": "2240",
+        "shr.base.EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/oncology/HER2ReceptorStatus"},
+        "shr.base.PersonOfRecord": { "EntryType": {"Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"}, "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e", "EntryId": "1"},
+        "shr.finding.ClinicallyRelevantTime": { "Value": "20 SEP 2017" },
+        "Value":  {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{
+                "Value": "C1446409", 
+                "shr.core.CodeSystem": {"Value": "http://ncimeta.nci.nih.gov"}, 
+                "shr.core.DisplayText": {"Value": "Positive"}}]},
+        "shr.finding.FindingStatus": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"},
+            "shr.core.Coding":[{ "Value": "final", "shr.core.CodeSystem": {"Value": "http://hl7.org/fhir/observation-status"}, 
+                "shr.core.DisplayText": {"Value": "Final"}}]
+        },
+        "shr.core.CreationTime": { "Value": "20 SEP 2017"},
+        "shr.base.LastUpdated": { "Value": "20 SEP 2017"}
     }
 ]

--- a/src/model/FluxObjectFactory.js
+++ b/src/model/FluxObjectFactory.js
@@ -18,7 +18,7 @@ import FluxOncologyObjectFactory from './oncology/FluxOncologyObjectFactory';
  *  Default case will return SHR model classes if no Flux wrapper class is found
  */
 export default class FluxObjectFactory {
-    static createInstance(json, type) {
+    static createInstance(json, type, patientRecord) {
         const { namespace } = getNamespaceAndName(json, type);
         switch (namespace) {
             case 'shr.adverse': return FluxAdverseObjectFactory.createInstance(json, type);
@@ -29,7 +29,7 @@ export default class FluxObjectFactory {
             case 'shr.entity': return FluxEntityObjectFactory.createInstance(json, type);
             case 'shr.finding': return FluxFindingObjectFactory.createInstance(json, type);
             case 'shr.medication': return FluxMedicationObjectFactory.createInstance(json, type);
-            case 'shr.oncology': return FluxOncologyObjectFactory.createInstance(json, type);
+            case 'shr.oncology': return FluxOncologyObjectFactory.createInstance(json, type, patientRecord);
             case 'shr.procedure': return FluxProcedureObjectFactory.createInstance(json, type);
             case 'shr.research': return FluxResearchObjectFactory.createInstance(json, type);
             case 'shr.allergy': return FluxAllergyObjectFactory.createInstance(json, type);

--- a/src/model/condition/FluxCondition.js
+++ b/src/model/condition/FluxCondition.js
@@ -4,7 +4,6 @@ import FluxObservation from '../finding/FluxObservation';
 import FluxProcedureRequested from '../procedure/FluxProcedureRequested';
 import FluxMedicationRequested from '../medication/FluxMedicationRequested';
 import FluxDiseaseProgression from './FluxDiseaseProgression';
-import PatientRecord from '../../patient/PatientRecord';
 import Lang from 'lodash';
 import moment from 'moment';
 
@@ -67,8 +66,7 @@ class FluxCondition {
 
     addObservation(observation) {
         this._patientRecord.addEntryToPatientWithPatientFocalSubject(observation);
-        let ref = PatientRecord.createEntryReferenceTo(observation);
-        //console.log(ref);
+        let ref = this._patientRecord.createEntryReferenceTo(observation);
         let currentObservations = this._condition.evidence || [];
         currentObservations.push(ref);
         this._condition.evidence  = currentObservations;
@@ -82,7 +80,6 @@ class FluxCondition {
     
     getObservationsOfType(type) {
         if (!this._condition.evidence) return [];
-        //console.log(this._condition.evidence);
         return this._condition.evidence.map((item) => {
             return this._patientRecord.getEntryFromReference(item);
         }).filter((item) => {

--- a/src/model/condition/FluxCondition.js
+++ b/src/model/condition/FluxCondition.js
@@ -4,17 +4,13 @@ import FluxObservation from '../finding/FluxObservation';
 import FluxProcedureRequested from '../procedure/FluxProcedureRequested';
 import FluxMedicationRequested from '../medication/FluxMedicationRequested';
 import FluxDiseaseProgression from './FluxDiseaseProgression';
-import FluxTNMStage from '../oncology/FluxTNMStage';
-import FluxEstrogenReceptorStatus from '../oncology/FluxEstrogenReceptorStatus';
-import FluxProgesteroneReceptorStatus from '../oncology/FluxProgesteroneReceptorStatus';
-import FluxHER2ReceptorStatus from '../oncology/FluxHER2ReceptorStatus';
-import FluxTumorDimensions from '../oncology/FluxTumorDimensions';
-import FluxHistologicGrade from '../oncology/FluxHistologicGrade';
+import PatientRecord from '../../patient/PatientRecord';
 import Lang from 'lodash';
 import moment from 'moment';
 
 class FluxCondition {
-    constructor(json) {
+    constructor(json, patientRecord) {
+        this._patientRecord = patientRecord;
         this._condition = Condition.fromJSON(json);
     }
 
@@ -45,7 +41,9 @@ class FluxCondition {
     }
 
     get observation() {
-        return this._condition.evidence || [];
+        return this._condition.evidence.map((item) => {
+            return this._patientRecord.getEntryFromReference(item);
+        }) || [];
     }
 
     get bodySite() {
@@ -68,14 +66,26 @@ class FluxCondition {
     }
 
     addObservation(observation) {
+        this._patientRecord.addEntryToPatientWithPatientFocalSubject(observation);
+        let ref = PatientRecord.createEntryReferenceTo(observation);
+        //console.log(ref);
         let currentObservations = this._condition.evidence || [];
-        currentObservations.push(observation);
+        currentObservations.push(ref);
         this._condition.evidence  = currentObservations;
     }
 
+    getObservationsOfTypeChronologicalOrder(type) {
+        let results = this.getObservationsOfType(type);
+        results.sort(this._observationsTimeSorter);
+        return results;
+    }
+    
     getObservationsOfType(type) {
         if (!this._condition.evidence) return [];
-        return this._condition.evidence.filter((item) => {
+        //console.log(this._condition.evidence);
+        return this._condition.evidence.map((item) => {
+            return this._patientRecord.getEntryFromReference(item);
+        }).filter((item) => {
             return item.constructor === type;
         });
     }
@@ -149,89 +159,8 @@ class FluxCondition {
 
         return mostRecentLabResultsArray;
     }
-
-    getMostRecentStaging(sinceDate = null) {
-        let stagingList = this.getObservationsOfType(FluxTNMStage);
-        if (stagingList.length === 0) return null; 
-        const sortedStagingList = stagingList.sort(this._stageTimeSorter);
-        const length = sortedStagingList.length;
-        let s = (sortedStagingList[length - 1]);
-        if (Lang.isNull(sinceDate)) return s; 
-        const startTime = new moment(s.occurrenceTime, "D MMM YYYY");
-        if (startTime < sinceDate) {
-            return null;
-        } else {
-            return s;
-        }
-    } 
-
-    _getMostRecentReceptorStatus(receptorType) {
-        const list = this.getObservationsOfType(receptorType);
-        const sortedList = list.sort(this._observationsTimeSorter);
-        if (list.length === 0) return null; else return sortedList.pop();
-    }
-
-    getMostRecentERReceptorStatus() {
-        return this._getMostRecentReceptorStatus(FluxEstrogenReceptorStatus);
-    }
-
-    getMostRecentPRReceptorStatus() {
-        return this._getMostRecentReceptorStatus(FluxProgesteroneReceptorStatus);
-    }
-
-    getMostRecentHER2ReceptorStatus() {
-        return this._getMostRecentReceptorStatus(FluxHER2ReceptorStatus);
-    }
-
-    /**
-     *  function to build HPI Narrative
-     *  Starts with initial summary of patient information
-     *  Then details chronological history of patient's procedures, medications, and most recent progression
-     */
-    buildHpiNarrative(patient) {
-        // Initial patient introduction section
-        const name = patient.getName();
-        const age = patient.getAge();
-        const gender = patient.getGender();
-
-        let hpiText = `${name} is a ${age} year old ${gender}.`;
-        hpiText += ` Patient was diagnosed with ${this.type} on ${this.diagnosisDate}.`;
-        
-        // Laterality
-        if (this.laterality) {
-            hpiText += ` Breast cancer diagnosed in ${this.laterality} breast.`;
-        }
-
-        // Staging
-        const staging = this.getMostRecentStaging();
-        if (staging && staging.stage) {
-            hpiText += ` Stage ${staging.stage} ${staging.t_Stage} ${staging.n_Stage} ${staging.m_Stage} disease.`;
-        }
-
-        // Tumor Size and HistologicGrade
-        const tumorSize = this.getObservationsOfType(FluxTumorDimensions);
-        const histologicGrade = this.getObservationsOfType(FluxHistologicGrade);
-        if (tumorSize.length > 0) {
-            hpiText += ` Primary tumor size was ${tumorSize[0].quantity.value} ${tumorSize[0].quantity.unit}.`;
-        }
-        if (histologicGrade.length > 0) {
-            hpiText += ` Histological grade was ${histologicGrade[0].grade}.`;
-        }
-
-        // ER, PR, HER2
-        const erStatus = this.getMostRecentERReceptorStatus();
-        const prStatus = this.getMostRecentPRReceptorStatus();
-        const her2Status = this.getMostRecentHER2ReceptorStatus();
-        if (erStatus) {
-            hpiText += ` Estrogen receptor was ${erStatus.status}.`;
-        }
-        if (prStatus) {
-            hpiText += ` Progesteron receptor was ${prStatus.status}.`;
-        }
-        if (her2Status) {
-            hpiText += ` HER2 was ${her2Status.status}.`;
-        }
-
+    
+    buildEventNarrative(hpiText, patient) {
         // Build narrative from sorted events
         // Get procedures, medications, recent lab results, and most recent progression from patient
         // Sort by start time and add snippets about each event to result text
@@ -314,7 +243,6 @@ class FluxCondition {
                 }
             }
         });
-        
         return hpiText;
     }
 

--- a/src/model/condition/FluxConditionObjectFactory.js
+++ b/src/model/condition/FluxConditionObjectFactory.js
@@ -5,14 +5,14 @@ import ShrConditionObjectFactory from '../shr/condition/ShrConditionObjectFactor
 import FluxDiseaseProgression from './FluxDiseaseProgression';
 
 export default class FluxConditionObjectFactory {
-    static createInstance(json, type) {
+    static createInstance(json, type, patientRecord) {
         const { namespace, elementName } = getNamespaceAndName(json, type);
         if (namespace !== 'shr.condition') {
             throw new Error(`Unsupported type in ShrConditionObjectFactory: ${type}`);
         }
         // returns Flux wrapper class if found, otherwise use ShrConditionObjectFactory
         switch (elementName) {
-            case 'Condition': return new FluxCondition(json);
+            case 'Condition': return new FluxCondition(json, patientRecord);
             case 'DiseaseProgression': return new FluxDiseaseProgression(json);
             case 'Injury': return new FluxInjury(json);
             default: return ShrConditionObjectFactory.createInstance(json, type);

--- a/src/model/condition/FluxInjury.js
+++ b/src/model/condition/FluxInjury.js
@@ -6,6 +6,24 @@ class FluxInjury extends FluxCondition {
         super(json);
         this._condition = Injury.fromJSON(json);
     }
+    /**
+     *  function to build HPI Narrative
+     *  Starts with initial summary of patient information
+     *  Then details chronological history of patient's procedures, medications, and most recent progression
+     */
+    buildHpiNarrative(patient) {
+        // Initial patient introduction section
+        const name = patient.getName();
+        const age = patient.getAge();
+        const gender = patient.getGender();
+
+        let hpiText = `${name} is a ${age} year old ${gender}.`;
+        hpiText += ` Patient was diagnosed with ${this.type} on ${this.diagnosisDate}.`;
+        
+        hpiText = this.buildEventNarrative(hpiText, patient);
+        
+        return hpiText;
+    }
 }
 
 export default FluxInjury;

--- a/src/model/finding/FluxObservation.js
+++ b/src/model/finding/FluxObservation.js
@@ -6,6 +6,10 @@ class FluxObservation {
         this._observation = Observation.fromJSON(json);
     }
     
+    get entryInfo() {
+        return this._observation.entryInfo;
+    }
+
     /**
      *  Getter for quantity
      *  If _value is an instance of Quantity, will return object with properties number and unit

--- a/src/model/oncology/FluxBreastCancer.js
+++ b/src/model/oncology/FluxBreastCancer.js
@@ -1,10 +1,116 @@
 import BreastCancer from '../shr/oncology/BreastCancer';
 import FluxCondition from '../condition/FluxCondition';
+import FluxEstrogenReceptorStatus from './FluxEstrogenReceptorStatus';
+import FluxHER2ReceptorStatus from './FluxHER2ReceptorStatus';
+import FluxHistologicGrade from './FluxHistologicGrade';
+import FluxProgesteroneReceptorStatus from './FluxProgesteroneReceptorStatus';
+import FluxTNMStage from '../oncology/FluxTNMStage';
+import FluxTumorDimensions from '../oncology/FluxTumorDimensions';
+import Lang from 'lodash';
+import moment from 'moment';
 
 class FluxBreastCancer extends FluxCondition {
-    constructor(json) {
-        super(json);
+    constructor(json, patientRecord) {
+        super();
+        this._patientRecord = patientRecord;
         this._condition = BreastCancer.fromJSON(json);
+    }
+    
+    getHistologicalGrades() {
+        return this.getObservationsOfType(FluxHistologicGrade);
+    }
+    
+    getMostRecentHistologicalGrade() {
+        let results = this.getObservationsOfTypeChronologicalOrder(FluxHistologicGrade);
+        if (!results || results.length === 0) return null;
+        return results.pop();
+    }
+
+    _getMostRecentReceptorStatus(receptorType) {
+        const list = this.getObservationsOfType(receptorType);
+        const sortedList = list.sort(this._observationsTimeSorter);
+        if (list.length === 0) return null; else return sortedList.pop();
+    }
+
+    getMostRecentERReceptorStatus() {
+        return this._getMostRecentReceptorStatus(FluxEstrogenReceptorStatus);
+    }
+
+    getMostRecentPRReceptorStatus() {
+        return this._getMostRecentReceptorStatus(FluxProgesteroneReceptorStatus);
+    }
+
+    getMostRecentHER2ReceptorStatus() {
+        return this._getMostRecentReceptorStatus(FluxHER2ReceptorStatus);
+    }
+
+    getMostRecentStaging(sinceDate = null) {
+        let stagingList = this.getObservationsOfType(FluxTNMStage);
+        if (stagingList.length === 0) return null; 
+        const sortedStagingList = stagingList.sort(this._stageTimeSorter);
+        const length = sortedStagingList.length;
+        let s = (sortedStagingList[length - 1]);
+        if (Lang.isNull(sinceDate)) return s; 
+        const startTime = new moment(s.occurrenceTime, "D MMM YYYY");
+        if (startTime < sinceDate) {
+            return null;
+        } else {
+            return s;
+        }
+    } 
+
+    /**
+     *  function to build HPI Narrative
+     *  Starts with initial summary of patient information
+     *  Then details chronological history of patient's procedures, medications, and most recent progression
+     */
+    buildHpiNarrative(patient) {
+        // Initial patient introduction section
+        const name = patient.getName();
+        const age = patient.getAge();
+        const gender = patient.getGender();
+
+        let hpiText = `${name} is a ${age} year old ${gender}.`;
+        hpiText += ` Patient was diagnosed with ${this.type} on ${this.diagnosisDate}.`;
+        
+        // Laterality
+        if (this.laterality) {
+            hpiText += ` Breast cancer diagnosed in ${this.laterality} breast.`;
+        }
+
+        // Staging
+        const staging = this.getMostRecentStaging();
+        if (staging && staging.stage) {
+            hpiText += ` Stage ${staging.stage} ${staging.t_Stage} ${staging.n_Stage} ${staging.m_Stage} disease.`;
+        }
+
+        // Tumor Size and HistologicGrade
+        const tumorSize = this.getObservationsOfType(FluxTumorDimensions);
+        const histologicGrade = this.getObservationsOfType(FluxHistologicGrade);
+        if (tumorSize.length > 0) {
+            hpiText += ` Primary tumor size was ${tumorSize[0].quantity.value} ${tumorSize[0].quantity.unit}.`;
+        }
+        if (histologicGrade.length > 0) {
+            hpiText += ` Histological grade was ${histologicGrade[0].grade}.`;
+        }
+
+        // ER, PR, HER2
+        const erStatus = this.getMostRecentERReceptorStatus();
+        const prStatus = this.getMostRecentPRReceptorStatus();
+        const her2Status = this.getMostRecentHER2ReceptorStatus();
+        if (erStatus) {
+            hpiText += ` Estrogen receptor was ${erStatus.status}.`;
+        }
+        if (prStatus) {
+            hpiText += ` Progesteron receptor was ${prStatus.status}.`;
+        }
+        if (her2Status) {
+            hpiText += ` HER2 was ${her2Status.status}.`;
+        }
+
+        hpiText = this.buildEventNarrative(hpiText, patient);
+        
+        return hpiText;
     }
 }
 

--- a/src/model/oncology/FluxEstrogenReceptorStatus.js
+++ b/src/model/oncology/FluxEstrogenReceptorStatus.js
@@ -1,25 +1,35 @@
+import Entry from '../shr/base/Entry';
+import EntryType from '../shr/base/EntryType';
 import EstrogenReceptorStatus from '../shr/oncology/EstrogenReceptorStatus';
+import FluxObservation from '../finding/FluxObservation';
 import lookup from '../../lib/receptor_lookup.jsx';
 
 // FluxEstrogenReceptorStatus class to hide codeableconcepts
-class FluxEstrogenReceptorStatus {
+class FluxEstrogenReceptorStatus extends FluxObservation {
     constructor(json) {
-        this._estrogenReceptorStatus = EstrogenReceptorStatus.fromJSON(json);
+        super();
+        this._observation = EstrogenReceptorStatus.fromJSON(json);
+        if (!this._observation.entryInfo) {
+            let entry = new Entry();
+            entry.entryType = new EntryType();
+            entry.entryType.uri = 'http://standardhealthrecord.org/spec/shr/oncology/EstrogenReceptorStatus';
+            this._observation.entryInfo = entry;
+        }
     }
     
     /**
      * Getter for shr.oncology.ReceptorType
      */
     get status() {
-        if (!this._estrogenReceptorStatus.value) return null;
-        return this._estrogenReceptorStatus.value.coding[0].displayText.value; 
+        if (!this._observation.value) return null;
+        return this._observation.value.coding[0].displayText.value; 
     }
 
     /**
      * Setter for shr.oncology.ReceptorType
      */
     set status(statusVal) {
-        this._estrogenReceptorStatus.value = lookup.getReceptorCodeableConcept(statusVal);
+        this._observation.value = lookup.getReceptorCodeableConcept(statusVal);
     }
 }
 

--- a/src/model/oncology/FluxHER2ReceptorStatus.js
+++ b/src/model/oncology/FluxHER2ReceptorStatus.js
@@ -1,24 +1,34 @@
+import Entry from '../shr/base/Entry';
+import EntryType from '../shr/base/EntryType';
+import FluxObservation from '../finding/FluxObservation';
 import HER2ReceptorStatus from '../shr/oncology/HER2ReceptorStatus';
 import lookup from '../../lib/receptor_lookup.jsx';
 
-class FluxHER2ReceptorStatus {
+class FluxHER2ReceptorStatus extends FluxObservation {
     constructor(json) {
-        this._her2ReceptorStatus = HER2ReceptorStatus.fromJSON(json);
+        super();
+        this._observation = HER2ReceptorStatus.fromJSON(json);
+        if (!this._observation.entryInfo) {
+            let entry = new Entry();
+            entry.entryType = new EntryType();
+            entry.entryType.uri = 'http://standardhealthrecord.org/spec/shr/oncology/HER2ReceptorStatus';
+            this._observation.entryInfo = entry;
+        }
     }
     
     /**
      * Getter for shr.oncology.ReceptorType
      */
     get status() {
-        if (!this._her2ReceptorStatus.value) return null;
-        return this._her2ReceptorStatus.value.coding[0].displayText.value;
+        if (!this._observation.value) return null;
+        return this._observation.value.coding[0].displayText.value;
     }
 
     /**
      * Setter for shr.oncology.ReceptorType
      */
     set status(statusVal) {
-        this._her2ReceptorStatus.value = lookup.getReceptorCodeableConcept(statusVal);
+        this._observation.value = lookup.getReceptorCodeableConcept(statusVal);
     }
 }
 

--- a/src/model/oncology/FluxHistologicGrade.js
+++ b/src/model/oncology/FluxHistologicGrade.js
@@ -5,6 +5,10 @@ class FluxHistologicGrade {
         this._histologicGrade = HistologicGrade.fromJSON(json);
     }
 
+    get entryInfo() {
+        return this._histologicGrade.entryInfo;
+    }
+
     /**
      *  Getter for grade
      *  This will return the displayText string from CodeableConcept Value

--- a/src/model/oncology/FluxOncologyObjectFactory.js
+++ b/src/model/oncology/FluxOncologyObjectFactory.js
@@ -12,7 +12,7 @@ import FluxTNMStage from './FluxTNMStage';
 import FluxTumorDimensions from './FluxTumorDimensions';
 
 export default class FluxOncologyObjectFactory {
-    static createInstance(json, type) {
+    static createInstance(json, type, patientRecord) {
         const { namespace, elementName } = getNamespaceAndName(json, type);
         if (namespace !== 'shr.oncology') {
             throw new Error(`Unsupported type in ShrOncologyObjectFactory: ${type}`);
@@ -21,7 +21,7 @@ export default class FluxOncologyObjectFactory {
         switch (elementName) {
             case 'BRCA1Variant': return new FluxBRCA1Variant(json);
             case 'BRCA2Variant': return new FluxBRCA2Variant(json);
-            case 'BreastCancer': return new FluxBreastCancer(json);
+            case 'BreastCancer': return new FluxBreastCancer(json, patientRecord);
             case 'BreastCancerGeneticAnalysisPanel': return new FluxBreastCancerGeneticAnalysisPanel(json);
             case 'EstrogenReceptorStatus': return new FluxEstrogenReceptorStatus(json);
             case 'ProgesteroneReceptorStatus': return new FluxProgesteroneReceptorStatus(json);

--- a/src/model/oncology/FluxProgesteroneReceptorStatus.js
+++ b/src/model/oncology/FluxProgesteroneReceptorStatus.js
@@ -1,24 +1,34 @@
+import Entry from '../shr/base/Entry';
+import EntryType from '../shr/base/EntryType';
+import FluxObservation from '../finding/FluxObservation';
 import ProgesteroneReceptorStatus from '../shr/oncology/ProgesteroneReceptorStatus';
 import lookup from '../../lib/receptor_lookup.jsx';
 
-class FluxProgesteroneReceptorStatus {
+class FluxProgesteroneReceptorStatus extends FluxObservation {
     constructor(json) {
-        this._progesteroneReceptorStatus = ProgesteroneReceptorStatus.fromJSON(json);
+        super();
+        this._observation = ProgesteroneReceptorStatus.fromJSON(json);
+        if (!this._observation.entryInfo) {
+            let entry = new Entry();
+            entry.entryType = new EntryType();
+            entry.entryType.uri = 'http://standardhealthrecord.org/spec/shr/oncology/ProgesteroneReceptorStatus';
+            this._observation.entryInfo = entry;
+        }
     }
     
     /**
      * Getter for shr.oncology.ReceptorType
      */
     get status() {
-        if (!this._progesteroneReceptorStatus.value) return null;
-        return this._progesteroneReceptorStatus.value.coding[0].displayText.value;
+        if (!this._observation.value) return null;
+        return this._observation.value.coding[0].displayText.value;
     }
 
     /**
      * Setter for shr.oncology.ReceptorType
      */
     set status(statusVal) {
-        this._progesteroneReceptorStatus.value = lookup.getReceptorCodeableConcept(statusVal);
+        this._observation.value = lookup.getReceptorCodeableConcept(statusVal);
     }
 }
 

--- a/src/model/oncology/FluxTNMStage.js
+++ b/src/model/oncology/FluxTNMStage.js
@@ -5,25 +5,22 @@ import TNMStage from '../shr/oncology/TNMStage';
 import T_Stage from '../shr/oncology/T_Stage';
 import Entry from '../shr/base/Entry';
 import EntryType from '../shr/base/EntryType';
-import Lang from 'lodash';
+import FluxObservation from '../finding/FluxObservation';
 import lookup from '../../lib/tnmstage_lookup.jsx';
 import staging from '../../lib/staging.jsx';
 
 // FluxTNMStage class to hide codeableconcepts
-class FluxTNMStage {
+class FluxTNMStage extends FluxObservation {
     constructor(json) {
-        this._tnmStage = TNMStage.fromJSON(json);
-        if (!this._tnmStage.entryInfo) {
+        super();
+        this._observation = TNMStage.fromJSON(json);
+        if (!this._observation.entryInfo) {
             let entry = new Entry();
             entry.entryType = new EntryType();
             entry.entryType.uri = 'http://standardhealthrecord.org/spec/shr/oncology/TNMStage';
-            this._tnmStage.entryInfo = entry;
-            this._tnmStage.observationComponent = [];
+            this._observation.entryInfo = entry;
+            this._observation.observationComponent = [];
         }
-    }
-
-    get entryInfo() {
-        return this._tnmStage.entryInfo;
     }
 
     /**
@@ -31,7 +28,7 @@ class FluxTNMStage {
      *  This will return the displayText string from CodeableConcept value
      */
     get stage() {
-        return this._tnmStage.value.coding[0].displayText.value;
+        return this._observation.value.coding[0].displayText.value;
     }
 
     /**
@@ -40,7 +37,7 @@ class FluxTNMStage {
      *  The function will lookup the corresponding coding/codesystem and set the TNMStage entry value property
      */
     set stage(stage) {
-        this._tnmStage.value = lookup.getStagingCodeableConcept(stage);
+        this._observation.value = lookup.getStagingCodeableConcept(stage);
     }
 
     /**
@@ -48,7 +45,7 @@ class FluxTNMStage {
      *  This will return the displayText string from T_Stage
      */
     get t_Stage() {
-        const tStage = this._tnmStage._observationComponent.find(o => {
+        const tStage = this._observation._observationComponent.find(o => {
             return o instanceof T_Stage;
         });
         if (!tStage) return null;
@@ -63,13 +60,13 @@ class FluxTNMStage {
     set t_Stage(tStage) {
         let t = new T_Stage();
         t.value = lookup.getTStageCodeableConcept(tStage);
-        const tIndex = this._tnmStage.observationComponent.findIndex((o) => {
+        const tIndex = this._observation.observationComponent.findIndex((o) => {
             return o instanceof T_Stage;
         });
         if (tIndex >= 0) {
-            this._tnmStage.observationComponent[tIndex] = t;
+            this._observation.observationComponent[tIndex] = t;
         } else {
-            this._tnmStage.observationComponent.push(t);
+            this._observation.observationComponent.push(t);
         }
         this._calculateStage();
     }
@@ -79,7 +76,7 @@ class FluxTNMStage {
      *  This will return the displayText string from N_Stage
      */
     get n_Stage() {
-        const nStage = this._tnmStage._observationComponent.find(o => {
+        const nStage = this._observation._observationComponent.find(o => {
             return o instanceof N_Stage
         });
         if (!nStage) return null;
@@ -94,13 +91,13 @@ class FluxTNMStage {
     set n_Stage(nStage) {
         let n = new N_Stage();
         n.value = lookup.getNStageCodeableConcept(nStage);
-        const nIndex = this._tnmStage.observationComponent.findIndex((o) => {
+        const nIndex = this._observation.observationComponent.findIndex((o) => {
             return o instanceof N_Stage;
         });
         if (nIndex >= 0) {
-            this._tnmStage.observationComponent[nIndex] = n;
+            this._observation.observationComponent[nIndex] = n;
         } else {
-            this._tnmStage.observationComponent.push(n);
+            this._observation.observationComponent.push(n);
         }
         this._calculateStage();
     }
@@ -110,7 +107,7 @@ class FluxTNMStage {
      *  This will return the displayText string from M_Stage
      */
     get m_Stage() {
-        const mStage = this._tnmStage._observationComponent.find(o => {
+        const mStage = this._observation._observationComponent.find(o => {
             return o instanceof M_Stage;
         });
         if (!mStage) return null;
@@ -125,24 +122,15 @@ class FluxTNMStage {
     set m_Stage(mStage) {
         let m = new M_Stage();
         m.value = lookup.getMStageCodeableConcept(mStage);
-        const mIndex = this._tnmStage.observationComponent.findIndex((o) => {
+        const mIndex = this._observation.observationComponent.findIndex((o) => {
             return o instanceof M_Stage;
         });
         if (mIndex >= 0) {
-            this._tnmStage.observationComponent[mIndex] = m;
+            this._observation.observationComponent[mIndex] = m;
         } else {
-            this._tnmStage.observationComponent.push(m);
+            this._observation.observationComponent.push(m);
         }
         this._calculateStage();
-    }
-
-    /*
-     * Getter for clinicallyRelevantTime
-     * This will return the value string from _clinicallyRelevantTime
-     */
-    get clinicallyRelevantTime() {
-        if (Lang.isUndefined(this._tnmStage._clinicallyRelevantTime)) return null;
-        return this._tnmStage._clinicallyRelevantTime.value;
     }
 
     /*
@@ -153,7 +141,7 @@ class FluxTNMStage {
     set clinicallyRelevantTime(clinicallyRelevantTime) {
         let t = new ClinicallyRelevantTime();
         t.value = clinicallyRelevantTime;
-        this._tnmStage._clinicallyRelevantTime = t;
+        this._observation._clinicallyRelevantTime = t;
     }
     
     _calculateStage() {

--- a/src/model/oncology/FluxTumorDimensions.js
+++ b/src/model/oncology/FluxTumorDimensions.js
@@ -5,6 +5,10 @@ class FluxTumorDimensions {
         this._tumorDimensions = TumorDimensions.fromJSON(json);
     }
 
+    get entryInfo() {
+        return this._tumorDimensions.entryInfo;
+    }
+
     /**
      *  Getter for quantity
      *  will return object with properties value and unit

--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -16,6 +16,7 @@ import FluxStudy from '../model/research/FluxStudy';
 import ClinicalTrialsList from '../clinicalTrials/ClinicalTrialsList.jsx'; // put jsx because yarn test-ui errors on this import otherwise
 import CreationTime from '../model/shr/core/CreationTime';
 import LastUpdated from '../model/shr/base/LastUpdated';
+import Reference from '../model/Reference';
 import mapper from '../lib/FHIRMapper';
 import Lang from 'lodash';
 import moment from 'moment';
@@ -45,7 +46,7 @@ class PatientRecord {
 
     _loadJSON(shrJson) {
         return shrJson.map((entry) => {
-			return FluxObjectFactory.createInstance(entry);
+			return FluxObjectFactory.createInstance(entry, undefined, this);
         });
     }
     
@@ -150,7 +151,8 @@ class PatientRecord {
     }
 
     static createEntryReferenceTo(entry) {
-        return {"entryType": entry.entryType[0], "shrId": entry.shrId, "entryId": entry.entryId};
+        return new Reference(entry.entryInfo.shrId, entry.entryInfo.entryId, entry.entryInfo.entryType.value);
+        //return {"EntryType": {"Value" : entry.entryInfo.entryType.value }, "ShrId": entry.entryInfo.shrId, "EntryId": entry.entryInfo.entryId};
     }
 
     getName() {

--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -150,7 +150,7 @@ class PatientRecord {
         return (entry.entryType.indexOf(type) >= 0);
     }
 
-    static createEntryReferenceTo(entry) {
+    createEntryReferenceTo(entry) {
         return new Reference(entry.entryInfo.shrId, entry.entryInfo.entryId, entry.entryInfo.entryType.value);
         //return {"EntryType": {"Value" : entry.entryInfo.entryType.value }, "ShrId": entry.entryInfo.shrId, "EntryId": entry.entryInfo.entryId};
     }

--- a/src/shortcuts/Shortcuts.json
+++ b/src/shortcuts/Shortcuts.json
@@ -55,7 +55,7 @@
                                 {"name":"N", "attribute":"n_Stage", "isSettable":"true", "setMethod":"n_Stage", "childShortcut": "StagingNCreator"},
                                 {"name":"M", "attribute":"m_Stage", "isSettable":"true", "setMethod":"m_Stage", "childShortcut": "StagingMCreator"},
                                 {"name":"stage", "attribute":"stage", "isSettable":"false"} ],
-    "updatePatient": [{"object":"$parentValueObject", "listAttribute": "observation", "args": [ "$valueObject" ]}],
+    "updatePatient": [{"object":"$parentValueObject", "method": "addObservation", "args": [ "$valueObject" ]}],
     "isContext": true,
     "stringTriggers": [{ "name": "#staging", "description": "The stage of a cancer, assessed according to the standard established by American Joint Committee on Cancer (AJCC). TNM Stage Grouping categorizes the progression of cancer using the Roman Numeral system."}],
     "regexpTrigger": null,

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -1,6 +1,5 @@
 import Lang from 'lodash'
 import moment from 'moment';
-import FluxHistologicGrade from '../model/oncology/FluxHistologicGrade';
 import FluxTumorDimensions from '../model/oncology/FluxTumorDimensions';
 
 /*
@@ -408,8 +407,8 @@ export default class SummaryMetadata {
                                     {
                                         name: "Histological Grade",
                                         value: (patient, currentConditionEntry) => {
-                                            let list = currentConditionEntry.getObservationsOfType(FluxHistologicGrade);
-                                            return [list[0].grade, patient.isUnsigned(currentConditionEntry)];
+                                            let histologicalGrade = currentConditionEntry.getMostRecentHistologicalGrade();
+                                            return [ histologicalGrade.grade, patient.isUnsigned(histologicalGrade) ];
                                         }
                                     },
                                     {
@@ -788,9 +787,7 @@ export default class SummaryMetadata {
 
     getTestsForSubSection = (patient, currentConditionEntry, subsection) => { 
         if (Lang.isNull(patient) || Lang.isNull(currentConditionEntry)) return [];
-        const labResults = currentConditionEntry.getTests();
-        labResults.sort(currentConditionEntry._observationsTimeSorter);
-
+        const labResults = currentConditionEntry.getLabResultsChronologicalOrder();
         const labs = labResults.filter((lab, i) => {
             return lab.codeableConceptCode === subsection.code;
         }).map((lab, i) => {


### PR DESCRIPTION
JIRA 904. Updated both hard coded patients such that evidence is a set of references to entries. Updated Flux wrappers to have base classes of FluxCondition for conditions and FluxObservation for the observations (e.g., TNMStage and ER, PR, and HER2)

Updated @hpi shortcut to have breast cancer specific portions in FluxBreastCancer only and rest in FluxCondition.

Also refactored breast cancer specific methods to FluxBreastCancer

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [ ] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [ ] This pull request describes why these changes were made
- [ ] Recognizes any potential shortcomings/bugs in the description 
- [ ] Cheat sheet is updated
- [ ] Demo script is updated 
- [ ] Documentation on Wiki has been updated 
- [ ] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [ ] Note parser has been updated if structured phrases change

**Code Quality**

- [ ] 4-space indents - convert any tabs to spaces
- [ ] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [ ] Code is commented

**Tests**

- [ ] Existing tests passed
- [ ] Added UI tests for slim mode 
- [ ] Added UI tests for full mode
- [ ] Added backend tests for fluxNotes code
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
