### PR TITLE
Laterality bug

### DIFF
--- a/src/model/condition/FluxCondition.js
+++ b/src/model/condition/FluxCondition.js
@@ -66,9 +66,10 @@ class FluxCondition {
     
     get laterality() {
         if (    !this._condition.bodySiteOrCode || 
-                !this._condition.bodySiteOrCode.value || 
-                !(this._condition.bodySiteOrCode.value instanceof BodySite)) return null;
-        return this._condition.bodySiteOrCode.value.laterality.value.coding[0].displayText.value;        
+                this._condition.bodySiteOrCode.length < 1 ||
+                !this._condition.bodySiteOrCode[0].value ||
+                !(this._condition.bodySiteOrCode[0].value instanceof BodySite)) return null;
+        return this._condition.bodySiteOrCode[0].value.laterality.value.coding[0].displayText.value;
     }
 
     addObservation(observation, clinicalNote) {


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

This fixed a really small bug that @nicoleng12 and I noticed where the laterality for the patients was being displayed as missing. I didn't want to just put the fix in with the rest of my current branch because I was afraid it would get lost in the changes, but it was a pretty simple fix. I think it must have broken when I updated the patient JSON a few weeks ago.

## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- N/A Cheat sheet is updated
- N/A Demo script is updated 
- N/A Documentation on Wiki has been updated 
- N/A Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- N/A Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- N/A Added UI tests for slim mode 
- N/A Added UI tests for full mode
- N/A Added backend tests for fluxNotes code
- N/A Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
