### PR TITLE
Local copy of patient entries in TargetedDataSubPanel (TDSP)

### DIFF
--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -712,6 +712,14 @@ class PatientRecord {
         });
     }
 
+    getEntriesOtherThanNotes() {
+        return this.entries.filter((item) => { 
+            // FIXME: FluxBreastCancer has a circular dependency to patientrecord (and it's clinical notes)? 
+            // Is this a pervasive problem? Are we planning on fixing this? 
+            return !(item instanceof FluxClinicalNote || item instanceof FluxBreastCancer);
+        });
+    }
+
     getEntriesOfType(type) {
         return this.entries.filter((item) => {
             return item instanceof type

--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -714,9 +714,7 @@ class PatientRecord {
 
     getEntriesOtherThanNotes() {
         return this.entries.filter((item) => { 
-            // FIXME: FluxBreastCancer has a circular dependency to patientrecord (and it's clinical notes)? 
-            // Is this a pervasive problem? Are we planning on fixing this? 
-            return !(item instanceof FluxClinicalNote || item instanceof FluxBreastCancer);
+            return !(item instanceof FluxClinicalNote);
         });
     }
 

--- a/src/summary/TargetedDataSubpanel.jsx
+++ b/src/summary/TargetedDataSubpanel.jsx
@@ -77,7 +77,7 @@ export default class TargetedDataSubpanel extends Component {
         // Case 4: isWide 
         const newIsWide = nextProps.isWide;
         const changesToIsWide = (this._currentIsWide !== newIsWide)
-        if(changesToIsWide) { 
+        if (changesToIsWide) { 
             this._currentIsWide = newIsWide;
         }
 

--- a/src/summary/TargetedDataSubpanel.jsx
+++ b/src/summary/TargetedDataSubpanel.jsx
@@ -31,7 +31,7 @@ export default class TargetedDataSubpanel extends Component {
         // Need to ignore patientRecords on entries, as they reference the clinical notes ignored above. 
         // Solution: Remove them during comparison, restore those value after comparison.
         const newRelevantPatientEntries = nextProps.patient.getEntriesOtherThanNotes();
-        const arrayOfPatientRecords = newRelevantPatientEntries.reduce(function (accumulator, currentEntry, currentIndex) { 
+        const arrayOfPatientRecords = newRelevantPatientEntries.reduce((accumulator, currentEntry, currentIndex) => { 
             if (currentEntry._patientRecord) { 
                 const copyOfPatientRecord = currentEntry._patientRecord;
                 currentEntry._patientRecord = null;
@@ -58,7 +58,7 @@ export default class TargetedDataSubpanel extends Component {
         };
         
         // Case 2: SignedNote count 
-        const newSignedNotesCount = nextProps.patient.getNotes().reduce(function (totalNumberOfSignedNotes, currentNote) { 
+        const newSignedNotesCount = nextProps.patient.getNotes().reduce((totalNumberOfSignedNotes, currentNote) => { 
             return totalNumberOfSignedNotes + (currentNote.signed ? 1 : 0);
         }, 0);
         const changesToSignedNotesCount = newSignedNotesCount !== this._signedNotesCount;
@@ -70,7 +70,7 @@ export default class TargetedDataSubpanel extends Component {
         // Case 3: ClinicalEvent 
         const newClinicalEvent = nextProps.clinicalEvent;
         const changesToClinicalEvent = (this._clinicalEvent !== newClinicalEvent)
-        if(changesToClinicalEvent) { 
+        if (changesToClinicalEvent) { 
             this._clinicalEvent = newClinicalEvent;
         }
 

--- a/src/summary/TargetedDataSubpanel.jsx
+++ b/src/summary/TargetedDataSubpanel.jsx
@@ -16,15 +16,17 @@ export default class TargetedDataSubpanel extends Component {
         this._signedNotesCount = 0;
         this._clinicalEvent = "";
         this._currentIsWide = null;
+        this._currentConditionString = "";
         this._visualizerManager = new VisualizerManager();
     }
 
     shouldComponentUpdate(nextProps, nextState) { 
-        // Four current reasons to update:
+        // Five current reasons to update:
         // - There is a change to the entries this component cares about
         // - A note has been signed and our representation of the data should reflect it's new signedness
         // - Clinical event has shifted
         // - isWide has changed
+        // - Condition has changed
         // Case 1: Entries
         // Need to ignore patientRecords on entries, as they reference the clinical notes ignored above. 
         // Solution: Remove them during comparison, restore those value after comparison.
@@ -79,7 +81,22 @@ export default class TargetedDataSubpanel extends Component {
             this._currentIsWide = newIsWide;
         }
 
-        return changesToRelevantEntries || changesToSignedNotesCount || changesToClinicalEvent || changesToIsWide;
+        // Case 5: Condition string changes: need string represenatation
+        const newConditionCodeSystem = nextProps.condition.codeSystem;
+        const newConditionCode = nextProps.condition.code
+        // May not be human readable, but is a unique identifier and that's all we need here.
+        const newConditionString = `${newConditionCodeSystem}${newConditionCode}`;
+        // const changesToConditionString = false; 
+        const changesToConditionString = (this._currentConditionString !== newConditionString)
+        if (changesToConditionString) { 
+            this._currentConditionString = newConditionString
+        }
+
+        return changesToRelevantEntries 
+            || changesToSignedNotesCount 
+            || changesToClinicalEvent 
+            || changesToIsWide
+            || changesToConditionString;
     }
 
     getConditionMetadata() {

--- a/src/summary/TargetedDataSubpanel.jsx
+++ b/src/summary/TargetedDataSubpanel.jsx
@@ -11,8 +11,21 @@ import './TargetedDataSubpanel.css';
 export default class TargetedDataSubpanel extends Component {
     constructor(props) {
         super(props);
-
+        // No patient by default
+        this._relevantPatientEntries = {};
         this._visualizerManager = new VisualizerManager();
+    }
+
+    shouldComponentUpdate(nextProps, nextState) { 
+        const newRelevantPatientEntries = nextProps.patient.getEntriesOtherThanNotes();
+
+        // Only update when a change occurs on non-note related objects.
+        if (!_.isEqual(this._relevantPatientEntries, newRelevantPatientEntries)) { 
+            this._relevantPatientEntries = _.cloneDeep(newRelevantPatientEntries);
+            return true;
+        } else { 
+            return false
+        }
     }
 
     getConditionMetadata() {


### PR DESCRIPTION
Addresses JIRA-1024: [Full] Initial implementation of TargetedDataSubpanel's copy of patient object, using that to determine return value of "shouldComponentUpdate"

In addition to storing a local copy of the patient entries (sans notes) I had to store a few other key elements that play into whether or not the TDSP, including: 
- The current clincal event (visualizers and minimap update when the number 
- The number of signed entries (as values get signed, their underlines in visualizers change)
- Whether or not the TDSP isWide (width changes the way some visualizers like tabular and bandedlinechart are displayed)

Compare the performance of typing text in our editor with that of fluxnotes.org or master. Let me know if there are any cases I've missed for updates, if you're not seeing the performance boost, if you'd like anything in my code to change or if there's anything else on your mind! 

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- **N/A** Cheat sheet is updated
- **N/A** Demo script is updated 
- **N/A** Documentation on Wiki has been updated 
- **N/A** Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- **N/A** Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- **N/A** Added UI tests for slim mode 
- **N/A** Added UI tests for full mode
- **N/A** Added backend tests for fluxNotes code
- **N/A** Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
