### PR TITLE
Added HPI Configuration to simplify auto-generated HPI

### DIFF
--- a/src/model/hpi-configuration.json
+++ b/src/model/hpi-configuration.json
@@ -1,0 +1,31 @@
+{
+    "408643008": {
+        "exclusions": {
+            "procedures": [
+                {
+                    "name": "Insertion of Port-a-cath",
+                    "code": "312376000",
+                    "codeSystem": "http://snomed.info/sct"
+                },
+                {
+                    "name": "Removal of Port-a-cath",
+                    "code": "312379007",
+                    "codeSystem": "http://snomed.info/sct"
+                }
+            ],
+            "medications": [
+                {
+                    "name": "ibuprofen 600mg tablet",
+                    "code": "316077",
+                    "codeSystem": "http://snomed.info/sct"
+                }
+            ]
+        }
+    },
+    "default": {
+        "exclusions": {
+            "procedures": [],
+            "medications": []
+        }
+    }
+}

--- a/src/model/oncology/FluxBreastCancer.js
+++ b/src/model/oncology/FluxBreastCancer.js
@@ -108,7 +108,7 @@ class FluxBreastCancer extends FluxCondition {
             hpiText += ` HER2 was ${her2Status.status}.`;
         }
 
-        hpiText = this.buildEventNarrative(hpiText, patient);
+        hpiText = this.buildEventNarrative(hpiText, patient, this.code);
         
         return hpiText;
     }

--- a/src/model/procedure/FluxProcedureRequested.js
+++ b/src/model/procedure/FluxProcedureRequested.js
@@ -51,6 +51,15 @@ class FluxProcedureRequested {
     }
 
     /*
+     *  Getter for procedure code
+     *  Returns procedure code string
+     */
+    get code() {
+        if (!this._procedureRequested.type) return null;
+        return this._procedureRequested.type.value.coding[0].code;
+    }
+
+    /*
      *  Getter for reason list for this procedure
      *  Returns array of reasons
      */


### PR DESCRIPTION
Addresses JIRA-1108.

- Added hpi-configuration.json file where users can provide codes for procedures and medications that they want excluded from the `@HPI` shortcut.
- Only excluded Port-A-Cath procedures and ibuprofen medication.
- Default configuration has no exclusions and will be used if no condition code is passed to `buildEventNarrative` function.

To test:
Type `@condition`, select 'Invasive Ductal carcinoma of breast', and type `@HPI` and notice that Port-A-Cath and ibuprofen is no longer included in the autogeneration.

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
-  Recognizes any potential shortcomings/bugs in the description 
-  Cheat sheet is updated
-  Demo script is updated 
-  Documentation on Wiki has been updated 
-  Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

-  Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
-  Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
-  Added UI tests for slim mode 
-  Added UI tests for full mode
-  Added backend tests for fluxNotes code
-  Added note parser examples to test new functionality


## Reviewer 1: Nicole

- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
