### PR TITLE
Use line-height to make close-note-button valid height

### DIFF
--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -706,7 +706,8 @@ class FluxNotesEditor extends React.Component {
                                 disabled={this.context_disabled}
                                 onClick={this.props.closeNote}
                                 style={{
-                                    float: "right"
+                                    float: "right",
+                                    lineHeight: "2.1rem"
                                 }}
                             >
                                 <FontAwesome 


### PR DESCRIPTION
Really small change. Should fix the close-note button looks on IE. People with IE: check that the close-note button looks good; people with other browsers: check that other browsers still look good in this regard. 