### PR TITLE
Reload original note content

### DIFF
--- a/src/dataaccess/HardCodedPatient.json
+++ b/src/dataaccess/HardCodedPatient.json
@@ -168,7 +168,7 @@
         "subject": "Clinical follow-up",
         "hospital": "Dana Farber",
         "clinician": "Dr. Smith",
-        "content": "@name is a @age year old @gender presenting with @condition[[Invasive ductal carcinoma of breast]].\nDisease #disease status #Stable based on #Pathology and #Symptoms #as of #08/02/2015.",
+        "content": "@name[[Debra Hernandez672]] is a @age[[49]] year old @gender[[Female]] presenting with @condition[[Invasive ductal carcinoma of breast]].\nDisease #disease status #Stable based on #Pathology and #Symptoms #as of #08/02/2015.",
         "shr.core.CreationTime": {"Value": "02 AUG 2015"},
         "shr.base.LastUpdated": {"Value": "02 AUG 2015"},
         "signed": true
@@ -182,7 +182,7 @@
         "subject": "Consult",
         "hospital": "Dana Farber",
         "clinician": "Dr. Zheng",
-        "content": "@patient presenting with @condition[[Invasive ductal carcinoma of breast]].\nPathology report indicates @name has staging values T1 N1 and M0, corresponding to stage IIA.",
+        "content": "@patient[[Debra Hernandez672 is a 46 year old Female]] presenting with @condition[[Invasive ductal carcinoma of breast]].\nPathology report indicates @name[[Debra Hernandez672]] has staging values T1 N1 and M0, corresponding to stage IIA.",
         "shr.core.CreationTime": {"Value": "12 JUL 2012"},
         "shr.base.LastUpdated": {"Value": "12 JUL 2012"},
         "signed": true
@@ -196,7 +196,7 @@
         "subject": "Clinical post-op",
         "hospital": "Brigham and Women's",
         "clinician": "Dr. Smith",
-        "content": "@patient presenting with @condition[[Invasive ductal carcinoma of breast]].\nToxicity Grade 4 Anemia related to Treatment",
+        "content": "@patient[[Debra Hernandez672 is a 46 year old Female]] presenting with @condition[[Invasive ductal carcinoma of breast]].\nToxicity Grade 4 Anemia related to Treatment",
         "shr.core.CreationTime": {"Value": "20 JUN 2012"} ,
         "shr.base.LastUpdated":{"Value": "20 JUN 2012"},
         "signed": true
@@ -210,7 +210,7 @@
         "subject": "Clinical follow-up",
         "hospital": "Dana Farber",
         "clinician": "Dr. Strauss",
-        "content": "@patient presenting with @condition[[Invasive ductal carcinoma of breast]].\n@name is enrolled in the clinical trial PATINA on 12/24/2017.",
+        "content": "@patient[[Debra Hernandez672 is a 46 year old Female]] presenting with @condition[[Invasive ductal carcinoma of breast]].\n@name[[Debra Hernandez672]] is enrolled in the clinical trial PATINA on 12/24/2017.",
         "shr.core.CreationTime": {"Value":"16 MAY 2012"},
         "shr.base.LastUpdated": {"Value": "16 MAY 2012"},
         "signed": true

--- a/src/dataaccess/HardCodedPatientMidYearDemo18.json
+++ b/src/dataaccess/HardCodedPatientMidYearDemo18.json
@@ -168,7 +168,7 @@
         "subject": "Experienced pain in breast and felt lump in right breast during self-examination",
         "hospital": "Hospital X",
         "clinician": "Dr. Smith",
-        "content": "@name is a @age year old @gender presenting with pain in her right breast. She felt a lump during a self-examination.\nOrdering mammography.",
+        "content": "@name[[Ella Ortiz111]] is a @age[[40]] year old @gender[[Female]] presenting with pain in her right breast. She felt a lump during a self-examination.\nOrdering mammography.",
         "shr.base.CreationTime": {"Value": "09 NOV 2015"},
         "shr.base.LastUpdated": {"Value": "09 NOV 2015"},
         "signed": true
@@ -182,7 +182,7 @@
         "subject": "Mammography",
         "hospital": "Hospital X",
         "clinician": "Dr. Zheng",
-        "content": "@patient given mammography.\nshowed unremarkable views of the right lower outer quadrant; however only an indeterminate lymph node in the right axilla, 13 mm, was apparent. Order a right targeted spot compression breast ultrasound.",
+        "content": "@patient[[Ella Ortiz111 is a 40 year old Female]] given mammography.\nshowed unremarkable views of the right lower outer quadrant; however only an indeterminate lymph node in the right axilla, 13 mm, was apparent. Order a right targeted spot compression breast ultrasound.",
         "shr.base.CreationTime": {"Value": "13 NOV 2015"},
         "shr.base.LastUpdated": {"Value": "13 NOV 2015"},
         "signed": true
