### PR TITLE
Dont show enrolled trial

### DIFF
--- a/src/clinicalTrials/ClinicalTrialsList.jsx
+++ b/src/clinicalTrials/ClinicalTrialsList.jsx
@@ -73,7 +73,7 @@ class ClinicalTrialsList {
     findPatientEligibility(patient, currentCondition) {
         let patient_id = '3cb09ecb-e927-4946-82b3-89957e193215';
         let eligibleTrials = [];
-        let enrolledTrials = patient.getClinicalTrials(currentCondition);
+        let enrolledTrials = patient.getEnrolledClinicalTrials();
         enrolledTrials = enrolledTrials.map((trial) => {
             return trial.title;
         });

--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -305,7 +305,7 @@ class PatientRecord {
         return result + ".";
     }
 
-    getClinicalTrials(){
+    getEnrolledClinicalTrials(){
         let clinicalTrialList = new ClinicalTrialsList();
         let result = this.getEntriesOfType(FluxResearchSubject);
 

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -818,7 +818,7 @@ export default class SummaryMetadata {
     getItemListForEnrolledClinicalTrials = (patient, currentConditionEntry) => {
         if (Lang.isNull(patient) || Lang.isNull(currentConditionEntry)) return [];
 
-        const clinicalTrials = patient.getClinicalTrials(currentConditionEntry);
+        const clinicalTrials = patient.getEnrolledClinicalTrials();
         if (clinicalTrials.length === 0) {
             return [];
         } else {


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

Addresses JIRA 1145
- Updated ClinicalTrialsList.jsx so that list of eligible clinical trials never includes already enrolled trials.

## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- Cheat sheet is updated
- Demo script is updated 
- Documentation on Wiki has been updated 
- Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- Added UI tests for slim mode 
- Added UI tests for full mode
- [x] Added backend tests for fluxNotes code
- Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
