### PR TITLE
updated moment; added resolutions to fix incompat b/t moment & testcafe

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "material-ui": "v1.0.0-beta.30",
     "material-ui-icons": "1.0.0-beta.15",
     "mkdirp": "0.5.1",
-    "moment": "2.18.1",
+    "moment": "2.22.0",
     "node-sass-chokidar": "0.0.3",
     "npm-run-all": "^4.1.2",
     "positions": "1.6.1",
@@ -62,6 +62,9 @@
     "slate-auto-replace": "0.5.0",
     "sync-request": "^4.1.0",
     "testcafe": "0.17.1"
+  },
+  "resolutions": {
+    "moment": "2.22.0"
   },
   "scripts": {
     "build-css": "node-sass-chokidar src/ -o src/",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4735,9 +4735,9 @@ moment-duration-format@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/moment-duration-format/-/moment-duration-format-1.3.0.tgz#541771b5f87a049cc65540475d3ad966737d6908"
 
-moment@2.18.1, moment@2.x, moment@^2.10.3, moment@^2.14.1:
-  version "2.18.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
+moment@2.22.0, moment@2.x, moment@^2.10.3, moment@^2.14.1:
+  version "2.22.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.0.tgz#7921ade01017dd45186e7fee5f424f0b8663a730"
 
 ms@0.7.1:
   version "0.7.1"


### PR DESCRIPTION
Updated us to the most version of moment. Performed manual tests and automated tests -- didn't notice any issues. Upgrade did produce an incompatability b/t the version of moment used by testcafe and the one specified in our package.json. This issue is referenced [here](https://github.com/DevExpress/testcafe/issues/1750) on testcafe's repo, which links out to [this issue on Yarn's repo](https://github.com/yarnpkg/yarn/issues/2763). Added resolutions to our project which specify a single version for a dependency that gets used across all dependent packages. 

Let me know if you see anything I missed!

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- **N/A** Cheat sheet is updated
- **N/A** Demo script is updated 
- **N/A** Documentation on Wiki has been updated 
- **N/A** Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- **N/A** Note parser has been updated if structured phrases change

**Code Quality**

- **N/A** 4-space indents - convert any tabs to spaces
- **N/A**Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- **N/A** Code is commented

**Tests**

- [x] Existing tests passed
- **N/A** Added UI tests for slim mode 
- **N/A** Added UI tests for full mode
- **N/A** Added backend tests for fluxNotes code
- **N/A** Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
