### PR TITLE
Fixed bug where search bar would disappear if returned no results

### DIFF
--- a/src/context/ContextOptions.jsx
+++ b/src/context/ContextOptions.jsx
@@ -12,7 +12,7 @@ export default class ContextOptions extends Component {
         super(props);
 
         this.state = {
-            searchString: "",
+            searchString: '',
             tooltipVisibility: 'visible'
         }
     }
@@ -51,6 +51,7 @@ export default class ContextOptions extends Component {
                 count++;
             });
         });
+        const countBeforeSearch = count;
 
         // enable filter?
         const showFilter = (count > 10);
@@ -58,6 +59,7 @@ export default class ContextOptions extends Component {
         // build our list of filtered triggers (only filter if we will be showing search bar)
         let triggers = [];
         count = 0;
+
         validShortcuts.forEach((shortcut, i) => {
             let groupName = this.props.shortcutManager.getShortcutGroupName(shortcut);
             this.props.shortcutManager.getTriggersForShortcut(shortcut, context).forEach((trigger, j) => {
@@ -90,7 +92,7 @@ export default class ContextOptions extends Component {
             }
         });
 
-        if (totalShown === 0) {
+        if (!showFilter && totalShown === 0) {
             return null;
         }
 
@@ -102,7 +104,7 @@ export default class ContextOptions extends Component {
                     <div className="shortcut-search-container">
                         <div className="shortcut-search-title">
                             <div>Filter:</div>
-                            <div className="count">(showing {totalShown} of {count})</div>
+                            <div className="count">(showing {totalShown} of {countBeforeSearch})</div>
                         </div>
 
                         <TextField


### PR DESCRIPTION
Fixed bug where search bar would disappear if it returned no results. Discovered a related bug where the total count showing was also incorrect, so that has been fixed as well. Tested in Chrome and IE. All tests pass.

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter: Noranda

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- Recognizes any potential shortcomings/bugs in the description 
- Cheat sheet is updated
- Demo script is updated 
- Documentation on Wiki has been updated 
- Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- Added UI tests for slim mode 
- Added UI tests for full mode
- Added backend tests for fluxNotes code
- Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
