### PR TITLE
Context tray conditions

### DIFF
--- a/src/context/ContextTray.css
+++ b/src/context/ContextTray.css
@@ -23,6 +23,15 @@
   color: #333;
 }
 
+.context-tray .section-item-disabled {
+  margin: 3px 0px 3px 26px;
+  font-size: 0.9em;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+
 .context-tray .fa {
   font-size: 1.4em;
   color: #aaa;

--- a/src/context/ContextTray.css
+++ b/src/context/ContextTray.css
@@ -1,38 +1,37 @@
 .context-tray {
-  margin: 20px 0;
-  color: #888;
+    margin: 20px 0;
+    color: #888;
 }
 
 .context-tray section {
-  padding: 10px 0;
-  border-bottom: 1px solid #ddd;
+    padding: 10px 0;
+    border-bottom: 1px solid #ddd;
 }
 
 .context-tray .section-item {
-  margin: 3px 0;
-  font-size: 0.9em;
-  cursor: pointer;
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
+    margin: 3px 0;
+    font-size: 0.9em;
+    cursor: pointer;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
 }
 
 .context-tray .section-item:hover,
 .context-tray .section-item.selected {
-  font-weight: bold;
-  color: #333;
+    font-weight: bold;
+    color: #333;
 }
 
 .context-tray .section-item-disabled {
-  margin: 3px 0px 3px 26px;
-  font-size: 0.9em;
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
+    margin: 3px 0px 3px 26px;
+    font-size: 0.9em;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
 }
 
-
 .context-tray .fa {
-  font-size: 1.4em;
-  color: #aaa;
+    font-size: 1.4em;
+    color: #aaa;
 }

--- a/src/context/ContextTray.jsx
+++ b/src/context/ContextTray.jsx
@@ -90,21 +90,12 @@ export default class ContextTray extends Component {
         const activeContext = contexts[activeContextIndex];
         const parentContexts = contexts.filter((context) => context.parentContext == null);
 
-        console.log("parent contexts");
-        console.log(parentContexts);
-
         if (parentContexts.length === 0) {
             return null;
         }
 
         const selectedParentContext = this.findParentContext(contexts);
-
-        console.log("selected parent context");
-        console.log(selectedParentContext);
         const children = this.filterContextChildren(contexts, selectedParentContext);
-
-        // console.log("children");
-        // console.log(children);
 
         return (
             <div>
@@ -113,21 +104,13 @@ export default class ContextTray extends Component {
                         const isActive = activeContext === context;
                         const contextIndex = contexts.indexOf(context) + 2;
 
-                        console.log("is active");
-                        console.log(isActive);
-
-                        console.log("context");
-                        console.log(context);
-
                         if (!isActive && (selectedParentContext !== context)) {
                             return (
                                 <div
                                     className={`section-item${isActive ? ' selected' : '-disabled'}`}
-
                                     key={`context-header-option-${contextIndex}`}
                                     title={context.text}
                                 >
-                                    {/*<FontAwesome name={isActive ? 'angle-down' : 'angle-right'} fixedWidth />*/}
                                     {context.text}
                                 </div>
                             );
@@ -215,11 +198,6 @@ export default class ContextTray extends Component {
     render() {
         const { value, templates } = this.state;
         const activeContexts = this.getActiveContexts();
-
-        // console.log(activeContexts);
-        // console.log("value: ");
-        // console.log(value);
-        // console.log("activeContexts");
 
         return (
             <div className="context-tray">

--- a/src/context/ContextTray.jsx
+++ b/src/context/ContextTray.jsx
@@ -77,11 +77,14 @@ export default class ContextTray extends Component {
         if (context == null || context.children.length === 0) {
             return [];
         }
-
+        
         return context.children.filter((childContext) => activeContexts.indexOf(childContext) > -1);
     }
 
     renderParentContexts(contexts) {
+        
+        console.log("contexts");
+        console.log(contexts);
         const activeContextIndex = this.state.value - 2;
         const activeContext = contexts[activeContextIndex];
         const parentContexts = contexts.filter((context) => context.parentContext == null);

--- a/src/context/ContextTray.jsx
+++ b/src/context/ContextTray.jsx
@@ -13,6 +13,9 @@ export default class ContextTray extends Component {
         super(props);
 
         this.state = {
+            // value keeps track of which context is active
+            // 0 when Templates are selected. 1 when Patient is selected
+            // In editor, value is incremented by 1 for each context added (i.e @condition, #disease status)
             value: 1,
             lastActiveContextCount: 0,
             templates: [
@@ -39,6 +42,7 @@ export default class ContextTray extends Component {
         }
     }
 
+    // Get all contexts being used in the editor
     getActiveContexts() {
         let activeContexts = [];
 
@@ -82,19 +86,25 @@ export default class ContextTray extends Component {
     }
 
     renderParentContexts(contexts) {
-        
-        console.log("contexts");
-        console.log(contexts);
         const activeContextIndex = this.state.value - 2;
         const activeContext = contexts[activeContextIndex];
         const parentContexts = contexts.filter((context) => context.parentContext == null);
+
+        console.log("parent contexts");
+        console.log(parentContexts);
 
         if (parentContexts.length === 0) {
             return null;
         }
 
         const selectedParentContext = this.findParentContext(contexts);
+
+        console.log("selected parent context");
+        console.log(selectedParentContext);
         const children = this.filterContextChildren(contexts, selectedParentContext);
+
+        // console.log("children");
+        // console.log(children);
 
         return (
             <div>
@@ -103,17 +113,39 @@ export default class ContextTray extends Component {
                         const isActive = activeContext === context;
                         const contextIndex = contexts.indexOf(context) + 2;
 
-                        return (
-                            <div
-                                className={`section-item${isActive ? ' selected' : ''}`}
-                                onClick={() => this.setState({ value: contextIndex })}
-                                key={`context-header-option-${contextIndex}`}
-                                title={context.text}
-                            >
-                                <FontAwesome name={isActive ? 'angle-down' : 'angle-right'} fixedWidth />
-                                {context.text}
-                            </div>
-                        );
+                        console.log("is active");
+                        console.log(isActive);
+
+                        console.log("context");
+                        console.log(context);
+
+                        if (!isActive && (selectedParentContext !== context)) {
+                            return (
+                                <div
+                                    className={`section-item${isActive ? ' selected' : '-disabled'}`}
+
+                                    key={`context-header-option-${contextIndex}`}
+                                    title={context.text}
+                                >
+                                    {/*<FontAwesome name={isActive ? 'angle-down' : 'angle-right'} fixedWidth />*/}
+                                    {context.text}
+                                </div>
+                            );
+                        } else {
+                            return (
+                                <div
+                                    className={`section-item${isActive ? ' selected' : ''}`}
+                                    onClick={() => this.setState({ value: contextIndex })}
+                                    key={`context-header-option-${contextIndex}`}
+                                    title={context.text}
+                                >
+                                    <FontAwesome name={isActive ? 'angle-down' : 'angle-right'} fixedWidth />
+                                    {context.text}
+                                </div>
+                            );
+                        }
+
+
                     })}
                 </section>
 
@@ -183,6 +215,11 @@ export default class ContextTray extends Component {
     render() {
         const { value, templates } = this.state;
         const activeContexts = this.getActiveContexts();
+
+        // console.log(activeContexts);
+        // console.log("value: ");
+        // console.log(value);
+        // console.log("activeContexts");
 
         return (
             <div className="context-tray">

--- a/test/ui/FullApp.js
+++ b/test/ui/FullApp.js
@@ -664,6 +664,38 @@ test('Clicking "@condition" and choosing multiple conditions creates condition s
         .notOk();
 });
 
+test('Clicking "@condition" and choosing multiple conditions does not allow user to select other conditions besides the current condition from the context tray in the condition section.', async t => {
+    const clinicalEventSelector = Selector('.clinical-event-select');
+    await t
+        .click(clinicalEventSelector)
+        .click(Selector('[data-test-clinical-event-selector-item="Post-encounter"]'));
+    const contextPanelElements = Selector('.context-options-list').find('.context-option');
+    const sectionItemElements = Selector('.context-tray').find('.section-item');
+    const conditionButton = await contextPanelElements.withText(/@condition/ig);
+    const patientButton = await sectionItemElements.withText(/Patient/g);
+
+    // Input first condition
+    await t
+        .click(conditionButton);
+    const selectedConditionFracture = Selector('.context-portal').find('li').withText('Fracture');
+    await t
+        .click(selectedConditionFracture);
+
+    // Input second condition
+    await t
+        .click(patientButton);
+    await t
+        .click(conditionButton);
+    const selectedConditionInvasive = Selector('.context-portal').find('li').withText('Invasive ductal carcinoma of breast');
+    await t
+        .click(selectedConditionInvasive);
+
+    const condition1Button = await sectionItemElements.withText(/Fracture/g);
+
+    await t
+        .expect(condition1Button.exists)
+        .notOk()
+});
 
 fixture('Patient Mode - Clinical Notes list')
     .page(startPage);


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

This PR addresses issue 972. After talking with @gregquinn2001 the goal of this task is to make other conditions not clickable in the context tray when the cursor is on a selected condition. For example, if you enter @condition and select "Invasive...." then enter @condition and select "Fracture", since the cursor is at the end of fracture, only the fracture shortcuts should be displayed in the context tray. "Invasive..." condition still appears in the condition section but you cannot click on it and the options for that condition are not visible. If you place your cursor after "Invasive..." in the editor, then the options for "Invasive..." are displayed.

![image](https://user-images.githubusercontent.com/26877672/37372171-3edec3bc-26e8-11e8-8a95-3937cfa82344.png)

- Added logic so that conditions other than the current condition in the context tray are not clickable (and as a result those options are not displayed)
- Added styling for disabled (non clickable) conditions
- Added UI test to check that user cannot click on other conditions to view options when a different conditon is the current context

Note:
- Even though options for other conditions are no longer clickable from the context tray, you can still type shortcuts. For example if you have "Invasive ductal carcinoma of breast" followed by
"Fracture", you can still type #disease status after fracture.  I spoke with @gregquinn2001 who said that for the moment this is expected behavior. We will need to re-evaluate how multiple conditions are handled which is covered as part of jira issue 1007
- Bolding of items in the context tray needs to be revisited. Since this also shows up in fluxnotes.org I made a jira: https://jira.mitre.org/browse/ASCODCP-1032
- At the suggestion of @gregquinn2001 also made another jira looking at a possible solution of handling shortcuts that appear in multiple conditions: https://jira.mitre.org/browse/ASCODCP-1033

## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- N/A Cheat sheet is updated
- N/A Demo script is updated 
- N/A Documentation on Wiki has been updated 
- N/A Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- N/A Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- N/A Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- N/A Added UI tests for slim mode 
- [x] Added UI tests for full mode
- N/A Added backend tests for fluxNotes code
- N/A Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
