### PR TITLE
Remove note sorting from Note Assistant

### DIFF
--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -190,7 +190,6 @@ export default class NoteAssistant extends Component {
 
     // creates blank new note and puts it on the screen
     createBlankNewNote = () => {
-        this.toggleView("context-tray");
         this.props.setFullAppState("noteClosed", false);
 
         // Create info to be set for new note
@@ -295,8 +294,8 @@ export default class NoteAssistant extends Component {
                         {this.renderInProgressNotes()}
 
                         <div className="previous-notes-label">{numberOfPreviousSignedNotes} previous notes</div>
-
-                        {this.renderSortSelection()}
+                        {/*Sort selection is currently disabled*/}
+                        {/*this.renderSortSelection()*/}
                         {this.renderNotes()}
                         {this.renderMoreNotesButton()}
                     </div>


### PR DESCRIPTION
Addresses ASCODCP-1061: Disables the rendering of note-sort dropdown. Also removed an extraneous contex-tray toggle dones in createBlankNote. Again, removing the checklist b/c of the limited range of impact. I checked that the front-end tests didn't break, but I'd recommend others do the same in particular. Also, let me know if you think the styling is lacking. 