### PR TITLE
Saving v2

### DIFF
--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -616,6 +616,13 @@ class FluxNotesEditor extends React.Component {
         let bullets = [];
         let liStartIndex = listText.indexOf('<li>');
         let liEndIndex = listText.indexOf('</li>');
+        let tag = type === 'numbered-list' ? '<ol>' : '<ul>';
+        let nextListStart = listText.indexOf(tag);
+        let nextListString = '';
+        if (nextListStart > -1) {
+            nextListString = listText.substring(nextListStart);
+            listText = listText.substring(0, nextListStart);
+        }
         let after = '';
         let structuredFieldToFollow = false;
         while(liStartIndex !== -1 || liEndIndex !== -1) {
@@ -643,6 +650,7 @@ class FluxNotesEditor extends React.Component {
                 transform.splitBlock();
             }
         }
+        after += nextListString;
         this.insertTextWithStyles(transform, after);
     }
 
@@ -706,7 +714,6 @@ class FluxNotesEditor extends React.Component {
             result = this.insertNewLine(result);
             return this.insertPlainText(result, text.substring(returnIndex + 1));
         } else if (divReturnIndex >= 0) {
-            // TODO will returnIndex be relevant any more? how about with dictation?
             let result = this.insertPlainText(transform, text.substring(0, divReturnIndex));
             result = this.insertNewLine(result);
             return this.insertPlainText(result, text.substring(divReturnIndex + 6)); // cuts off </div>

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -170,9 +170,6 @@ function StructuredFieldPlugin(opts) {
             } else if (node.type === 'bulleted-list-item' || node.type === 'numbered-list-item') {
                 // node.nodes will be text here.
                 result += `<li>${convertSlateNodesToText(node.nodes)}</li>`;
-            } else if (node.type === '' && node.nodes) {
-                // TODO what is this case? it happens if close, reopen, type at end. Other cases? how to give it a type?
-                result += convertSlateNodesToText(node.nodes);
             }
         });
         return result;


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

Styling (bold, italics, underlined, numbered and bulleted lists) are all supported and are reloaded when reopening in progress notes. Bold, italics, and underlines are not currently working in structured phrases. There is a separate jira for this. I did not have time to address it in this pull request.

There are a few outstanding bugs in this branch, which are related to copying and pasting.
- Copy/cut sometimes pastes more than you copied. I'm having trouble reproducing this right now, so I will continue to look into it to see when exactly it happens if it is new to this branch.
- Copying only maintains styling when there is more than one node in slate. This means that copying a single word that is bold does not maintain the styling. This is new to this branch and I have not figured out the right way to catch and correct this case. I will make a jira item for this.

Some good things to test this with:
- Having multiple styles turned on
- Having structured phrases mixed within text with styles
- Inserting from the left and right sides
- Copying and pasting should work when you have multiple words and styles added, although it may still have a few bugs I haven't seen yet.

I am working on testing this with Dragon now. Update: @gregquinn2001 tested this with Dragon and it still works.

## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- Cheat sheet is updated
- Demo script is updated 
- Documentation on Wiki has been updated 
- Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- Added UI tests for slim mode 
- Added UI tests for full mode
- Added backend tests for fluxNotes code
- Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
