### PR TITLE
Add padding to bottom of sign note button

### DIFF
--- a/src/notes/FluxNotesEditor.css
+++ b/src/notes/FluxNotesEditor.css
@@ -129,8 +129,10 @@
 }
 
 .editor-panel {
-    /* 106px is the height of the Patient Control Panel, 16px is the height of the top margin of post encounter view content, 130px accounts for the editor header and editor toolbar plus margins, 76px is the height of the sign button */
-    height: calc(100vh - 106px - 16px - 130px - 76px) !important;
+    /* 106px is the height of the Patient Control Panel, 16px is the height of the top margin of post encounter view
+    content, 130px accounts for the editor header and editor toolbar plus margins, 76px is the height of the sign button,
+    20px is the margin on the sign button */
+    height: calc(100vh - 106px - 16px - 130px - 76px - 20px) !important;
     overflow-y: scroll;
     overflow-x: hidden;
     text-align: left;

--- a/src/panels/NotesPanel.css
+++ b/src/panels/NotesPanel.css
@@ -14,5 +14,5 @@
     text-transform: none !important;
     display: inline-block !important;
     min-width: 90% !important;
-    margin: 20px 20px 20px 20px;
+    margin: 20px 20px 20px 20px !important;
 }


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

Addresses jira 1020. Straightforward fix. Added !important to btn_finish class so margin doesn't get overridden 


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- N/A Cheat sheet is updated
- N/A Demo script is updated 
- N/A Documentation on Wiki has been updated 
- N/A Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- N/A Note parser has been updated if structured phrases change

**Code Quality**

- N/A 4-space indents - convert any tabs to spaces
- N/A Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- N/A Code is commented

**Tests**

- [x] Existing tests passed
- N/A Added UI tests for slim mode 
- N/A Added UI tests for full mode
- N/A Added backend tests for fluxNotes code
- N/A Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
