### PR TITLE
Fix @ros then delete s then hit enter enter bug

### DIFF
--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -320,8 +320,16 @@ class FluxNotesEditor extends React.Component {
         if (Lang.isNull(transform)) {
             transform = state.transform();
         }
-        const {anchorText, anchorOffset} = state
-        const text = anchorText.text
+        let {anchorText, anchorOffset} = state;
+        let anchorKey = state.anchorBlock.key;
+        let text = anchorText.text
+        if (text.length === 0) {
+            const block = state.document.getPreviousSibling(anchorKey);
+            if (block) {
+                text = block.getFirstText().text;
+                anchorOffset = text.length;
+            }
+        }
 
         let index = {start: anchorOffset - 1, end: anchorOffset}
 
@@ -331,6 +339,7 @@ class FluxNotesEditor extends React.Component {
 
         const newText = `${text.substring(0, index.start)}`
         return transform
+            .deleteBackward(0)
             .deleteBackward(anchorOffset)
             .insertText(newText)
     }


### PR DESCRIPTION
This PR addresses jira issue 965. This was a collaborative effort with @gregquinn2001, @Dtphelan1 , and @jafeltra . The bug was fixed using a solution from @gregquinn2001 

The bug originally appeared when performing the following steps:
- Type '@ros'
- Delete 's', leaving '@ro'
- Select 'procedure' from the drop down by hitting the enter key
- Select any available procedure such as "mammography" by hitting the enter key

Tested the following cases and they all work:
- **enter** to select 'procedure', **enter** to select 'mammography'
- **enter** to select 'procedure', **mouse click** to select 'mammography'
- **mouse click** to select 'procedure', **enter** to select 'mammography'
- **mouse click** to select 'procedure', **mouse click** to select 'mammography'

NOTE: Since @gregquinn2001 and I worked on the solution I'm asking the rest of you guys to review this PR please, thanks!

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- N/A Cheat sheet is updated
- N/A Demo script is updated 
- N/A Documentation on Wiki has been updated 
- N/A Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- N/A Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- N/A Added UI tests for slim mode 
- N/A Added UI tests for full mode
- N/A Added backend tests for fluxNotes code
- N/A Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