@@ -196,7 +196,7 @@
         "subject": "Ultrasound Report",
         "hospital": "Hospital X",
         "clinician": "Dr. Strauss",
-        "content": "@patient given a right targeted spot compression breast ultrasound of a palpable lump. Image revealed a mass at 7 o’clock measuring 1.6 cm, indeterminate right axillary lymph nodes, measuring 1.4 cm with the cortex of 3 mm - indeterminate, and another measuring 12 mm with cortex of 4 mm - indeterminate",
+        "content": "@patient[[Ella Ortiz111 is a 40 year old Female]] given a right targeted spot compression breast ultrasound of a palpable lump. Image revealed a mass at 7 o’clock measuring 1.6 cm, indeterminate right axillary lymph nodes, measuring 1.4 cm with the cortex of 3 mm - indeterminate, and another measuring 12 mm with cortex of 4 mm - indeterminate",
         "shr.base.CreationTime": {"Value": "29 NOV 2015"} ,
         "shr.base.LastUpdated":{"Value": "29 NOV 2015"},
         "signed": true

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -245,6 +245,9 @@ class FluxNotesEditor extends React.Component {
             } else {
                 return this.openPortalToSelectValueForShortcut(shortcut, false, transform);
             }
+        } else if (text.length > 0) {
+            shortcut.setText(text)
+            return this.insertStructuredFieldTransform(transform, shortcut).collapseToStartOfNextText().focus();
         } else {
             return this.insertStructuredFieldTransform(transform, shortcut).collapseToStartOfNextText().focus();
         }
@@ -535,6 +538,10 @@ class FluxNotesEditor extends React.Component {
                     after = remainder.substring(2, end);
                     // FIXME: 2 is a magic number based on [[ length, ditto for 2 below for ]]
                     remainder = remainder.substring(end + 2);
+                    // If there were brackets, but nothing in the brackets, add a space to be inserted, otherwise pulls current data.
+                    if (after.length === 0) {
+                        after = ' ';
+                    }
                     // FIXME: Temporary work around that can parse '@condition's inserted via mic with extraneous space
                 } else if (remainder.startsWith(" [[")) {
                     remainder = remainder.replace(/\s+(\[\[\S*\s*.*)/g, '$1');

--- a/test/ui/FullApp.js
+++ b/test/ui/FullApp.js
@@ -209,6 +209,24 @@ test('Typing an inserterShortcut in the editor results in a structured data inse
         .contains(new PatientRecord(hardCodedPatient).getName());
 });
 
+test('Pasting an inserterShortcut in the editor with [[]] notation sets that text rather than pulling current data ', async t => {
+    // This test mimics loading an inserter shortcut in a note that specifies its values. Ex. @age[[89]]
+    const clinicalEventSelector = Selector('.clinical-event-select');
+    await t
+        .click(clinicalEventSelector)
+        .click(Selector('[data-test-clinical-event-selector-item="Post-encounter"]'));
+    const editor = Selector("div[data-slate-editor='true']");
+    await t
+        .typeText(editor, "@age[[89]] ", { paste: true });
+    const structuredField = editor.find("span[class='structured-field']");
+
+    // The structured field set the specified value, not the current value on the patient record.
+    await t
+        .expect(structuredField.innerText)
+        .notContains(new PatientRecord(hardCodedPatient).getAge())
+        .expect(structuredField.innerText).contains('89');
+});
+
 test('Typing an inserterShortcut that is not currently valid in the editor does not result in a structured data insertion ', async t => {
     const clinicalEventSelector = Selector('.clinical-event-select');
     await t


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

This allows inserters to set the text that was originally inserted. This means that notes that were written 5 years ago when a patient was 40 and used @age will reload with 40 inserted rather than the current age of 45. Notes were already being saved with the [[text]] format, so I added a case to actually set that text. I also updated the stored notes to use this format.

I spent some time trying to test this in the backend tests, rather than adding another frontend test. I think it is possible to do this, but I was running into issues with Slate and the structure field plugins. Rather than spend more time on it, I added one simple test to the frontend tests. Eventually, maybe we can spend more time investigating the issues I ran into.

## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- N/A Cheat sheet is updated
- N/A Demo script is updated 
- N/A Documentation on Wiki has been updated 
- N/A Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- N/A Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- N/A Added UI tests for slim mode 
- [x] Added UI tests for full mode
- N/A Added backend tests for fluxNotes code
- N/A Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
