### PR TITLE
Reduce note max width

### DIFF
--- a/src/notes/NoteAssistant.css
+++ b/src/notes/NoteAssistant.css
@@ -12,7 +12,7 @@ span.button-hover {
 .toggle-buttons-container {
     display: flex !important;
     margin-left: auto;
-    max-width: 211px; /* Max width of Notes is 211px. This should match. */
+    max-width: 188px; /* Max width of Notes is 188px. This should match. */
     margin-right: 0;
 }
 
@@ -45,6 +45,7 @@ span.button-hover {
     font-weight: bold;
     font-size: 0.8em;
     margin: 10px;
+    max-width: 184px;
 }
 
 /* Sort */
@@ -56,6 +57,7 @@ span.button-hover {
 
 .sort-selection {
     margin-bottom: 20px;
+    max-width: 184px;
 }
 
 .sort-select {
@@ -103,6 +105,7 @@ li.sort-item:hover {
     background-color: white !important;
     padding: 10px !important;
     margin-top: 20px;
+    max-width: 184px;
 }
 
 .more-notes-btn:hover {
@@ -120,7 +123,7 @@ li.sort-item:hover {
 
 .note {
     position: relative;
-    max-width: 200px;
+    max-width: 150px;
     padding: 0.5em 1em;
     margin: 1em 0;
     color: #000;

--- a/src/panels/TargetedDataPanel.css
+++ b/src/panels/TargetedDataPanel.css
@@ -3,7 +3,7 @@
 }
 
 .fitted-panel.minimap-container {
-    margin-left: 90px;
+    margin-left: 122px;
     width: auto;
 }
 

--- a/src/styles/FullApp.css
+++ b/src/styles/FullApp.css
@@ -7,6 +7,9 @@
 /* Restricts app to max fixed width for very wide screens. */
 .FullApp-content {
     /*background-color: #F3F3F3;*/
+    /* Reduce padding that is set using fluid-container from react flex box */
+    padding-right: 0rem !important;
+    padding-left: 0rem !important;
 }
 
 .FullApp-content .container-fluid {


### PR DESCRIPTION
Feedback from Edwin said to make the note previews on the right always stay the same size. I could not get the notes to have a fixed size, so instead I reduced the maximum width of the notes. This makes the change in size less dramatic when switching from pre-encounter to post encounter or closing the editor. However, the notes do dynamically resize as the screen size gets smaller.

Any feedback on this solution is appreciated. I can also explain in more detail what I tried for fixing the width and the problems I ran encountered to anyone who is interested. The previous attempt is in the branch `fix-note-preview-width`. I can delete that branch once this pull request is merged if we don't need it anymore.

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- N/A Cheat sheet is updated
- N/A Demo script is updated 
- N/A Documentation on Wiki has been updated 
- N/A Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- N/A Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- N/A Added UI tests for slim mode 
- N/A Added UI tests for full mode
- N/A Added backend tests for fluxNotes code
- N/A Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
