### PR TITLE
Fixed copy-paste bug

### DIFF
--- a/src/shortcuts/CreatorBase.jsx
+++ b/src/shortcuts/CreatorBase.jsx
@@ -16,7 +16,11 @@ export default class CreatorBase extends Shortcut {
         } else {
             const dataObj = JSON.parse(shortcutData);
             this.object = patient.getEntryById(dataObj.entryId);
-            this.isObjectNew = false;
+            // We want to try and get this object -- if there is none, make a new one
+            this.isObjectNew = !this.object;
+            if (!this.object) { 
+                this.object = FluxObjectFactory.createInstance({}, this.metadata["valueObject"]);
+            }
         }
         this.setValueObject(this.object);
 
@@ -198,7 +202,6 @@ export default class CreatorBase extends Shortcut {
         let perItemFollowPath = (item) => {
             return this._followPath(item, attributePath, i + 1);
         };
-
         for (i = startIndex; i < len; i++) {
             if (attributePath[i].endsWith("[]")) {
                 attributeName = attributePath[i].substring(0, attributePath[i].length - 2);
@@ -226,7 +229,6 @@ export default class CreatorBase extends Shortcut {
 
     getAttributeValue(name) {
         const voa = this.valueObjectAttributes[name];
-
         if (Lang.isNull(voa["attributePath"])) {
             return this.values[voa["name"]];
         } else {


### PR DESCRIPTION
Addresses ASCODCP-1067: Copy and pasting creator shortcuts is not working.

Previous way to reproduce the error was: Type "@condition [choose invasive...] #staging". Select all the text. Copy it. Refresh the page. Pasting the text gives an error in the console.

In the process of fixing this bug I identified several other bugs, including:
- ASCODCP-1114: Copying existing entries will reference existing entry and enable users to delete signed information.
- ASCODCP-1113: Copying will copy whole editor when copying a drag-to-selected smaller selection.
- ASCODCP-1112: Insertions into our editor don't trigger note-saving.

People should take a look at these bugs and descriptions, but I don't think right now they were captured by the scope of this task. If people feel otherwise or notice anything else in testing, please let me know!

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- **N/A** Cheat sheet is updated
- **N/A** Demo script is updated 
- **N/A** Documentation on Wiki has been updated 
- **N/A** Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [x] Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- **N/A** Added UI tests for slim mode 
- **N/A** Added UI tests for full mode
- **N/A** Added backend tests for fluxNotes code
- **N/A** Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
