### PR TITLE
Suggestion Portal Bug Fix

### DIFF
--- a/src/lib/slate-suggestions-dist/suggestion-portal.js
+++ b/src/lib/slate-suggestions-dist/suggestion-portal.js
@@ -300,8 +300,9 @@ class SuggestionPortal extends React.Component {
     }
 
     render = () => {
-        const filteredSuggestions  = this.getFilteredSuggestions();
-
+        const filteredSuggestions = this.getFilteredSuggestions();
+        this.setCallbackSuggestion(filteredSuggestions, this.state.selectedIndex);
+        
         return (
             <Portal isOpened closeOnEsc closeOnOutsideClick onOpen={this.openPortal}>
                 <div className="suggestion-portal" ref="suggestionPortal">


### PR DESCRIPTION
This PR addresses JIRA-1069.

To reproduce on fluxnotes.org/demo1:
1. Type "some text @ other text"
2. Continue typing but type @condition and choose invasive... (or anything that requires opening and choosing from the context portal).
3. Hit enter immediately after the structured phrase is entered. "Invasive.." is replaced with the @patient structured phrase. This might be due to the fact that the suggestion portal has not been closed and @patient is the first choice in the list.

This is a pretty simple fix for this bug.  When the suggestion portal renders, I added logic to set the suggestion.  Previously when we closed the suggestion portal, it would default the list of suggestions and that is why the @patient structured phrase was chosen when we hit enter immediately after a structured phrase.

Another bug that I discovered while working on this is detailed in JIRA-1093.  This is also happening on master so I decided to just log it(I spent a little bit of time looking at this bug but it is not a trivial fix.).

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
-  Cheat sheet is updated
-  Demo script is updated 
-  Documentation on Wiki has been updated 
-  Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

-  Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
-  Use public class field syntax for binding functions - ex. handleChange = () => { ... };
-  Code is commented

**Tests**

- [x] Existing tests passed
-  Added UI tests for slim mode 
-  Added UI tests for full mode
-  Added backend tests for fluxNotes code
-  Added note parser examples to test new functionality


## Reviewer 1: Julia

- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
