### PR TITLE
Groups with no groupName list together with their label

### DIFF
--- a/src/context/ContextOptions.jsx
+++ b/src/context/ContextOptions.jsx
@@ -43,7 +43,7 @@ export default class ContextOptions extends Component {
                         className="context-options-header"
                         title={groupObj.groupName}
                     >
-                        {parentContext.getLabel()} - {groupObj.groupName}
+                        {capitalizeFirstLetter(parentContext.getLabel())} - {groupObj.groupName}
                     </div>
                 }
 
@@ -187,6 +187,10 @@ export default class ContextOptions extends Component {
             </section>
         );
     }
+}
+
+function capitalizeFirstLetter(string) {
+    return string.charAt(0).toUpperCase() + string.slice(1);
 }
 
 ContextOptions.proptypes = {


### PR DESCRIPTION
Addresses ASCODCP-1157: Categorize groups without a groupName together with their parentShortcut label. PR just pulls the rendering of a group into a function and splits groupObjs into two categories -- those with no groupName  and those with a groupName, rendering the former with a label of their parent shortcut. 

This feels like a small PR so I've removed the regular checks, but someone should let me know if they think I should add them back. 

Reference photo of old bug
![image](https://user-images.githubusercontent.com/5703736/41230486-06617fdc-6d4e-11e8-9e4a-cfc30364218a.png)